### PR TITLE
Change expect.not.objectContaining() to match documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[jest-resolve]` Replace read-pkg-up with escalade package ([#10781](https://github.com/facebook/jest/pull/10781))
 - `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -7,7 +7,6 @@
  */
 
 import {equals, fnNameFor, hasProperty, isA, isUndefined} from './jasmineUtils';
-import {emptyObject} from './utils';
 
 export class AsymmetricMatcher<T> {
   protected sample: T;
@@ -162,31 +161,19 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
       );
     }
 
-    if (this.inverse) {
-      for (const property in this.sample) {
-        if (
-          hasProperty(other, property) &&
-          equals(this.sample[property], other[property]) &&
-          !emptyObject(this.sample[property]) &&
-          !emptyObject(other[property])
-        ) {
-          return false;
-        }
-      }
+    let result = true;
 
-      return true;
-    } else {
-      for (const property in this.sample) {
-        if (
-          !hasProperty(other, property) ||
-          !equals(this.sample[property], other[property])
-        ) {
-          return false;
-        }
+    for (const property in this.sample) {
+      if (
+        !hasProperty(other, property) ||
+        !equals(this.sample[property], other[property])
+      ) {
+        result = false;
+        break;
       }
-
-      return true;
     }
+
+    return this.inverse ? !result : result;
   }
 
   toString() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #10186 by changing `expect.not.objectContaining()` to simply invert the result of `expect.objectContaining()`.

By semver this is a patch-level change, but I agree with [jeysal](https://github.com/facebook/jest/issues/10186#issuecomment-716196974) that it would be prudent to treat this as a breaking change anyway, just in case someone's relying on the previous behavior.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Revised existing tests which asserted undocumented behavior and added several new test cases.
