### PR TITLE
fix: `require.main` is undefined on using `jest.resetModules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-runtime]` fix: `require.main` is undefined on using `jest.resetModules` ([#10626](https://github.com/facebook/jest/pull/10626))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-runtime]` fix: `require.main` is undefined on using `jest.resetModules` ([#10626](https://github.com/facebook/jest/pull/10626))
+- `[jest-runtime]` `require.main` is no longer `undefined` when using `jest.resetModules` ([#10626](https://github.com/facebook/jest/pull/10626))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/requireMainResetModules.test.ts
+++ b/e2e/__tests__/requireMainResetModules.test.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('`require.main` on using `jest.resetModules` should not be undefined', () => {
+  const {exitCode} = runJest('require-main-reset-modules', [
+    `--resetModules='true'`,
+  ]);
+  expect(exitCode).toBe(0);
+});

--- a/e2e/__tests__/requireMainResetModules.test.ts
+++ b/e2e/__tests__/requireMainResetModules.test.ts
@@ -7,9 +7,17 @@
 
 import runJest from '../runJest';
 
-test('`require.main` on using `jest.resetModules` should not be undefined', () => {
+test("`require.main` on using `--resetModules='true'` should not be undefined", () => {
   const {exitCode} = runJest('require-main-reset-modules', [
     `--resetModules='true'`,
+    'index.test.js',
+  ]);
+  expect(exitCode).toBe(0);
+});
+
+test('`require.main` on using `jest.resetModules()` should not be undefined', () => {
+  const {exitCode} = runJest('require-main-reset-modules', [
+    'callJestResetModules.test.js',
   ]);
   expect(exitCode).toBe(0);
 });

--- a/e2e/require-main-reset-modules/__tests__/callJestResetModules.test.js
+++ b/e2e/require-main-reset-modules/__tests__/callJestResetModules.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  jest.resetModules();
+});
+
+test('require.main is set', () => {
+  const {getMain} = require('../index.js');
+  expect(getMain()).toBeTruthy();
+});
+
+test('require from main works', () => {
+  const {requireFromMain} = require('../index.js');
+  expect(requireFromMain('../package.json')).toBeTruthy();
+});

--- a/e2e/require-main-reset-modules/__tests__/index.test.js
+++ b/e2e/require-main-reset-modules/__tests__/index.test.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+test('require.main is set', () => {
+  const {getMain} = require('../index.js');
+  expect(getMain()).toBeTruthy();
+});
+
+test('require from main works', () => {
+  const {requireFromMain} = require('../index.js');
+  expect(requireFromMain('../package.json')).toBeTruthy();
+});

--- a/e2e/require-main-reset-modules/index.js
+++ b/e2e/require-main-reset-modules/index.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+Object.assign(exports, {getMain, requireFromMain});
+
+function getMain() {
+  return require.main;
+}
+
+function requireFromMain(pkg) {
+  return getMain().require(pkg);
+}

--- a/e2e/require-main-reset-modules/package.json
+++ b/e2e/require-main-reset-modules/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -139,7 +139,7 @@ describe('Runtime requireModule', () => {
   });
   it('provides `require.main` to modules', () =>
     createRuntime(__filename).then(runtime => {
-      runtime._moduleRegistry.set(__filename, module);
+      runtime._mainModule = module;
       [
         './test_root/modules_with_main/export_main.js',
         './test_root/modules_with_main/re_export_main.js',

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1061,6 +1061,10 @@ class Runtime {
       }),
     ];
 
+    if (!this._mainModule && filename === this._testPath) {
+      this._mainModule = module;
+    }
+
     Object.defineProperty(module, 'main', {
       enumerable: true,
       value: this._mainModule,
@@ -1394,14 +1398,11 @@ class Runtime {
       });
     })();
 
-    if (!this._mainModule && from.filename === this._testPath) {
-      this._mainModule = module;
-    }
-
     Object.defineProperty(moduleRequire, 'main', {
       enumerable: true,
       value: this._mainModule,
     });
+
     return moduleRequire;
   }
 

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1061,10 +1061,6 @@ class Runtime {
       }),
     ];
 
-    if (!this._mainModule && filename === this._testPath) {
-      this._mainModule = module;
-    }
-
     Object.defineProperty(module, 'main', {
       enumerable: true,
       value: this._mainModule,
@@ -1398,9 +1394,13 @@ class Runtime {
       });
     })();
 
+    if (!this._mainModule && from.filename === this._testPath) {
+      this._mainModule = module;
+    }
+
     Object.defineProperty(moduleRequire, 'main', {
       enumerable: true,
-      value: this._testPath ? this._moduleRegistry.get(this._testPath) : null,
+      value: this._mainModule,
     });
     return moduleRequire;
   }


### PR DESCRIPTION
## Summary
Closes #10625.

`require.main` is `undefined` on using the `--resetModules` flag. This PR aims to resolve this issue.

## Test plan

E2E tests added
