### PR TITLE
chore: remove custom `process.versions.pnp` type

### DIFF
--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.3",
+    "@types/pnpapi": "~0.0.1",
     "@types/resolve": "^1.20.0"
   },
   "engines": {

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -46,15 +46,6 @@ export type AsyncResolver = (
 
 export type Resolver = SyncResolver | AsyncResolver;
 
-// https://github.com/facebook/jest/pull/10617
-declare global {
-  namespace NodeJS {
-    export interface ProcessVersions {
-      pnp?: any;
-    }
-  }
-}
-
 const defaultResolver: SyncResolver = (path, options) => {
   // Yarn 2 adds support to `resolve` automatically so the pnpResolver is only
   // needed for Yarn 1 which implements version 1 of the pnp spec

--- a/yarn.lock
+++ b/yarn.lock
@@ -5180,6 +5180,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pnpapi@npm:~0.0.1":
+  version: 0.0.2
+  resolution: "@types/pnpapi@npm:0.0.2"
+  checksum: b58ec37cfaebe99ca7d1fa3200c57d8f8d51da58f6152c1b8ef6d03e00fa8595a937ae36234a0ff6f52306740bf4ddfd2633d62d5693eb9af41edb6181ef3d02
+  languageName: node
+  linkType: hard
+
 "@types/prettier@npm:*, @types/prettier@npm:^2.0.0, @types/prettier@npm:^2.1.5":
   version: 2.4.4
   resolution: "@types/prettier@npm:2.4.4"
@@ -13301,6 +13308,7 @@ __metadata:
   resolution: "jest-resolve@workspace:packages/jest-resolve"
   dependencies:
     "@types/graceful-fs": ^4.1.3
+    "@types/pnpapi": ~0.0.1
     "@types/resolve": ^1.20.0
     chalk: ^4.0.0
     graceful-fs: ^4.2.9


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This makes sure we don't pollute the global namespace. Also less code on our side.

It does for whatever reason add an `/// <reference types="pnpapi" />` to `handle_deprecation_warnings`, which breaks CI 🙁 Not sure why or how to avoid it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
