### PR TITLE
Add step for fetching backers.json to website install steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[docs]` Add step for fetching `backers.json` file in website setup docs ([#10631](https://github.com/facebook/jest/pull/10631))
 - `[jest-cli, jest-config]` Add support for the `jest.config.ts` configuration file ([#10564](https://github.com/facebook/jest/pull/10564))
 
 ### Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ If you are making changes to the website or documentation, test the website fold
     ```sh-session
     $ cd website       # Only needed if you are not already in the website directory
     $ yarn
+    $ node fetchSupporters.js
     $ yarn start
     ```
 1.  You can run a development server to check if the changes you made are being displayed accurately by running `yarn start` in the website directory.

--- a/website/README.md
+++ b/website/README.md
@@ -10,6 +10,12 @@ yarn
 
 in the root directory.
 
+Fetch `backers.json` file by running
+
+```bash
+node fetchSupporters.js
+```
+
 Then, run the server via
 
 ```bash


### PR DESCRIPTION
Supercedes: #10191
Fixes: #9808

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When attempting to run `yarn start` for the first time after following the install steps I got this error message:
```
Error: Cannot find module '/Users/stdavis/Documents/Projects/jest/website/backers.json'
```

This PR adds the required command to fix this error.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I've run `node fetchSupporters.js` and now the website behaves normally without errors.