### PR TITLE
Fix: "resetAllMocks" does not reset all mocks

### DIFF
--- a/e2e/__tests__/resetAllMocks.test.ts
+++ b/e2e/__tests__/resetAllMocks.test.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('`jest.resetAllMocks` should work on using `jest.generateFromMetadata`', () => {
+  const result = runJest('reset-all-mocks');
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/reset-all-mocks/__tests__/index.test.js
+++ b/e2e/reset-all-mocks/__tests__/index.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const mock = require('../util');
+
+class Test {
+  testMethod() {
+    return false;
+  }
+}
+
+describe('test mock', () => {
+  const testMock = mock(Test);
+
+  it('should reset mocks', () => {
+    testMock.testMethod();
+    testMock.testMethod.mockReset(); // <--- works as expected
+    expect(testMock.testMethod).not.toHaveBeenCalled(); // <---- passes
+
+    testMock.testMethod();
+    jest.resetAllMocks(); // <--- does not reset the mock
+    expect(testMock.testMethod).not.toHaveBeenCalled(); // <--- fails
+  });
+});

--- a/e2e/reset-all-mocks/package.json
+++ b/e2e/reset-all-mocks/package.json
@@ -1,0 +1,6 @@
+{
+    "jest": {
+      "testEnvironment": "node"
+    }
+  }
+  

--- a/e2e/reset-all-mocks/util.js
+++ b/e2e/reset-all-mocks/util.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const jestMock = require('jest-mock');
+
+module.exports = function mock(classType) {
+  const mockType = jestMock.generateFromMetadata(
+    jestMock.getMetadata(classType),
+  );
+  return new mockType();
+};


### PR DESCRIPTION
## Summary

Closes #7083. 

I've been able to repro the issue and set up tests for the same. I'm a little unsure of the approach I would take, I think [this](https://github.com/facebook/jest/issues/7083#issuecomment-441380653) might be feasible but I'd like someone to give me a green light before I get on with it!

## Test plan

E2E tests added.
