### PR TITLE
Show suggestion only when unrecognized cli param is longer than 1 character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-validate]` Show suggestion only when unrecognized cli param is longer than 1 character ([#10604](https://github.com/facebook/jest/pull/10604))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not show suggestion when unrecognized cli param length <= 1 1`] = `
+"<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
+<red></>
+<red>  Unrecognized option <bold>\\"l\\"</>.</>
+<red></>
+<red>  <bold>CLI Options Documentation</>:</>
+<red>  https://jestjs.io/docs/en/cli.html</>
+<red></>"
+`;
+
 exports[`fails for multiple unknown options 1`] = `
 "<red><bold><bold>●</><bold> Unrecognized CLI Parameters</>:</>
 <red></>
@@ -15,6 +25,16 @@ exports[`fails for unknown option 1`] = `
 "<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
 <red></>
 <red>  Unrecognized option <bold>\\"unknown\\"</>.</>
+<red></>
+<red>  <bold>CLI Options Documentation</>:</>
+<red>  https://jestjs.io/docs/en/cli.html</>
+<red></>"
+`;
+
+exports[`shows suggestion when unrecognized cli param length > 1 1`] = `
+"<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
+<red></>
+<red>  Unrecognized option <bold>\\"hell\\"</>. Did you mean <bold>\\"help\\"</>?</>
 <red></>
 <red>  <bold>CLI Options Documentation</>:</>
 <red>  https://jestjs.io/docs/en/cli.html</>

--- a/packages/jest-validate/src/__tests__/validateCLIOptions.test.js
+++ b/packages/jest-validate/src/__tests__/validateCLIOptions.test.js
@@ -41,3 +41,25 @@ test('fails for multiple unknown options', () => {
     validateCLIOptions(argv, options),
   ).toThrowErrorMatchingSnapshot();
 });
+
+test('does not show suggestion when unrecognized cli param length <= 1', () => {
+  const options = ['$0', '_', 'help', 'h'];
+  const argv = {
+    $0: true,
+    l: true,
+  };
+  expect(() =>
+    validateCLIOptions(argv, options),
+  ).toThrowErrorMatchingSnapshot();
+});
+
+test('shows suggestion when unrecognized cli param length > 1', () => {
+  const options = ['$0', '_', 'help', 'h'];
+  const argv = {
+    $0: true,
+    hell: true,
+  };
+  expect(() =>
+    validateCLIOptions(argv, options),
+  ).toThrowErrorMatchingSnapshot();
+});

--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -31,10 +31,10 @@ const createCLIValidationError = (
 
   if (unrecognizedOptions.length === 1) {
     const unrecognized = unrecognizedOptions[0];
-    const didYouMeanMessage = createDidYouMeanMessage(
-      unrecognized,
-      Array.from(allowedOptions),
-    );
+    const didYouMeanMessage =
+      unrecognized.length > 1
+        ? createDidYouMeanMessage(unrecognized, Array.from(allowedOptions))
+        : '';
     message =
       `  Unrecognized option ${chalk.bold(format(unrecognized))}.` +
       (didYouMeanMessage ? ` ${didYouMeanMessage}` : '');


### PR DESCRIPTION
## Summary
Resolves #9007 
Currently running CLI command with an unrecognized parameter of length 1 results in a message containing `Did you mean "$0"?`

![Screenshot from 2020-10-07 17-13-56](https://user-images.githubusercontent.com/33008847/95331597-db8e9200-08c7-11eb-83ab-a90e7c2bba1e.png)

## Test plan

This fix adds a check to make a suggestion only when the unrecognized cli param length is greater than 1, so that `"$0"` is not suggested to the user as a possible param

![Screenshot from 2020-10-07 18-18-45](https://user-images.githubusercontent.com/33008847/95332840-966b5f80-08c9-11eb-9c91-1e3907d8f32b.png)

Added relevant tests to `validateCLIOptions.test.ts`