### PR TITLE
chore: remove custom babel plugin for stripping namespaces

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,13 +17,22 @@ module.exports = {
   overrides: [
     {
       plugins: [
-        'babel-plugin-typescript-strip-namespaces',
         'babel-plugin-replace-ts-export-assignment',
         require.resolve(
           './scripts/babel-plugin-jest-replace-ts-require-assignment.js',
         ),
       ],
-      presets: ['@babel/preset-typescript'],
+      presets: [
+        [
+          '@babel/preset-typescript',
+          {
+            // will be the default in Babel 8, so let's just turn it on now
+            allowDeclareFields: true,
+            // will be default in the future, but we don't want to use it
+            allowNamespaces: false,
+          },
+        ],
+      ],
       test: /\.tsx?$/,
     },
     // we want this file to keep `import()`, so exclude the transform for it

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "ansi-styles": "^4.2.0",
     "babel-eslint": "^10.0.3",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
-    "babel-plugin-typescript-strip-namespaces": "^1.1.1",
     "camelcase": "^6.0.0",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.0",

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -421,7 +421,7 @@ expect.extractExpectedAssertionsErrors = extractExpectedAssertionsErrors;
 
 const expectExport = expect as Expect;
 
-namespace expectExport {
+declare namespace expectExport {
   export type MatcherState = JestMatcherState;
   export interface Matchers<R> extends MatcherInterface<R> {}
 }

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -104,7 +104,7 @@ type Watcher = {
 type WorkerInterface = {worker: typeof worker; getSha1: typeof getSha1};
 
 // TODO: Ditch namespace when this module exports ESM
-namespace HasteMap {
+declare namespace HasteMap {
   export type ModuleMap = HasteModuleMap;
   export type SerializableModuleMap = HasteSerializableModuleMap;
   export type FS = HasteFS;

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -220,7 +220,7 @@ const addSnapshotData = (
   return results;
 };
 
-namespace jasmine2 {
+declare namespace jasmine2 {
   export type Jasmine = JestJasmine;
 }
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -9,7 +9,7 @@
 
 type Global = NodeJS.Global; // | Window – add once TS improves typings;
 
-namespace JestMock {
+declare namespace JestMock {
   export type ModuleMocker = ModuleMockerClass;
   export type MockFunctionMetadataType =
     | 'object'

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -11,7 +11,7 @@ import type {FS as HasteFS} from 'jest-haste-map';
 import type {ResolveModuleConfig, ResolverType} from 'jest-resolve';
 import {SnapshotResolver, isSnapshotPath} from 'jest-snapshot';
 
-namespace DependencyResolver {
+declare namespace DependencyResolver {
   export type ResolvedModule = {
     file: Config.Path;
     dependencies: Array<Config.Path>;

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -34,7 +34,7 @@ type FindNodeModuleConfig = {
 // TODO: replace with a Map in Jest 26
 type BooleanObject = Record<string, boolean>;
 
-namespace Resolver {
+declare namespace Resolver {
   export type ResolveModuleConfig = {
     skipNodeResolution?: boolean;
     paths?: Array<Config.Path>;

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -34,7 +34,7 @@ interface WorkerInterface extends Worker {
   worker: typeof worker;
 }
 
-namespace TestRunner {
+declare namespace TestRunner {
   export type Test = JestTest;
   export type OnTestFailure = JestOnTestFailure;
   export type OnTestStart = JestOnTestStart;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -107,7 +107,7 @@ const fromEntries: typeof Object.fromEntries =
     }, {});
   };
 
-namespace Runtime {
+declare namespace Runtime {
   export type Context = JestContext;
   // ditch this export when moving to esm - for now we need it for to avoid faulty type elision
   export type RuntimeType = Runtime;

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -560,7 +560,7 @@ const JestSnapshot = {
   utils,
 };
 
-namespace JestSnapshot {
+declare namespace JestSnapshot {
   export type SnapshotResolver = JestSnapshotResolver;
   export type SnapshotStateType = SnapshotState;
 }

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -530,7 +530,7 @@ prettyFormat.plugins = {
   ReactTestComponent,
 };
 
-namespace prettyFormat {
+declare namespace prettyFormat {
   export type Colors = PrettyFormat.Colors;
   export type Config = PrettyFormat.Config;
   export type Options = PrettyFormat.Options;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4839,15 +4839,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-typescript-strip-namespaces@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "babel-plugin-typescript-strip-namespaces@npm:1.1.1"
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: f0e59ea0d37bcf98cc7891db8f6089b1a1f2607e43ddc6a8c6b19ed782f1277f8f46998267e8ab636c12f8d0ed70194fb0a84ab610f4df463e1712e493002ee9
-  languageName: node
-  linkType: hard
-
 "babel-preset-current-node-syntax@npm:^0.1.3":
   version: 0.1.4
   resolution: "babel-preset-current-node-syntax@npm:0.1.4"
@@ -17152,7 +17143,6 @@ fsevents@^1.2.7:
     ansi-styles: ^4.2.0
     babel-eslint: ^10.0.3
     babel-plugin-replace-ts-export-assignment: ^0.0.2
-    babel-plugin-typescript-strip-namespaces: ^1.1.1
     camelcase: ^6.0.0
     chalk: ^4.0.0
     chokidar: ^3.3.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://babeljs.io/docs/en/babel-plugin-transform-typescript#impartial-namespace-support

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I tested locally by checking in `build/` and there is zero diff in the output, in neither `d.ts` files or `js` files. Beyond that, green CI should verify

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
