### PR TITLE
fix(jest-circus): add fast fail behaviour for beforeEach hooks

### DIFF
--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -1,6 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`beforeAll is exectued correctly 1`] = `
+exports[`a failing beforeAll should skip all beforeEach and afterEach hooks 1`] = `
+start_describe_definition: test suite beforeAll
+add_hook: beforeAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: test 1
+finish_describe_definition: test suite beforeAll
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+run_describe_start: test suite beforeAll
+hook_start: beforeAll
+> beforeAll 1 runs
+hook_failure: beforeAll
+test_start: test 1
+test_fn_start: test 1
+test_done: test 1
+run_describe_finish: test suite beforeAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0
+`;
+
+exports[`a failing beforeAll should skip any nested describe blocks 1`] = `
+start_describe_definition: test suite beforeAll
+add_hook: beforeAll
+start_describe_definition: test suite nested
+add_hook: beforeAll
+add_test: test 1
+finish_describe_definition: test suite nested
+add_test: test 2
+finish_describe_definition: test suite beforeAll
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+run_describe_start: test suite beforeAll
+hook_start: beforeAll
+> beforeAll 1 runs
+hook_failure: beforeAll
+run_describe_start: test suite nested
+test_start: test 1
+test_fn_start: test 1
+test_done: test 1
+run_describe_finish: test suite nested
+test_start: test 2
+test_fn_start: test 2
+test_done: test 2
+run_describe_finish: test suite beforeAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0
+`;
+
+exports[`a failing beforeAll should skip other beforeAll hooks 1`] = `
+start_describe_definition: test suite beforeAll
+add_hook: beforeAll
+add_hook: beforeAll
+add_test: test 1
+finish_describe_definition: test suite beforeAll
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+run_describe_start: test suite beforeAll
+hook_start: beforeAll
+> beforeAll 1 runs
+hook_failure: beforeAll
+test_start: test 1
+test_fn_start: test 1
+test_done: test 1
+run_describe_finish: test suite beforeAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0
+`;
+
+exports[`beforeAll is executed correctly 1`] = `
 start_describe_definition: describe 1
 add_hook: beforeAll
 add_test: test 1

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -13,8 +13,6 @@ run_describe_start: test suite beforeAll
 hook_start: beforeAll
 > beforeAll 1 runs
 hook_failure: beforeAll
-test_start: test 1
-test_done: test 1
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish
@@ -37,12 +35,6 @@ run_describe_start: test suite beforeAll
 hook_start: beforeAll
 > beforeAll 1 runs
 hook_failure: beforeAll
-run_describe_start: test suite nested
-test_start: test 1
-test_done: test 1
-run_describe_finish: test suite nested
-test_start: test 2
-test_done: test 2
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish
@@ -62,8 +54,6 @@ run_describe_start: test suite beforeAll
 hook_start: beforeAll
 > beforeAll 1 runs
 hook_failure: beforeAll
-test_start: test 1
-test_done: test 1
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -61,6 +61,34 @@ run_finish
 unhandledErrors: 0
 `;
 
+exports[`all afterEach hooks should still be called even if an a beforeEach hook fails and an afterEach hook fails 1`] = `
+start_describe_definition: test suite beforeAll
+add_hook: beforeEach
+add_hook: afterEach
+add_hook: afterEach
+add_test: test 1
+finish_describe_definition: test suite beforeAll
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+run_describe_start: test suite beforeAll
+test_start: test 1
+hook_start: beforeEach
+> beforeEach 1 runs
+hook_failure: beforeEach
+hook_start: afterEach
+> afterEach 1 runs
+hook_failure: afterEach
+hook_start: afterEach
+> afterEach 2 runs
+hook_success: afterEach
+test_done: test 1
+run_describe_finish: test suite beforeAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0
+`;
+
 exports[`beforeAll is executed correctly 1`] = `
 start_describe_definition: describe 1
 add_hook: beforeAll

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -14,7 +14,6 @@ hook_start: beforeAll
 > beforeAll 1 runs
 hook_failure: beforeAll
 test_start: test 1
-test_fn_start: test 1
 test_done: test 1
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
@@ -40,11 +39,9 @@ hook_start: beforeAll
 hook_failure: beforeAll
 run_describe_start: test suite nested
 test_start: test 1
-test_fn_start: test 1
 test_done: test 1
 run_describe_finish: test suite nested
 test_start: test 2
-test_fn_start: test 2
 test_done: test 2
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
@@ -66,7 +63,6 @@ hook_start: beforeAll
 > beforeAll 1 runs
 hook_failure: beforeAll
 test_start: test 1
-test_fn_start: test 1
 test_done: test 1
 run_describe_finish: test suite beforeAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
@@ -193,7 +189,6 @@ test_start: 2nd describe test
 hook_start: beforeEach
 > 2nd describe beforeEach that throws
 hook_failure: beforeEach
-test_fn_start: 2nd describe test
 test_done: 2nd describe test
 run_describe_finish: 2nd describe
 run_describe_finish: ROOT_DESCRIBE_BLOCK

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -56,7 +56,7 @@ test('multiple before each hooks in one describe are executed in the right order
   expect(wrap(stdout)).toMatchSnapshot();
 });
 
-test('beforeAll is exectued correctly', () => {
+test('beforeAll is executed correctly', () => {
   const {stdout} = runTest(`
     describe('describe 1', () => {
       beforeAll(() => console.log('> beforeAll 1'));
@@ -68,6 +68,87 @@ test('beforeAll is exectued correctly', () => {
         test('test 3', () => console.log('> test 3'));
       });
     });
+  `);
+
+  expect(wrap(stdout)).toMatchSnapshot();
+});
+
+test('a failing beforeAll should skip other beforeAll hooks', () => {
+  const {stdout} = runTest(`
+    describe('test suite beforeAll', () => {
+
+    beforeAll(() => {
+        console.log('> beforeAll 1 runs')
+        throw new Error('> beforeAll 1 error');
+    });
+
+    beforeAll(() => {
+        console.log('> beforeAll 2 runs')
+    });
+
+    test('test 1', () => {
+        console.log('> the test ran')
+    });
+
+});
+  `);
+
+  expect(wrap(stdout)).toMatchSnapshot();
+});
+
+test('a failing beforeAll should skip all beforeEach and afterEach hooks', () => {
+  const {stdout} = runTest(`
+    describe('test suite beforeAll', () => {
+
+    beforeAll(() => {
+        console.log('> beforeAll 1 runs')
+        throw new Error('> beforeAll 1 error');
+    });
+
+    beforeEach(() => {
+        console.log('> beforeEach 1 runs')
+    });
+
+    afterEach(() => {
+        console.log('> afterEach 1 runs')
+    });
+
+    test('test 1', () => {
+        console.log('> the test ran')
+    });
+
+});
+  `);
+
+  expect(wrap(stdout)).toMatchSnapshot();
+});
+
+test('a failing beforeAll should skip any nested describe blocks', () => {
+  const {stdout} = runTest(`
+    describe('test suite beforeAll', () => {
+
+    beforeAll(() => {
+        console.log('> beforeAll 1 runs')
+        throw new Error('beforeAll 1 error');
+    });
+
+    describe('test suite nested', () => {
+
+      beforeAll(() => {
+          console.log('> beforeAll 2 runs')
+          throw new Error('beforeAll 2 error');
+      });
+
+      test('test 1', () => {
+          console.log('> test 1 ran')
+      });
+    })
+
+    test('test 2', () => {
+        console.log('> test 2 ran')
+    });
+
+});
   `);
 
   expect(wrap(stdout)).toMatchSnapshot();

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -123,6 +123,34 @@ test('a failing beforeAll should skip all beforeEach and afterEach hooks', () =>
   expect(wrap(stdout)).toMatchSnapshot();
 });
 
+test('all afterEach hooks should still be called even if an a beforeEach hook fails and an afterEach hook fails', () => {
+  const {stdout} = runTest(`
+    describe('test suite beforeAll', () => {
+
+    beforeEach(() => {
+        console.log('> beforeEach 1 runs')
+        throw new Error('> beforeEach 1 error');
+    });
+
+    afterEach(() => {
+        console.log('> afterEach 1 runs')
+        throw new Error('> afterEach 1 error');
+    });
+
+    afterEach(() => {
+        console.log('> afterEach 2 runs')
+    });
+
+    test('test 1', () => {
+        console.log('> the test ran')
+    });
+
+});
+  `);
+
+  expect(wrap(stdout)).toMatchSnapshot();
+});
+
 test('a failing beforeAll should skip any nested describe blocks', () => {
   const {stdout} = runTest(`
     describe('test suite beforeAll', () => {

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -157,6 +157,7 @@ const eventHandler: Circus.EventHandler = (
       if (type === 'beforeAll') {
         invariant(describeBlock, 'always present for `*All` hooks');
         addErrorToEachTestUnderDescribe(describeBlock, error, asyncError);
+        describeBlock.errors.push([error, asyncError]);
       } else if (type === 'afterAll') {
         // Attaching `afterAll` errors to each test makes execution flow
         // too complicated, so we'll consider them to be global.

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -12,7 +12,7 @@ import {
 } from './globalErrorHandlers';
 import {TEST_TIMEOUT_SYMBOL} from './types';
 import {
-  addErrorToEachTestUnderDescribe,
+  addErrorToEachChildUnderDescribe,
   describeBlockHasTests,
   getTestDuration,
   invariant,
@@ -156,7 +156,7 @@ const eventHandler: Circus.EventHandler = (
 
       if (type === 'beforeAll') {
         invariant(describeBlock, 'always present for `*All` hooks');
-        addErrorToEachTestUnderDescribe(describeBlock, error, asyncError);
+        addErrorToEachChildUnderDescribe(describeBlock, error, asyncError);
         describeBlock.errors.push([error, asyncError]);
       } else if (type === 'afterAll') {
         // Attaching `afterAll` errors to each test makes execution flow

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -124,7 +124,7 @@ const _runTest = async (test: Circus.TestEntry): Promise<void> => {
 
   await _callCircusTest(test, testContext);
 
-  if (!test.parent.errors.length) {
+  if (test.parent.errors.length === 0) {
     // skip running afterEach hooks if there is a describe block setup failure.
     // If there is a failure then no beforeEach hooks will run either
     for (const hook of afterEach) {

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -68,7 +68,7 @@ const _runTestsForDescribeBlock = async (
     }
   }
 
-  if (!describeBlock.errors.length) {
+  if (describeBlock.errors.length === 0) {
     // skip test retry if any beforeAll setup fails
     // Re-run failed tests n-times if configured
     for (const test of deferredRetryTests) {

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -35,7 +35,7 @@ const _runTestsForDescribeBlock = async (
   const {beforeAll, afterAll} = getAllHooksForDescribe(describeBlock);
 
   for (const hook of beforeAll) {
-    if (describeBlock.errors.length) {
+    if (describeBlock.errors.length > 0) {
       // discontinue running beforeAll hooks on failure
       break;
     }

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -34,6 +34,7 @@ export const makeDescribe = (
   return {
     type: 'describeBlock', // eslint-disable-next-line sort-keys
     children: [],
+    errors: [],
     hooks: [],
     mode: _mode,
     name: convertDescriptorToString(name),
@@ -405,10 +406,8 @@ export const addErrorToEachTestUnderDescribe = (
       case 'describeBlock':
         addErrorToEachTestUnderDescribe(child, error, asyncError);
         break;
-      case 'test':
-        child.errors.push([error, asyncError]);
-        break;
     }
+    child.errors.push([error, asyncError]);
   }
 };
 

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -402,10 +402,8 @@ export const addErrorToEachTestUnderDescribe = (
   asyncError: Circus.Exception,
 ): void => {
   for (const child of describeBlock.children) {
-    switch (child.type) {
-      case 'describeBlock':
-        addErrorToEachTestUnderDescribe(child, error, asyncError);
-        break;
+    if (child.type === 'describeBlock') {
+      addErrorToEachTestUnderDescribe(child, error, asyncError);
     }
     child.errors.push([error, asyncError]);
   }

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -396,14 +396,19 @@ const _getError = (
 const getErrorStack = (error: Error): string =>
   typeof error.stack === 'string' ? error.stack : error.message;
 
-export const addErrorToEachTestUnderDescribe = (
+export const addErrorToEachChildUnderDescribe = (
   describeBlock: Circus.DescribeBlock,
   error: Circus.Exception,
   asyncError: Circus.Exception,
 ): void => {
   for (const child of describeBlock.children) {
     if (child.type === 'describeBlock') {
-      addErrorToEachTestUnderDescribe(child, error, asyncError);
+      addErrorToEachChildUnderDescribe(child, error, asyncError);
+    } else {
+      if (!child.status) {
+        // mark test as done for reporting
+        child.status = 'done';
+      }
     }
     child.errors.push([error, asyncError]);
   }

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -220,6 +220,7 @@ export type DescribeBlock = {
   hooks: Array<Hook>;
   mode: BlockMode;
   name: BlockName;
+  errors: Array<TestError>;
   parent?: DescribeBlock;
   /** @deprecated Please get from `children` array instead */
   tests: Array<TestEntry>;


### PR DESCRIPTION
- add a new errors object reference to describe blocks for conditionally running `beforeAll` and `afterEach` hooks depending on the describe block setup status.

- skip test retry on failed `beforeAll` setup

- add errors to all child describe blocks and tests when a parent describe block hook throws an error.

- add snapshot tests to show execution behaviour when a `beforeAll` hook fails.

- fix typo in `packages/jest-circus/src/__tests__/hooks.test.ts`, exectued -> executed

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
A failing `beforeAll` hook will mark all child tests for failure. Currently when a `beforeAll` hook fails, the sibling and child `beforeAll` hooks will still run and so will the `afterEach` hooks of the child tests.

## Test plan
I added a few snapshot tests demonstrating the expected flow.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Issues: #10774 