### PR TITLE
fix: do not mention implied `runInBand` on `detectOpenHandles` warning

### DIFF
--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -273,7 +273,7 @@ class TestRunner {
           chalk.yellow(
             'A worker process has failed to exit gracefully and has been force exited. ' +
               'This is likely caused by tests leaking due to improper teardown. ' +
-              'Try running with --runInBand --detectOpenHandles to find leaks.',
+              'Try running with --detectOpenHandles to find leaks.',
           ),
         );
       }


### PR DESCRIPTION
The documentation says when you use `--detectOpenHandles` `--runInBand` is implied, I'm assuming there is no need to add it to the text then, (I might be wrong).


