### PR TITLE
more consistent function sign

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1080,7 +1080,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 

--- a/website/versioned_docs/version-22.x/ExpectAPI.md
+++ b/website/versioned_docs/version-22.x/ExpectAPI.md
@@ -780,7 +780,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -1044,7 +1044,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 

--- a/website/versioned_docs/version-24.x/ExpectAPI.md
+++ b/website/versioned_docs/version-24.x/ExpectAPI.md
@@ -1055,7 +1055,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 

--- a/website/versioned_docs/version-25.x/ExpectAPI.md
+++ b/website/versioned_docs/version-25.x/ExpectAPI.md
@@ -1081,7 +1081,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 

--- a/website/versioned_docs/version-26.2/ExpectAPI.md
+++ b/website/versioned_docs/version-26.2/ExpectAPI.md
@@ -1081,7 +1081,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 


### PR DESCRIPTION
to make function sign consistent with other functions sign like
`expect.not.stringMatching(string | regexp)`
or
`expect.stringMatching(string | regexp)`

closes #10664
closes #10665
closes #10666
closes #10667
closes #10668