### PR TITLE
fix: revert usage of Escalade and yargs@16 as they breaks Node 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-resolve]` Revert usage of Escalade as it breaks Node 13
+- `[jest-resolve]` Revert usage of Escalade as it breaks Node 13 ([#10599](https://github.com/facebook/jest/pull/10599))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixes
 
+- `[*]` Revert usage of Escalade and rollback Yargs to v15 as it breaks Node 13 ([#10599](https://github.com/facebook/jest/pull/10599))
 - `[jest-circus]` Setup globals before emitting `setup`, and include Jest globals in the `setup` payload ([#10598](https://github.com/facebook/jest/pull/10598))
 - `[jest-mock]` Fix typings for `mockResolvedValue`, `mockResolvedValueOnce`, `mockRejectedValue` and `mockRejectedValueOnce` ([#10600](https://github.com/facebook/jest/pull/10600))
-- `[jest-resolve]` Revert usage of Escalade and rollback Yargs to v15 as it breaks Node 13 ([#10599](https://github.com/facebook/jest/pull/10599))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-resolve]` Revert usage of Escalade as it breaks Node 13
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-resolve]` Revert usage of Escalade as it breaks Node 13 ([#10599](https://github.com/facebook/jest/pull/10599))
+- `[jest-resolve]` Revert usage of Escalade and rollback Yargs to v15 as it breaks Node 13 ([#10599](https://github.com/facebook/jest/pull/10599))
 
 ### Chore & Maintenance
 

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -17,7 +17,7 @@
     "jest-util": "^26.5.0",
     "jest-validate": "^26.5.0",
     "prompts": "^2.0.1",
-    "yargs": "^16.0.3"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@jest/test-utils": "^26.5.0",

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -16,7 +16,7 @@
     "jest-runtime": "^26.5.0",
     "jest-validate": "^26.5.0",
     "repl": "^0.1.3",
-    "yargs": "^16.0.3"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@jest/test-utils": "^26.5.0",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -44,7 +44,7 @@
     "strip-ansi": "^6.0.0"
   },
   "optionalDependencies": {
-    "node-notifier": "7.0.1"
+    "node-notifier": "^8.0.0"
   },
   "engines": {
     "node": ">= 10.14.2"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -44,7 +44,7 @@
     "strip-ansi": "^6.0.0"
   },
   "optionalDependencies": {
-    "node-notifier": "^8.0.0"
+    "node-notifier": "7.0.1"
   },
   "engines": {
     "node": ">= 10.14.2"

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@jest/types": "^26.5.0",
     "chalk": "^4.0.0",
-    "escalade": "^3.1.0",
     "graceful-fs": "^4.2.4",
     "jest-pnp-resolver": "^1.2.2",
     "jest-util": "^26.5.0",
+    "read-pkg-up": "^7.0.1",
     "resolve": "^1.17.0",
     "slash": "^3.0.0"
   },

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -8,20 +8,17 @@
 import {dirname, extname} from 'path';
 // @ts-expect-error: experimental, not added to the types
 import {SyntheticModule} from 'vm';
-import {readFileSync} from 'graceful-fs';
-import escalade from 'escalade/sync';
 import type {Config} from '@jest/types';
+import readPkgUp = require('read-pkg-up');
 
 const runtimeSupportsVmModules = typeof SyntheticModule === 'function';
 
 const cachedFileLookups = new Map<string, boolean>();
 const cachedDirLookups = new Map<string, boolean>();
-const cachedChecks = new Map<string, boolean>();
 
 export function clearCachedLookups(): void {
   cachedFileLookups.clear();
   cachedDirLookups.clear();
-  cachedChecks.clear();
 }
 
 export default function cachedShouldLoadAsEsm(path: Config.Path): boolean {
@@ -70,29 +67,12 @@ function shouldLoadAsEsm(path: Config.Path): boolean {
 }
 
 function cachedPkgCheck(cwd: Config.Path): boolean {
-  const pkgPath = escalade(cwd, (_dir, names) => {
-    if (names.includes('package.json')) {
-      // will be resolved into absolute
-      return 'package.json';
-    }
-    return false;
-  });
-  if (!pkgPath) {
+  // TODO: can we cache lookups somehow?
+  const pkg = readPkgUp.sync({cwd, normalize: false});
+
+  if (!pkg) {
     return false;
   }
 
-  let hasModuleField = cachedChecks.get(pkgPath);
-  if (hasModuleField != null) {
-    return hasModuleField;
-  }
-
-  try {
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    hasModuleField = pkg.type === 'module';
-  } catch {
-    hasModuleField = false;
-  }
-
-  cachedChecks.set(pkgPath, hasModuleField);
-  return hasModuleField;
+  return pkg.packageJson.type === 'module';
 }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -35,7 +35,7 @@
     "jest-validate": "^26.5.0",
     "slash": "^3.0.0",
     "strip-bom": "^4.0.0",
-    "yargs": "^16.0.3"
+    "yargs": "^15.4.1"
   },
   "devDependencies": {
     "@jest/test-utils": "^26.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,7 +1895,7 @@ __metadata:
     jest-util: ^26.5.0
     jest-worker: ^26.5.0
     mock-fs: ^4.4.1
-    node-notifier: 7.0.1
+    node-notifier: ^8.0.0
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
@@ -11206,7 +11206,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.1.1":
+"is-wsl@npm:^2.2.0":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -14242,17 +14242,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-notifier@npm:7.0.1":
-  version: 7.0.1
-  resolution: "node-notifier@npm:7.0.1"
+"node-notifier@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "node-notifier@npm:8.0.0"
   dependencies:
     growly: ^1.3.0
-    is-wsl: ^2.1.1
-    semver: ^7.2.1
+    is-wsl: ^2.2.0
+    semver: ^7.3.2
     shellwords: ^0.1.1
-    uuid: ^7.0.3
+    uuid: ^8.3.0
     which: ^2.0.2
-  checksum: d851b89ba6e6cbab7803370516ff25424b95d2fa0d0a15c01c199447502cd959f2153d2976674eb297a01faff64a85598297e54da362c933c3fb199ecfc39118
+  checksum: 3016eccb32cbfc0ec26129500570a0d875c32e28c43aef9c32d4cea24617cdd870eaf39247faffed5b89f78ef69ca4506270d2f8f76f027222597b700cc8aec9
   languageName: node
   linkType: hard
 
@@ -19488,16 +19488,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"uuid@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "uuid@npm:7.0.3"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: a56be8a5bbf2bae755d749d0693637274935b5ae250dfaaaf79241391cf1a7c142a202492196363ec62ec51a476e5e3fc4de2944d854abf2e9b35a33e0e31d4c
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.2.0":
+"uuid@npm:^8.2.0, uuid@npm:^8.3.0":
   version: 8.3.1
   resolution: "uuid@npm:8.3.1"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11773,11 +11773,11 @@ fsevents@^1.2.7:
     "@types/graceful-fs": ^4.1.3
     "@types/resolve": ^1.17.0
     chalk: ^4.0.0
-    escalade: ^3.1.0
     graceful-fs: ^4.2.4
     jest-haste-map: ^26.5.0
     jest-pnp-resolver: ^1.2.2
     jest-util: ^26.5.0
+    read-pkg-up: ^7.0.1
     resolve: ^1.17.0
     slash: ^3.0.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,7 +1895,7 @@ __metadata:
     jest-util: ^26.5.0
     jest-worker: ^26.5.0
     mock-fs: ^4.4.1
-    node-notifier: ^8.0.0
+    node-notifier: 7.0.1
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
@@ -11206,7 +11206,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-wsl@npm:^2.2.0":
+"is-wsl@npm:^2.1.1":
   version: 2.2.0
   resolution: "is-wsl@npm:2.2.0"
   dependencies:
@@ -14242,17 +14242,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-notifier@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "node-notifier@npm:8.0.0"
+"node-notifier@npm:7.0.1":
+  version: 7.0.1
+  resolution: "node-notifier@npm:7.0.1"
   dependencies:
     growly: ^1.3.0
-    is-wsl: ^2.2.0
-    semver: ^7.3.2
+    is-wsl: ^2.1.1
+    semver: ^7.2.1
     shellwords: ^0.1.1
-    uuid: ^8.3.0
+    uuid: ^7.0.3
     which: ^2.0.2
-  checksum: 3016eccb32cbfc0ec26129500570a0d875c32e28c43aef9c32d4cea24617cdd870eaf39247faffed5b89f78ef69ca4506270d2f8f76f027222597b700cc8aec9
+  checksum: d851b89ba6e6cbab7803370516ff25424b95d2fa0d0a15c01c199447502cd959f2153d2976674eb297a01faff64a85598297e54da362c933c3fb199ecfc39118
   languageName: node
   linkType: hard
 
@@ -19488,7 +19488,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.2.0, uuid@npm:^8.3.0":
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: a56be8a5bbf2bae755d749d0693637274935b5ae250dfaaaf79241391cf1a7c142a202492196363ec62ec51a476e5e3fc4de2944d854abf2e9b35a33e0e31d4c
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.2.0":
   version: 8.3.1
   resolution: "uuid@npm:8.3.1"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5860,17 +5860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^7.0.0":
-  version: 7.0.1
-  resolution: "cliui@npm:7.0.1"
-  dependencies:
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    wrap-ansi: ^7.0.0
-  checksum: 9c1433067a5860f9b8df76e5e0186a86992a180b8f8dd316357e19aa65b68d46964d448d18991fb598ab638a6c24218ce1331344fa4eec6767fcab40232b19fa
-  languageName: node
-  linkType: hard
-
 "clone-deep@npm:^4.0.1":
   version: 4.0.1
   resolution: "clone-deep@npm:4.0.1"
@@ -7758,7 +7747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.0.2, escalade@npm:^3.1.0":
+"escalade@npm:^3.1.0":
   version: 3.1.0
   resolution: "escalade@npm:3.1.0"
   checksum: 437c5b2619a412c0b075fb33e590e3516f187f7da8b20035685e08f346e27842722e5740a3398535d7d590ae4fb70068374ed59190d4eb4f9bb06d052e2fc92f
@@ -9360,7 +9349,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"get-caller-file@npm:^2.0.1, get-caller-file@npm:^2.0.5":
+"get-caller-file@npm:^2.0.1":
   version: 2.0.5
   resolution: "get-caller-file@npm:2.0.5"
   checksum: 9dd9e1e2591039ee4c38c897365b904f66f1e650a8c1cb7b7db8ce667fa63e88cc8b13282b74df9d93de481114b3304a0487880d31cd926dfda6efe71455855d
@@ -11428,7 +11417,7 @@ fsevents@^1.2.7:
     jest-util: ^26.5.0
     jest-validate: ^26.5.0
     prompts: ^2.0.1
-    yargs: ^16.0.3
+    yargs: ^15.4.1
   bin:
     jest: ./bin/jest.js
   languageName: unknown
@@ -11746,7 +11735,7 @@ fsevents@^1.2.7:
     jest-runtime: ^26.5.0
     jest-validate: ^26.5.0
     repl: ^0.1.3
-    yargs: ^16.0.3
+    yargs: ^15.4.1
   bin:
     jest-repl: ./bin/jest-repl.js
   languageName: unknown
@@ -11862,7 +11851,7 @@ fsevents@^1.2.7:
     jest-validate: ^26.5.0
     slash: ^3.0.0
     strip-bom: ^4.0.0
-    yargs: ^16.0.3
+    yargs: ^15.4.1
   bin:
     jest-runtime: ./bin/jest-runtime.js
   languageName: unknown
@@ -19861,17 +19850,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0"
-  dependencies:
-    ansi-styles: ^4.0.0
-    string-width: ^4.1.0
-    strip-ansi: ^6.0.0
-  checksum: 09939dd775ae565bb99a25a6c072fe3775a95fa71751b5533c94265fe986ba3e3ab071a027ab76cf26876bd9afd10ac3c2d06d7c4bcce148bf7d2d9514e3a0df
-  languageName: node
-  linkType: hard
-
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
@@ -20092,13 +20070,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"y18n@npm:^5.0.1":
-  version: 5.0.2
-  resolution: "y18n@npm:5.0.2"
-  checksum: ba6106061c8ef612d888fa3fca61d094027200c4792275886eca2f82e92b1f24120011cc878d808a38be98c2ed1e3f831117691bf4d526a084e339cbd7c9f587
-  languageName: node
-  linkType: hard
-
 "yallist@npm:^2.1.2":
   version: 2.1.2
   resolution: "yallist@npm:2.1.2"
@@ -20153,13 +20124,6 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.0.0":
-  version: 20.2.1
-  resolution: "yargs-parser@npm:20.2.1"
-  checksum: c4945ade7d792bde00e3f68930f56f1fdd531e501c4ecf944c524c1541c5fe2468c27b4f76b0b459009ef09e338750d01810732f99f0a1fa061af4126cf5f53e
-  languageName: node
-  linkType: hard
-
 "yargs@npm:^14.2.0, yargs@npm:^14.2.2":
   version: 14.2.3
   resolution: "yargs@npm:14.2.3"
@@ -20179,7 +20143,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"yargs@npm:^15.1.0":
+"yargs@npm:^15.1.0, yargs@npm:^15.4.1":
   version: 15.4.1
   resolution: "yargs@npm:15.4.1"
   dependencies:
@@ -20195,21 +20159,6 @@ fsevents@^1.2.7:
     y18n: ^4.0.0
     yargs-parser: ^18.1.2
   checksum: dbf687d6b938f01bbf11e158dde6df906282b70cd9295af0217ee8cefbd83ad09d49fa9458d0d5325b0e66f03df954a38986db96f91e5b46ccdbbaf9a0157b23
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^16.0.3":
-  version: 16.0.3
-  resolution: "yargs@npm:16.0.3"
-  dependencies:
-    cliui: ^7.0.0
-    escalade: ^3.0.2
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.1
-    yargs-parser: ^20.0.0
-  checksum: 39490963e02bceb73ffff285cd9b241e5b019acbedef456586c97027cc18d0cadb743ad1340ccdc9340d0a21e18176c63b9f8bd90eee64c7e1f512c147aab1c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #10596

This reverts commit 0a9e77d5e75adc87f8d7497ec30472c661c6fc11.

Let's land it for Jest 27 instead

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
