### PR TITLE
feat: tell Babel about Jest's ESM support

### DIFF
--- a/e2e/__tests__/__snapshots__/transform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:180:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:201:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -40,6 +40,14 @@ interface BabelJestTransformOptions extends TransformOptions {
   sourceMaps: 'both';
 }
 
+// https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49267
+declare module '@babel/core' {
+  interface TransformCaller {
+    supportsExportNamespaceFrom?: boolean;
+    supportsTopLevelAwait?: boolean;
+  }
+}
+
 const createTransformer = (
   userOptions?: TransformOptions | null,
 ): BabelJestTransformer => {
@@ -49,7 +57,9 @@ const createTransformer = (
     caller: {
       name: 'babel-jest',
       supportsDynamicImport: false,
+      supportsExportNamespaceFrom: false,
       supportsStaticESM: false,
+      supportsTopLevelAwait: false,
       ...inputOptions.caller,
     },
     compact: false,
@@ -72,9 +82,15 @@ const createTransformer = (
         supportsDynamicImport:
           transformOptions?.supportsDynamicImport ??
           options.caller.supportsDynamicImport,
+        supportsExportNamespaceFrom:
+          transformOptions?.supportsExportNamespaceFrom ??
+          options.caller.supportsExportNamespaceFrom,
         supportsStaticESM:
           transformOptions?.supportsStaticESM ??
           options.caller.supportsStaticESM,
+        supportsTopLevelAwait:
+          transformOptions?.supportsTopLevelAwait ??
+          options.caller.supportsTopLevelAwait,
       },
       filename,
     });

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -34,6 +34,7 @@
     "jest-snapshot": "^26.6.1",
     "jest-util": "^26.6.1",
     "jest-validate": "^26.6.1",
+    "semver": "^7.3.2",
     "slash": "^3.0.0",
     "strip-bom": "^4.0.0",
     "yargs": "^15.4.1"
@@ -44,6 +45,7 @@
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.2",
     "@types/node": "^14.0.27",
+    "@types/semver": "^7.3.4",
     "execa": "^4.0.0",
     "jest-environment-node": "^26.6.1",
     "jest-snapshot-serializer-raw": "^1.1.0"

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -24,7 +24,9 @@ export type Options = ShouldInstrumentOptions &
     isCoreModule: boolean;
     isInternalModule: boolean;
     supportsDynamicImport: boolean;
+    supportsExportNamespaceFrom: boolean;
     supportsStaticESM: boolean;
+    supportsTopLevelAwait: boolean;
   }>;
 
 // This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
@@ -41,9 +43,11 @@ export type TransformResult = TransformTypes.TransformResult;
 
 export interface TransformOptions {
   instrument: boolean;
-  // names are copied from babel
+  // names are copied from babel: https://babeljs.io/docs/en/options#caller
   supportsDynamicImport?: boolean;
+  supportsExportNamespaceFrom?: boolean;
   supportsStaticESM?: boolean;
+  supportsTopLevelAwait?: boolean;
 }
 
 // TODO: For Jest 26 we should combine these into one options shape

--- a/yarn.lock
+++ b/yarn.lock
@@ -3747,7 +3747,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7.1.0":
+"@types/semver@npm:^7.1.0, @types/semver@npm:^7.3.4":
   version: 7.3.4
   resolution: "@types/semver@npm:7.3.4"
   checksum: 7e8588aa55ecb344eda6954674b83a3c568d97d478e70e4617bd3ab22902590ac416ccf2cea48b58fb2f0fbd80f9ad1896332c9b3c3189ffd24e4350ff22094a
@@ -11957,6 +11957,7 @@ fsevents@^1.2.7:
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.2
     "@types/node": ^14.0.27
+    "@types/semver": ^7.3.4
     "@types/yargs": ^15.0.0
     chalk: ^4.0.0
     cjs-module-lexer: ^0.4.2
@@ -11976,6 +11977,7 @@ fsevents@^1.2.7:
     jest-snapshot-serializer-raw: ^1.1.0
     jest-util: ^26.6.1
     jest-validate: ^26.6.1
+    semver: ^7.3.2
     slash: ^3.0.0
     strip-bom: ^4.0.0
     yargs: ^15.4.1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is mostly to have `@babel/preset-env` leave some constructs alone.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI - it's just passing stuff through to Babel.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
