### PR TITLE
refactor(resolve): replace read-pkg-up with escalade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Chore & Maintenance
 
+- `[jest-resolve]` Replace read-pkg-up with escalade package ([10558](https://github.com/facebook/jest/pull/10558))
+
 ### Performance
 
 ## 26.4.2

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`on node ^12.16.0 || >=13.2.0 runs test with native ESM 1`] = `
+exports[`on node ^12.16.0 || >=13.7.0 runs test with native ESM 1`] = `
 Test Suites: 1 passed, 1 total
 Tests:       12 passed, 12 total
 Snapshots:   0 total

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -21,7 +21,7 @@ test('test config is without transform', () => {
 });
 
 // The versions vm.Module was introduced
-onNodeVersions('^12.16.0 || >=13.2.0', () => {
+onNodeVersions('^12.16.0 || >=13.7.0', () => {
   test('runs test with native ESM', () => {
     const {exitCode, stderr, stdout} = runJest(DIR, [], {
       nodeOptions: '--experimental-vm-modules',

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -20,7 +20,7 @@ test('test config is without transform', () => {
   expect(configs[0].transform).toEqual([]);
 });
 
-// The versions vm.Module was introduced
+// The versions where vm.Module exists and commonjs with "exports" is not broken
 onNodeVersions('^12.16.0 || >=13.7.0', () => {
   test('runs test with native ESM', () => {
     const {exitCode, stderr, stdout} = runJest(DIR, [], {

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@jest/types": "^26.3.0",
     "chalk": "^4.0.0",
+    "escalade": "^3.1.0",
     "graceful-fs": "^4.2.4",
     "jest-pnp-resolver": "^1.2.2",
     "jest-util": "^26.3.0",
-    "read-pkg-up": "^7.0.1",
     "resolve": "^1.17.0",
     "slash": "^3.0.0"
   },

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -70,7 +70,6 @@ function shouldLoadAsEsm(path: Config.Path): boolean {
 }
 
 function cachedPkgCheck(cwd: Config.Path): boolean {
-  // TODO: can we cache lookups somehow?
   const pkgPath = escalade(cwd, (_dir, names) => {
     if (names.includes('package.json')) {
       // will be resolved into absolute

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -21,6 +21,7 @@ const cachedChecks = new Map<string, boolean>();
 export function clearCachedLookups(): void {
   cachedFileLookups.clear();
   cachedDirLookups.clear();
+  cachedChecks.clear();
 }
 
 export default function cachedShouldLoadAsEsm(path: Config.Path): boolean {
@@ -89,7 +90,7 @@ function cachedPkgCheck(cwd: Config.Path): boolean {
   try {
     const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
     hasModuleField = pkg.type === 'module';
-  } catch (e) {
+  } catch {
     hasModuleField = false;
   }
 

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -6,6 +6,7 @@
  */
 
 import {dirname, extname} from 'path';
+import {readFileSync} from 'fs';
 // @ts-expect-error: experimental, not added to the types
 import {SyntheticModule} from 'vm';
 import escalade from 'escalade/sync';
@@ -68,19 +69,19 @@ function shouldLoadAsEsm(path: Config.Path): boolean {
 
 function cachedPkgCheck(cwd: Config.Path): boolean {
   // TODO: can we cache lookups somehow?
-  const pkgContent = escalade(cwd, (_dir, names) => {
+  const pkgPath = escalade(cwd, (_dir, names) => {
     if (names.includes('package.json')) {
       // will be resolved into absolute
       return 'package.json';
     }
     return false;
   });
-  if (!pkgContent) {
+  if (!pkgPath) {
     return false;
   }
 
   try {
-    const pkg = JSON.parse(pkgContent);
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
     return pkg.type === 'module';
   } catch (e) {
     return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7743,7 +7743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.0.2":
+"escalade@npm:^3.0.2, escalade@npm:^3.1.0":
   version: 3.1.0
   resolution: "escalade@npm:3.1.0"
   checksum: 437c5b2619a412c0b075fb33e590e3516f187f7da8b20035685e08f346e27842722e5740a3398535d7d590ae4fb70068374ed59190d4eb4f9bb06d052e2fc92f
@@ -11758,11 +11758,11 @@ fsevents@^1.2.7:
     "@types/graceful-fs": ^4.1.3
     "@types/resolve": ^1.17.0
     chalk: ^4.0.0
+    escalade: ^3.1.0
     graceful-fs: ^4.2.4
     jest-haste-map: ^26.3.0
     jest-pnp-resolver: ^1.2.2
     jest-util: ^26.3.0
-    read-pkg-up: ^7.0.1
     resolve: ^1.17.0
     slash: ^3.0.0
   languageName: unknown


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Ref https://packagephobia.com/result?p=read-pkg-up https://packagephobia.com/result?p=escalade

Read-pkg-up package is quite big and have a lot of dependencies.
It also handles cases not necessary for jest. Beautiful JSON parsing
errors are not relevant and can be replaced with builtin JSON.parse.

## Test plan

Not sure about this. Looks like es modules support was not covered by tests.