### PR TITLE
refactor: add missing options for timers on config.ts file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 - `[jest-runtime]` `require.main` is no longer `undefined` when using `jest.resetModules` ([#10626](https://github.com/facebook/jest/pull/10626))
+- `[@jest/types]` Add missing values for `timers` ([#10632](https://github.com/facebook/jest/pull/10632))
 
 ### Chore & Maintenance
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -11,7 +11,7 @@ import type {ForegroundColor} from 'chalk';
 
 type CoverageProvider = 'babel' | 'v8';
 
-type Timers = 'real' | 'fake' | 'modern';
+type Timers = 'real' | 'fake' | 'modern' | 'legacy';
 
 export type Path = string;
 
@@ -364,7 +364,7 @@ export type ProjectConfig = {
   testRegex: Array<string | RegExp>;
   testRunner: string;
   testURL: string;
-  timers: Timers | 'legacy';
+  timers: Timers;
   transform: Array<[string, Path, Record<string, unknown>]>;
   transformIgnorePatterns: Array<Glob>;
   watchPathIgnorePatterns: Array<string>;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -11,6 +11,8 @@ import type {ForegroundColor} from 'chalk';
 
 type CoverageProvider = 'babel' | 'v8';
 
+type Timers = 'real' | 'fake' | 'modern';
+
 export type Path = string;
 
 export type Glob = string;
@@ -92,7 +94,7 @@ export type DefaultOptions = {
   testRunner: string;
   testSequencer: string;
   testURL: string;
-  timers: 'real' | 'fake';
+  timers: Timers;
   transformIgnorePatterns: Array<Glob>;
   useStderr: boolean;
   watch: boolean;
@@ -206,7 +208,7 @@ export type InitialOptions = Partial<{
   testSequencer: string;
   testURL: string;
   testTimeout: number;
-  timers: 'real' | 'fake';
+  timers: Timers;
   transform: {
     [regex: string]: Path | TransformerConfig;
   };
@@ -362,7 +364,7 @@ export type ProjectConfig = {
   testRegex: Array<string | RegExp>;
   testRunner: string;
   testURL: string;
-  timers: 'real' | 'fake' | 'modern' | 'legacy';
+  timers: Timers | 'legacy';
   transform: Array<[string, Path, Record<string, unknown>]>;
   transformIgnorePatterns: Array<Glob>;
   watchPathIgnorePatterns: Array<string>;


### PR DESCRIPTION
## Summary

`@jest/types` config in `Config.ts` has missing value(s) for `timers` in two variables `InitialOptions` and `DefaultOptions`.

----

Closes #10609
