### PR TITLE
Don't throw an error if mock dependency can't be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-resolve-dependencies]` Continue dependency resolution if mock dependency can't be found ([#10779](https://github.com/facebook/jest/pull/10779))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -149,3 +149,17 @@ test('resolves dependencies correctly when dependency resolution fails', () => {
 
   expect(resolved).toEqual([]);
 });
+
+test('resolves dependencies correctly when mock dependency resolution fails', () => {
+  jest.spyOn(runtimeContextResolver, 'getMockModule').mockImplementation(() => {
+    throw new Error('getMockModule has failed');
+  });
+
+  const resolved = dependencyResolver.resolve(
+    path.resolve(__dirname, '__fixtures__', 'file.test.js'),
+  );
+
+  expect(resolved).toEqual([
+    expect.stringContaining(path.join('__tests__', '__fixtures__', 'file.js')),
+  ]);
+});

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -75,10 +75,14 @@ class DependencyResolver {
 
       // If we resolve a dependency, then look for a mock dependency
       // of the same name in that dependency's directory.
-      resolvedMockDependency = this._resolver.getMockModule(
-        resolvedDependency,
-        path.basename(dependency),
-      );
+      try {
+        resolvedMockDependency = this._resolver.getMockModule(
+          resolvedDependency,
+          path.basename(dependency),
+        );
+      } catch {
+        // leave resolvedMockDependency as undefined if nothing can be found
+      }
 
       if (resolvedMockDependency) {
         const dependencyMockDir = path.resolve(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This fixes https://github.com/facebook/jest/issues/10771, a regression caused by https://github.com/facebook/jest/pull/10713

I've basically wrapped the `getMockModule` call with a `try/catch`, similarly to how it's done in the bit above.

## Test plan

Added a unit test to make sure dependency resolution continues if a mock dependency can't be found.