### PR TITLE
feat(expect): allow constructor names to be used with expect.any()

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -269,7 +269,7 @@ test('map calls its argument with a non-null argument', () => {
 
 ### `expect.any(constructor)`
 
-`expect.any(constructor)` matches anything that was created with the given constructor. You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value. For example, if you want to check that a mock function is called with a number:
+`expect.any(constructor)` matches anything that was created with the given constructor, or the given constructor name. You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value. For example, if you want to check that a mock function is called with a number:
 
 ```js
 function randocall(fn) {

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -36,6 +36,7 @@ test('Any.asymmetricMatch()', () => {
     any(Object).asymmetricMatch(null),
     any(Array).asymmetricMatch([]),
     any(Thing).asymmetricMatch(new Thing()),
+    any('Thing').asymmetricMatch(new Thing()),
   ].forEach(test => {
     jestExpect(test).toBe(true);
   });

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -26,14 +26,22 @@ test('Any.asymmetricMatch()', () => {
 
   [
     any(String).asymmetricMatch('jest'),
+    any('string').asymmetricMatch('jest'),
     any(Number).asymmetricMatch(1),
+    any('number').asymmetricMatch(1),
     any(Function).asymmetricMatch(() => {}),
+    any('function').asymmetricMatch(() => {}),
     any(Boolean).asymmetricMatch(true),
+    any('boolean').asymmetricMatch(true),
     /* global BigInt */
     any(BigInt).asymmetricMatch(1n),
+    any('bigint').asymmetricMatch(1n),
     any(Symbol).asymmetricMatch(Symbol()),
+    any('symbol').asymmetricMatch(Symbol()),
     any(Object).asymmetricMatch({}),
+    any('object').asymmetricMatch({}),
     any(Object).asymmetricMatch(null),
+    any('object').asymmetricMatch(null),
     any(Array).asymmetricMatch([]),
     any(Thing).asymmetricMatch(new Thing()),
     any('Thing').asymmetricMatch(new Thing()),

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -33,41 +33,41 @@ class Any extends AsymmetricMatcher<any> {
   }
 
   asymmetricMatch(other: unknown) {
-    if (this.sample == String || this.sample === 'string') {
+    if (this.sample == String || this.sample == 'string') {
       return typeof other == 'string' || other instanceof String;
     }
 
-    if (this.sample == Number || this.sample === 'number') {
+    if (this.sample == Number || this.sample == 'number') {
       return typeof other == 'number' || other instanceof Number;
     }
 
-    if (this.sample == Function || this.sample === 'function') {
+    if (this.sample == Function || this.sample == 'function') {
       return typeof other == 'function' || other instanceof Function;
     }
 
-    if (this.sample == Object || this.sample === 'object') {
+    if (this.sample == Object || this.sample == 'object') {
       return typeof other == 'object';
     }
 
-    if (this.sample == Boolean || this.sample === 'boolean') {
+    if (this.sample == Boolean || this.sample == 'boolean') {
       return typeof other == 'boolean';
     }
 
     /* global BigInt */
-    if (this.sample == BigInt || this.sample === 'bigint') {
+    if (this.sample == BigInt || this.sample == 'bigint') {
       return typeof other == 'bigint';
     }
 
-    if (this.sample == Symbol || this.sample === 'symbol') {
+    if (this.sample == Symbol || this.sample == 'symbol') {
       return typeof other == 'symbol';
     }
 
     if (
-      typeof this.sample === 'string' &&
-      typeof other === 'object' &&
+      typeof this.sample == 'string' &&
+      typeof other == 'object' &&
       other !== null
     ) {
-      return other.constructor.name === this.sample;
+      return other.constructor.name == this.sample;
     }
 
     return other instanceof this.sample;
@@ -98,7 +98,7 @@ class Any extends AsymmetricMatcher<any> {
       return 'boolean';
     }
 
-    if (typeof this.sample === 'string') {
+    if (typeof this.sample == 'string') {
       return this.sample;
     }
 

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -25,7 +25,7 @@ class Any extends AsymmetricMatcher<any> {
   constructor(sample: unknown) {
     if (typeof sample === 'undefined') {
       throw new TypeError(
-        'any() expects to be passed a constructor function. ' +
+        'any() expects to be passed a constructor function or name. ' +
           'Please pass one or use anything() to match any object.',
       );
     }
@@ -62,6 +62,14 @@ class Any extends AsymmetricMatcher<any> {
       return typeof other == 'symbol';
     }
 
+    if (
+      typeof this.sample === 'string' &&
+      typeof other === 'object' &&
+      other !== null
+    ) {
+      return other.constructor.name === this.sample;
+    }
+
     return other instanceof this.sample;
   }
 
@@ -88,6 +96,10 @@ class Any extends AsymmetricMatcher<any> {
 
     if (this.sample == Boolean) {
       return 'boolean';
+    }
+
+    if (typeof this.sample === 'string') {
+      return this.sample;
     }
 
     return fnNameFor(this.sample);

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -33,32 +33,32 @@ class Any extends AsymmetricMatcher<any> {
   }
 
   asymmetricMatch(other: unknown) {
-    if (this.sample == String) {
+    if (this.sample == String || this.sample === 'string') {
       return typeof other == 'string' || other instanceof String;
     }
 
-    if (this.sample == Number) {
+    if (this.sample == Number || this.sample === 'number') {
       return typeof other == 'number' || other instanceof Number;
     }
 
-    if (this.sample == Function) {
+    if (this.sample == Function || this.sample === 'function') {
       return typeof other == 'function' || other instanceof Function;
     }
 
-    if (this.sample == Object) {
+    if (this.sample == Object || this.sample === 'object') {
       return typeof other == 'object';
     }
 
-    if (this.sample == Boolean) {
+    if (this.sample == Boolean || this.sample === 'boolean') {
       return typeof other == 'boolean';
     }
 
     /* global BigInt */
-    if (this.sample == BigInt) {
+    if (this.sample == BigInt || this.sample === 'bigint') {
       return typeof other == 'bigint';
     }
 
-    if (this.sample == Symbol) {
+    if (this.sample == Symbol || this.sample === 'symbol') {
       return typeof other == 'symbol';
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`expect.any(constructor)` expects a constructor, which for non global classes requires it to be imported. I think it would be a nice addition to be able to pass a constructor name.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added an assertion which tests that constructor names work.
