### PR TITLE
Add support for `recursiveDenylist` option as an alternative to `recursiveBlacklist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-validate]` Add support for `recursiveDenylist` option as an alternative to `recursiveBlacklist` ([#10236](https://github.com/facebook/jest/pull/10236))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -62,7 +62,7 @@ Almost anything can be overwritten to suite your needs.
 
 ### Options
 
-- `recursiveBlacklist` – optional array of string keyPaths that should be excluded from deep (recursive) validation.
+- `recursiveDenylist` – optional array of string keyPaths that should be excluded from deep (recursive) validation.
 - `comment` – optional string to be rendered below error/warning message.
 - `condition` – an optional function with validation condition.
 - `deprecate`, `error`, `unknown` – optional functions responsible for displaying warning and error messages.

--- a/packages/jest-validate/src/__tests__/validate.test.ts
+++ b/packages/jest-validate/src/__tests__/validate.test.ts
@@ -101,7 +101,7 @@ test.each([
   },
 );
 
-test('respects blacklist', () => {
+test('respects recursiveBlacklist', () => {
   const warn = console.warn;
   console.warn = jest.fn();
   const config = {
@@ -129,6 +129,40 @@ test('respects blacklist', () => {
   validate(config, {
     exampleConfig,
     recursiveBlacklist: ['something.nested'],
+  });
+
+  expect(console.warn).not.toBeCalled();
+  console.warn = warn;
+});
+
+test('respects recursiveDenylist', () => {
+  const warn = console.warn;
+  console.warn = jest.fn();
+  const config = {
+    something: {
+      nested: {
+        some_random_key: 'value',
+        some_random_key2: 'value2',
+      },
+    },
+  };
+  const exampleConfig = {
+    something: {
+      nested: {
+        test: true,
+      },
+    },
+  };
+
+  validate(config, {exampleConfig});
+
+  expect(console.warn).toBeCalled();
+
+  console.warn.mockReset();
+
+  validate(config, {
+    exampleConfig,
+    recursiveDenylist: ['something.nested'],
   });
 
   expect(console.warn).not.toBeCalled();
@@ -292,7 +326,7 @@ test('Comments in config JSON using "//" key are not warned', () => {
 
   validate(config, {
     exampleConfig: validConfig,
-    recursiveBlacklist: ['myCustomKey' as "don't validate this"],
+    recursiveDenylist: ['myCustomKey' as "don't validate this"],
   });
   expect(console.warn).not.toBeCalled();
 

--- a/packages/jest-validate/src/defaultConfig.ts
+++ b/packages/jest-validate/src/defaultConfig.ts
@@ -22,7 +22,7 @@ const validationOptions: ValidationOptions = {
   exampleConfig: {},
   recursive: true,
   // Allow NPM-sanctioned comments in package.json. Use a "//" key.
-  recursiveBlacklist: ['//'],
+  recursiveDenylist: ['//'],
   title: {
     deprecation: DEPRECATION,
     error: ERROR,

--- a/packages/jest-validate/src/exampleConfig.ts
+++ b/packages/jest-validate/src/exampleConfig.ts
@@ -17,7 +17,7 @@ const config: ValidationOptions = {
   error: () => {},
   exampleConfig: {key: 'value', test: 'case'},
   recursive: true,
-  recursiveBlacklist: [],
+  recursiveDenylist: [],
   title: {
     deprecation: 'Deprecation Warning',
     error: 'Validation Error',

--- a/packages/jest-validate/src/types.ts
+++ b/packages/jest-validate/src/types.ts
@@ -35,6 +35,7 @@ export type ValidationOptions = {
   exampleConfig: Record<string, unknown>;
   recursive?: boolean;
   recursiveBlacklist?: Array<string>;
+  recursiveDenylist?: Array<string>;
   title?: Title;
   unknown?: (
     config: Record<string, unknown>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Clone of #10236 which has to be closed because the original repo was deleted by me.

Part of #10235.

* Adds support for `recursiveDenylist` option as an alternative to `recursiveBlacklist` in `jest-validate`. Does NOT remove `recursiveBlacklist` option. It will continue to work, unless overwritten with `recursiveDenylist`, to which I've given the priority.
* Updates documentation not to mention `recursiveBlacklist` (in favor of the newly added option).
* ~~Changes internal calls to `validate()` to use new config **(Maintainers: I'm not sure if that's a good idea - can you please advise? Should we expect `jest-config`, say, v26.2 work with other dependencies @ v26.1 at all times? Shall I roll that back and add it as a TODO to #10235 instead? TIA)**~~

## Motivation

Part of continuous effort to get rid of non-inclusive terms like "whitelist" and "blacklist" implying that white = good and black = bad.

## Test plan

`jest-validate` had one suite where `recursiveBlacklist` option was used, in two cases:
* test the very `recursiveBlacklist` option
* test for warning against unknown config options

The former was left intact, and copied 1:1 over to create a new test, testing whether `recursiveDenylist` beaves exactly the same as `recursiveBlacklist`.

The latter was updated to use `recursiveDenylist`.

Tests were ran successfully. 

<img width="411" alt="obraz" src="https://user-images.githubusercontent.com/5426427/86458383-72760c00-bd25-11ea-83fc-32b5587c34db.png">
