### PR TITLE
fix(expect): `objectContaining` traversing non vanilla Objects

### DIFF
--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -169,6 +169,17 @@ test('ObjectContaining matches', () => {
     objectContaining({first: objectContaining({second: {}})}).asymmetricMatch({
       first: {second: {}},
     }),
+    objectContaining({foo: Buffer.from('foo')}).asymmetricMatch({
+      foo: Buffer.from('foo'),
+      jest: 'jest',
+    }),
+    objectContaining({foo: {bar: [Buffer.from('foo')]}}).asymmetricMatch({
+      foo: {
+        bar: [Buffer.from('foo'), 1],
+        qux: 'qux',
+      },
+      jest: 'jest',
+    }),
   ].forEach(test => {
     jestExpect(test).toEqual(true);
   });

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -178,11 +178,21 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
       return true;
     } else {
       for (const property in this.sample) {
-        const expected =
-          typeof this.sample[property] === 'object' &&
-          !(this.sample[property] instanceof AsymmetricMatcher)
-            ? objectContaining(this.sample[property] as Record<string, unknown>)
-            : this.sample[property];
+        let expected = this.sample[property];
+
+        if (typeof this.sample[property] === 'object') {
+          const samplePropertyPrototype = Object.getPrototypeOf(
+            this.sample[property],
+          );
+          if (
+            samplePropertyPrototype === Object.prototype ||
+            samplePropertyPrototype === Array.prototype
+          ) {
+            expected = objectContaining(
+              this.sample[property] as Record<string, unknown>,
+            );
+          }
+        }
 
         if (
           !hasProperty(other, property) ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->
Attempting to fix the bug found in https://github.com/facebook/jest/issues/10716

## Summary
This change will change `objectContaining` to only recursively step into vanilla sub-objects

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
Added new test cases to cover this behaviour
