### PR TITLE
feat(jest-runner): set exit code to 1 if test logs after teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Features
 
 - `[jest-core]` Add `findRelatedTests` and `nonFlagArgs` in allowed config options for `updateConfigAndRun` in watch plugins ([#10659](https://github.com/facebook/jest/pull/10659))
+- `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-config]` [**BREAKING**] Default to Node testing environment instead of browser (JSDOM) ([#9874](https://github.com/facebook/jest/pull/9874))
+- `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
 
 ### Fixes
 
@@ -25,7 +26,6 @@
 ### Features
 
 - `[jest-core]` Add `findRelatedTests` and `nonFlagArgs` in allowed config options for `updateConfigAndRun` in watch plugins ([#10659](https://github.com/facebook/jest/pull/10659))
-- `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
 
 ### Fixes
 

--- a/e2e/__tests__/consoleAfterTeardown.test.ts
+++ b/e2e/__tests__/consoleAfterTeardown.test.ts
@@ -13,7 +13,7 @@ test('console printing', () => {
   const {stderr, exitCode} = runJest('console-after-teardown');
   const {rest} = extractSummary(stderr);
 
-  expect(exitCode).toBe(0);
+  expect(exitCode).toBe(1);
 
   const withoutTrace = rest.split('\n').slice(0, -3).join('\n');
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -61,8 +61,7 @@ function freezeConsole(
     );
 
     process.stderr.write('\n' + formattedError + '\n');
-    // TODO: set exit code in Jest 25
-    // process.exitCode = 1;
+    process.exitCode = 1;
   };
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Resolve https://github.com/facebook/jest/issues/10715
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
