### PR TITLE
more consistent function sign

### DIFF
--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -1044,7 +1044,7 @@ If differences between properties do not help you to understand why a test fails
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
 
-### `.toMatch(regexpOrString)`
+### `.toMatch(regexp | string)`
 
 Use `.toMatch` to check that a string matches a regular expression.
 


### PR DESCRIPTION
to make function sign consistent with other functions sign like
expect.not.stringMatching(string | regexp)
or
expect.stringMatching(string | regexp)
