### PR TITLE
fix(circus): make sure to install globals before emitting `setup` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-circus]` Setup globals before emitting `init`, and include Jets globals in the `init` payload ([#10598](https://github.com/facebook/jest/pull/10598))
+- `[jest-circus]` Setup globals before emitting `init`, and include Jest globals in the `init` payload ([#10598](https://github.com/facebook/jest/pull/10598))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-circus]` Setup globals before emitting `init`, and include Jets globals in the `init` payload ([#10598](https://github.com/facebook/jest/pull/10598))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-circus]` Setup globals before emitting `init`, and include Jest globals in the `init` payload ([#10598](https://github.com/facebook/jest/pull/10598))
+- `[jest-circus]` Setup globals before emitting `setup`, and include Jest globals in the `setup` payload ([#10598](https://github.com/facebook/jest/pull/10598))
 - `[jest-mock]` Fix typings for `mockResolvedValue`, `mockResolvedValueOnce`, `mockRejectedValue` and `mockRejectedValueOnce` ([#10600](https://github.com/facebook/jest/pull/10600))
 
 ### Chore & Maintenance

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -43,23 +43,16 @@ const jestAdapter = async (
   const {globals, snapshotState} = await initialize({
     config,
     environment,
+    expect,
     getBabelTraverse,
     getPrettier,
     globalConfig,
     localRequire: runtime.requireModule.bind(runtime),
     parentProcess: process,
     sendMessageToJest,
+    setGlobalsForRuntime: runtime.setGlobalsForRuntime?.bind(runtime),
     testPath,
   });
-
-  const runtimeGlobals = {expect, ...globals};
-  // TODO: `jest-circus` might be newer than `jest-runtime` - remove `?.` for Jest 27
-  runtime.setGlobalsForRuntime?.(runtimeGlobals);
-
-  // TODO: `jest-circus` might be newer than `jest-config` - remove `??` for Jest 27
-  if (config.injectGlobals ?? true) {
-    Object.assign(environment.global, runtimeGlobals);
-  }
 
   if (config.timers === 'fake' || config.timers === 'legacy') {
     // during setup, this cannot be null (and it's fine to explode if it is)

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {JestEnvironment} from '@jest/environment';
 import type {TestResult} from '@jest/test-result';
@@ -14,8 +13,7 @@ import type {RuntimeType as Runtime} from 'jest-runtime';
 import type {SnapshotStateType} from 'jest-snapshot';
 import {deepCyclicCopy} from 'jest-util';
 
-const FRAMEWORK_INITIALIZER = path.resolve(__dirname, './jestAdapterInit.js');
-const EXPECT_INITIALIZER = path.resolve(__dirname, './jestExpect.js');
+const FRAMEWORK_INITIALIZER = require.resolve('./jestAdapterInit');
 
 const jestAdapter = async (
   globalConfig: Config.GlobalConfig,
@@ -32,10 +30,6 @@ const jestAdapter = async (
     FRAMEWORK_INITIALIZER,
   );
 
-  const expect = runtime
-    .requireInternalModule<typeof import('./jestExpect')>(EXPECT_INITIALIZER)
-    .default(globalConfig);
-
   const getPrettier = () =>
     config.prettierPath ? require(config.prettierPath) : null;
   const getBabelTraverse = () => require('@babel/traverse').default;
@@ -43,7 +37,6 @@ const jestAdapter = async (
   const {globals, snapshotState} = await initialize({
     config,
     environment,
-    expect,
     getBabelTraverse,
     getPrettier,
     globalConfig,

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -130,8 +130,7 @@ export const initialize = async ({
     addEventHandler(environment.handleTestEvent.bind(environment));
   }
 
-  // @ts-expect-error
-  const runtimeGlobals: JestGlobals = {expect, ...globals};
+  const runtimeGlobals: JestGlobals = {expect, ...globalsObject};
   // TODO: `jest-circus` might be newer than `jest-runtime` - remove `?.` for Jest 27
   setGlobalsForRuntime?.(runtimeGlobals);
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -35,7 +35,7 @@ import {getTestID} from '../utils';
 import run from '../run';
 import testCaseReportHandler from '../testCaseReportHandler';
 import globals from '..';
-import type {Expect} from './jestExpect';
+import createExpect, {Expect} from './jestExpect';
 
 type Process = NodeJS.Process;
 
@@ -46,7 +46,6 @@ interface JestGlobals extends Global.TestFrameworkGlobals {
 export const initialize = async ({
   config,
   environment,
-  expect,
   getPrettier,
   getBabelTraverse,
   globalConfig,
@@ -58,7 +57,6 @@ export const initialize = async ({
 }: {
   config: Config.ProjectConfig;
   environment: JestEnvironment;
-  expect: Expect;
   getPrettier: () => null | any;
   getBabelTraverse: () => typeof BabelTraverse;
   globalConfig: Config.GlobalConfig;
@@ -129,7 +127,10 @@ export const initialize = async ({
     addEventHandler(environment.handleTestEvent.bind(environment));
   }
 
-  const runtimeGlobals: JestGlobals = {expect, ...globalsObject};
+  const runtimeGlobals: JestGlobals = {
+    ...globalsObject,
+    expect: createExpect(globalConfig),
+  };
   // TODO: `jest-circus` might be newer than `jest-runtime` - remove `?.` for Jest 27
   setGlobalsForRuntime?.(runtimeGlobals);
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -35,10 +35,9 @@ import {getTestID} from '../utils';
 import run from '../run';
 import testCaseReportHandler from '../testCaseReportHandler';
 import globals from '..';
+import type {Expect} from './jestExpect';
 
 type Process = NodeJS.Process;
-
-type Expect = typeof import('expect');
 
 interface JestGlobals extends Global.TestFrameworkGlobals {
   expect: Expect;

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
@@ -16,7 +16,9 @@ import {
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
 
-export default (config: Pick<Config.GlobalConfig, 'expand'>): typeof expect => {
+export type Expect = typeof expect;
+
+export default (config: Pick<Config.GlobalConfig, 'expand'>): Expect => {
   expect.setState({expand: config.expand});
   expect.extend({
     toMatchInlineSnapshot,

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -38,6 +38,11 @@ export interface EventHandler {
 
 export type Event = SyncEvent | AsyncEvent;
 
+interface JestGlobals extends Global.TestFrameworkGlobals {
+  // we cannot type `expect` properly as it'd create circular dependencies
+  expect: unknown;
+}
+
 export type SyncEvent =
   | {
       asyncError: Error;
@@ -77,6 +82,7 @@ export type AsyncEvent =
       // first action to dispatch. Good time to initialize all settings
       name: 'setup';
       testNamePattern?: string;
+      runtimeGlobals: JestGlobals;
       parentProcess: Process;
     }
   | {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fix for https://github.com/facebook/jest/pull/10484#issuecomment-703761828

In addition to restoring time when globals are added, I've also added a property to the `setup` event that comes with the globals. That way consumers don't have to care about `this.globals.*`, which would also be unset if the end user use `injectGlobals: false`.

/cc @noomorph

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Verified locally that globals are set during `setup`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
