### PR TITLE
chore: update jsdom in jest-environment-jsdom

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -16,7 +16,7 @@
     "@types/node": "*",
     "jest-mock": "^26.3.0",
     "jest-util": "^26.3.0",
-    "jsdom": "^16.2.2"
+    "jsdom": "^16.4.0"
   },
   "devDependencies": {
     "@types/jsdom": "^16.2.1"


### PR DESCRIPTION
This bumps up the transitive dependency acorn to 6.0.0, which should resolve the security issues in the previous release