### PR TITLE
fix: do not inject `global` variable into module wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/global-mutation.test.ts
+++ b/e2e/__tests__/global-mutation.test.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const global = 'woo!';
+
+test('can redefine global', () => {
+  expect(global).toBe('woo!');
+});

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -45,6 +45,9 @@ class JSDOMEnvironment implements JestEnvironment {
       throw new Error('JSDOM did not return a Window object');
     }
 
+    // for "universal" code (code should use `globalThis`)
+    global.global = global;
+
     // In the `jsdom@16`, ArrayBuffer was not added to Window, ref: https://github.com/jsdom/jsdom/commit/3a4fd6258e6b13e9cf8341ddba60a06b9b5c7b5b
     // Install ArrayBuffer to Window to fix it. Make sure the test is passed, ref: https://github.com/facebook/jest/pull/7626
     global.ArrayBuffer = ArrayBuffer;

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -29,7 +29,6 @@ export type ModuleWrapper = (
   require: Module['require'],
   __dirname: string,
   __filename: Module['filename'],
-  global: Global.Global,
   jest?: Jest,
   ...extraGlobals: Array<Global.Global[keyof Global.Global]>
 ) => unknown;

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Runtime wrapCodeInModuleWrapper generates the correct args for the module wrapper 1`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "Hello!"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){module.exports = "Hello!"
 }});
 `;
 
 exports[`Runtime wrapCodeInModuleWrapper injects "extra globals" 1`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = "Hello!"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest,Math){module.exports = "Hello!"
 }});
 `;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -383,7 +383,7 @@ class Runtime {
       invariant(context);
 
       if (this._resolver.isCoreModule(modulePath)) {
-        const core = await this._importCoreModule(modulePath, context);
+        const core = this._importCoreModule(modulePath, context);
         this._esmoduleRegistry.set(cacheKey, core);
         return core;
       }
@@ -1123,7 +1123,6 @@ class Runtime {
         module.require, // require implementation
         module.path, // __dirname
         module.filename, // __filename
-        this._environment.global, // global object
         // @ts-expect-error
         ...lastArgs.filter(notEmpty),
       );
@@ -1678,7 +1677,6 @@ class Runtime {
       'require',
       '__dirname',
       '__filename',
-      'global',
       this._config.injectGlobals ? 'jest' : undefined,
       ...this._config.extraGlobals,
     ].filter(notEmpty);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

It's not part of the module wrapper, so we shouldn't inject it: https://nodejs.org/api/modules.html#modules_the_module_wrapper

Fixes #10565.

EDIT: Huh, seems like this blows up for tests I didn't bother to run locally. Specifically, it explodes for tests using `global` in JSDOM. I'm thinking we can just add it to the JSDOM env and remove in a future version. Might be considered a breaking change, though?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
