### PR TITLE
Fix type definitions for promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-mock]` Fix typings for `mockResolvedValue`, `mockResolvedValueOnce`, `mockRejectedValue` and `mockRejectedValueOnce`
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -63,12 +63,14 @@ namespace JestMock {
     mockReturnThis(): this;
     mockReturnValue(value: T): this;
     mockReturnValueOnce(value: T): this;
-    mockResolvedValue(value: T): this;
-    mockResolvedValueOnce(value: T): this;
-    mockRejectedValue(value: T): this;
-    mockRejectedValueOnce(value: T): this;
+    mockResolvedValue(value: Unpromisify<T>): this;
+    mockResolvedValueOnce(value: Unpromisify<T>): this;
+    mockRejectedValue(value: unknown): this;
+    mockRejectedValueOnce(value: unknown): this;
   }
 }
+
+type Unpromisify<T> = T extends Promise<infer R> ? R : never;
 
 /**
  * Possible types of a MockFunctionResult.
@@ -661,20 +663,20 @@ class ModuleMockerClass {
         // next function call will return this value or default return value
         f.mockImplementationOnce(() => value);
 
-      f.mockResolvedValueOnce = (value: T) =>
-        f.mockImplementationOnce(() => Promise.resolve(value));
+      f.mockResolvedValueOnce = (value: Unpromisify<T>) =>
+        f.mockImplementationOnce(() => Promise.resolve(value as T));
 
-      f.mockRejectedValueOnce = (value: T) =>
+      f.mockRejectedValueOnce = (value: unknown) =>
         f.mockImplementationOnce(() => Promise.reject(value));
 
       f.mockReturnValue = (value: T) =>
         // next function call will return specified return value or this one
         f.mockImplementation(() => value);
 
-      f.mockResolvedValue = (value: T) =>
-        f.mockImplementation(() => Promise.resolve(value));
+      f.mockResolvedValue = (value: Unpromisify<T>) =>
+        f.mockImplementation(() => Promise.resolve(value as T));
 
-      f.mockRejectedValue = (value: T) =>
+      f.mockRejectedValue = (value: unknown) =>
         f.mockImplementation(() => Promise.reject(value));
 
       f.mockImplementationOnce = (

--- a/test-types/top-level-jest-namespace.test.ts
+++ b/test-types/top-level-jest-namespace.test.ts
@@ -10,6 +10,7 @@
 import {expectError, expectType} from 'mlh-tsd';
 //eslint-disable-next-line import/no-extraneous-dependencies
 import {jest} from '@jest/globals';
+import type {Mock} from 'jest-mock';
 
 expectType<void>(jest.addMatchers({}));
 expectType<typeof jest>(jest.autoMockOff());
@@ -37,6 +38,26 @@ expectType<typeof jest>(jest.resetModuleRegistry());
 expectType<typeof jest>(jest.resetModules());
 expectType<typeof jest>(jest.isolateModules(() => {}));
 expectType<typeof jest>(jest.retryTimes(3));
+expectType<Mock<Promise<string>, []>>(
+  jest
+    .fn(() => Promise.resolve('string value'))
+    .mockResolvedValueOnce('A string, not a Promise'),
+);
+expectType<Mock<Promise<string>, []>>(
+  jest
+    .fn(() => Promise.resolve('string value'))
+    .mockResolvedValue('A string, not a Promise'),
+);
+expectType<Mock<Promise<string>, []>>(
+  jest
+    .fn(() => Promise.resolve('string value'))
+    .mockRejectedValueOnce(new Error('An error, not a string')),
+);
+expectType<Mock<Promise<string>, []>>(
+  jest
+    .fn(() => Promise.resolve('string value'))
+    .mockRejectedValue(new Error('An error, not a string')),
+);
 
 expectType<void>(jest.runAllImmediates());
 expectType<void>(jest.runAllTicks());


### PR DESCRIPTION
## Summary

When calling `mockResolvedValue` (-`Once`), the argument should be
the expected return value unwrapped from its Promise. Likewise,
when mocking a rejected value, the passed argument needs not
necessarily be of the same type as the expected successful return
value.

## Test plan

Without this change, the following code will cause TypeScript to complain:

```typescript
    const mockFetch = jest.fn(window.fetch).mockResolvedValue(new Response());
```

```
Argument of type 'Response' is not assignable to parameter of type 'Promise<Response>'.
  Type 'Response' is missing the following properties from type 'Promise<Response>': then, catch, [Symbol.toStringTag], finally
```

That error will disappear with this PR.