### PR TITLE
fix: validate `testURL` as CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-validate]` Show suggestion only when unrecognized cli param is longer than 1 character ([#10604](https://github.com/facebook/jest/pull/10604))
+- `[jest-validate]` Validate `testURL` as CLI option ([#10595](https://github.com/facebook/jest/pull/10595))
 
 ### Chore & Maintenance
 

--- a/packages/jest-validate/src/__tests__/validateCLIOptions.test.js
+++ b/packages/jest-validate/src/__tests__/validateCLIOptions.test.js
@@ -19,6 +19,19 @@ test('validates yargs special options', () => {
   expect(validateCLIOptions(argv, options)).toBe(true);
 });
 
+test('validates testURL', () => {
+  const options = {
+    testURL: {
+      description: 'This option sets the URL for the jsdom environment.',
+      type: 'string',
+    },
+  };
+  const argv = {
+    testURL: 'http://localhost',
+  };
+  expect(validateCLIOptions(argv, options)).toBe(true);
+});
+
 test('fails for unknown option', () => {
   const options = ['$0', '_', 'help', 'h'];
   const argv = {

--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -79,6 +79,7 @@ export default function validateCLIOptions(
   const unrecognizedOptions = Object.keys(argv).filter(
     arg =>
       !allowedOptions.has(camelcase(arg)) &&
+      !allowedOptions.has(arg) &&
       (!rawArgv.length || rawArgv.includes(arg)),
     [],
   );


### PR DESCRIPTION
Resolves #8889 
Currently running `jest --testURL "https://localhost"` fails with `--testURL` being treated as `Unrecognized CLI Parameter`.
