### PR TITLE
fix: don't mutate the sample in expect.objectContaining()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[expect]` Stop modifying the sample in `expect.objectContaining()` ([#10711](https://github.com/facebook/jest/pull/10711))
+
 ### Chore & Maintenance
 
 - `[jest-cli]` chore: standardize files and folder names ([#10698](https://github.com/facebook/jest/pull/1098))

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -212,9 +212,9 @@ test('ObjectContaining throws for non-objects', () => {
 });
 
 test('ObjectContaining does not mutate the sample', () => {
-  const sample = { foo: { bar: {} } };
+  const sample = {foo: {bar: {}}};
   const sample_json = JSON.stringify(sample);
-  expect({ foo: { bar: {} } }).toEqual(expect.objectContaining(sample));
+  expect({foo: {bar: {}}}).toEqual(expect.objectContaining(sample));
 
   expect(JSON.stringify(sample)).toEqual(sample_json);
 });

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -211,6 +211,14 @@ test('ObjectContaining throws for non-objects', () => {
   jestExpect(() => objectContaining(1337).asymmetricMatch()).toThrow();
 });
 
+test('ObjectContaining does not mutate the sample', () => {
+  const sample = { foo: { bar: {} } };
+  const sample_json = JSON.stringify(sample);
+  expect({ foo: { bar: {} } }).toEqual(expect.objectContaining(sample));
+
+  expect(JSON.stringify(sample)).toEqual(sample_json);
+});
+
 test('ObjectNotContaining matches', () => {
   [
     objectNotContaining({}).asymmetricMatch('jest'),

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -178,18 +178,15 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
       return true;
     } else {
       for (const property in this.sample) {
-        if (
+        const expected =
           typeof this.sample[property] === 'object' &&
           !(this.sample[property] instanceof AsymmetricMatcher)
-        ) {
-          this.sample[property] = objectContaining(
-            this.sample[property] as Record<string, unknown>,
-          );
-        }
+            ? objectContaining(this.sample[property] as Record<string, unknown>)
+            : this.sample[property];
 
         if (
           !hasProperty(other, property) ||
-          !equals(this.sample[property], other[property])
+          !equals(expected, other[property])
         ) {
           return false;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Closes #10689. PR #10508 replaced the sample's properties with asymmetric matchers to facilitate recursion. This PR instead constructs asymmetric matchers each time the base matcher is invoked, avoiding the need to mutate the sample.

## Test plan

Added a test case asserting that the sample is not mutated.