### PR TITLE
chore: add name to root project

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
+  "name": "@jest/monorepo",
   "private": true,
+  "version": "0.0.0",
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1862,6 +1862,98 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jest/monorepo@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@jest/monorepo@workspace:."
+  dependencies:
+    "@babel/core": ^7.3.4
+    "@babel/plugin-proposal-class-properties": ^7.3.4
+    "@babel/plugin-proposal-dynamic-import": ^7.8.3
+    "@babel/plugin-syntax-dynamic-import": ^7.8.3
+    "@babel/plugin-transform-modules-commonjs": ^7.1.0
+    "@babel/plugin-transform-strict-mode": ^7.0.0
+    "@babel/preset-env": ^7.1.0
+    "@babel/preset-react": ^7.0.0
+    "@babel/preset-typescript": ^7.0.0
+    "@babel/register": ^7.0.0
+    "@jest/globals": "workspace:*"
+    "@jest/test-utils": "workspace:*"
+    "@types/babel__core": ^7.0.0
+    "@types/babel__generator": ^7.0.0
+    "@types/babel__template": ^7.0.0
+    "@types/dedent": 0.7.0
+    "@types/jest": ^26.0.15
+    "@types/node": ~10.14.0
+    "@types/which": ^1.3.2
+    "@typescript-eslint/eslint-plugin": ^4.1.0
+    "@typescript-eslint/parser": ^4.1.0
+    ansi-regex: ^5.0.0
+    ansi-styles: ^4.2.0
+    babel-eslint: ^10.0.3
+    babel-plugin-replace-ts-export-assignment: ^0.0.2
+    camelcase: ^6.0.0
+    chalk: ^4.0.0
+    chokidar: ^3.3.0
+    codecov: ^3.0.0
+    debug: ^4.0.1
+    dedent: ^0.7.0
+    eslint: ^7.7.0
+    eslint-config-fb-strict: ^26.0.0
+    eslint-config-prettier: ^6.1.0
+    eslint-plugin-babel: ^5.1.0
+    eslint-plugin-eslint-comments: ^3.1.2
+    eslint-plugin-flowtype: ^5.2.0
+    eslint-plugin-import: ^2.6.0
+    eslint-plugin-jest: ^24.0.0
+    eslint-plugin-jsx-a11y: ^6.0.2
+    eslint-plugin-local: ^1.0.0
+    eslint-plugin-markdown: ^1.0.0
+    eslint-plugin-prettier: ^3.0.1
+    eslint-plugin-react: ^7.1.0
+    execa: ^4.0.0
+    fast-check: ^2.0.0
+    find-process: ^1.4.1
+    glob: ^7.1.1
+    globby: ^11.0.0
+    graceful-fs: ^4.2.4
+    isbinaryfile: ^4.0.0
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-reports: ^3.0.0
+    jest: "workspace:*"
+    jest-changed-files: "workspace:*"
+    jest-junit: ^12.0.0
+    jest-mock: "workspace:*"
+    jest-runner-tsd: ^1.1.0
+    jest-silent-reporter: ^0.2.1
+    jest-snapshot: "workspace:*"
+    jest-snapshot-serializer-raw: ^1.1.0
+    jest-watch-typeahead: ^0.6.0
+    jquery: ^3.2.1
+    lerna: ^3.20.2
+    micromatch: ^4.0.2
+    mlh-tsd: ^0.14.1
+    mock-fs: ^4.4.1
+    prettier: ^2.1.1
+    progress: ^2.0.0
+    promise: ^8.0.2
+    read-pkg: ^5.2.0
+    resolve: ^1.15.0
+    rimraf: ^3.0.0
+    semver: ^7.3.2
+    slash: ^3.0.0
+    stealthy-require: ^1.1.1
+    string-length: ^4.0.1
+    strip-ansi: ^6.0.0
+    tempy: ^1.0.0
+    throat: ^5.0.0
+    ts-node: ^9.0.0
+    type-fest: ^0.16.0
+    typescript: ^4.0.2
+    which: ^2.0.1
+  languageName: unknown
+  linkType: soft
+
 "@jest/reporters@^26.6.2, @jest/reporters@workspace:packages/jest-reporters":
   version: 0.0.0-use.local
   resolution: "@jest/reporters@workspace:packages/jest-reporters"
@@ -17218,98 +17310,6 @@ fsevents@^1.2.7:
   checksum: a84877f6c9027bdc3c501b0761603f0171e032581897308030b4314486ccd5ef65571239d62f23ee62a4a6cada948e2a9a0446da30ed3566498c1eee474f23e0
   languageName: node
   linkType: hard
-
-"root-workspace-0b6124@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "root-workspace-0b6124@workspace:."
-  dependencies:
-    "@babel/core": ^7.3.4
-    "@babel/plugin-proposal-class-properties": ^7.3.4
-    "@babel/plugin-proposal-dynamic-import": ^7.8.3
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
-    "@babel/plugin-transform-modules-commonjs": ^7.1.0
-    "@babel/plugin-transform-strict-mode": ^7.0.0
-    "@babel/preset-env": ^7.1.0
-    "@babel/preset-react": ^7.0.0
-    "@babel/preset-typescript": ^7.0.0
-    "@babel/register": ^7.0.0
-    "@jest/globals": "workspace:*"
-    "@jest/test-utils": "workspace:*"
-    "@types/babel__core": ^7.0.0
-    "@types/babel__generator": ^7.0.0
-    "@types/babel__template": ^7.0.0
-    "@types/dedent": 0.7.0
-    "@types/jest": ^26.0.15
-    "@types/node": ~10.14.0
-    "@types/which": ^1.3.2
-    "@typescript-eslint/eslint-plugin": ^4.1.0
-    "@typescript-eslint/parser": ^4.1.0
-    ansi-regex: ^5.0.0
-    ansi-styles: ^4.2.0
-    babel-eslint: ^10.0.3
-    babel-plugin-replace-ts-export-assignment: ^0.0.2
-    camelcase: ^6.0.0
-    chalk: ^4.0.0
-    chokidar: ^3.3.0
-    codecov: ^3.0.0
-    debug: ^4.0.1
-    dedent: ^0.7.0
-    eslint: ^7.7.0
-    eslint-config-fb-strict: ^26.0.0
-    eslint-config-prettier: ^6.1.0
-    eslint-plugin-babel: ^5.1.0
-    eslint-plugin-eslint-comments: ^3.1.2
-    eslint-plugin-flowtype: ^5.2.0
-    eslint-plugin-import: ^2.6.0
-    eslint-plugin-jest: ^24.0.0
-    eslint-plugin-jsx-a11y: ^6.0.2
-    eslint-plugin-local: ^1.0.0
-    eslint-plugin-markdown: ^1.0.0
-    eslint-plugin-prettier: ^3.0.1
-    eslint-plugin-react: ^7.1.0
-    execa: ^4.0.0
-    fast-check: ^2.0.0
-    find-process: ^1.4.1
-    glob: ^7.1.1
-    globby: ^11.0.0
-    graceful-fs: ^4.2.4
-    isbinaryfile: ^4.0.0
-    istanbul-lib-coverage: ^3.0.0
-    istanbul-lib-report: ^3.0.0
-    istanbul-reports: ^3.0.0
-    jest: "workspace:*"
-    jest-changed-files: "workspace:*"
-    jest-junit: ^12.0.0
-    jest-mock: "workspace:*"
-    jest-runner-tsd: ^1.1.0
-    jest-silent-reporter: ^0.2.1
-    jest-snapshot: "workspace:*"
-    jest-snapshot-serializer-raw: ^1.1.0
-    jest-watch-typeahead: ^0.6.0
-    jquery: ^3.2.1
-    lerna: ^3.20.2
-    micromatch: ^4.0.2
-    mlh-tsd: ^0.14.1
-    mock-fs: ^4.4.1
-    prettier: ^2.1.1
-    progress: ^2.0.0
-    promise: ^8.0.2
-    read-pkg: ^5.2.0
-    resolve: ^1.15.0
-    rimraf: ^3.0.0
-    semver: ^7.3.2
-    slash: ^3.0.0
-    stealthy-require: ^1.1.1
-    string-length: ^4.0.1
-    strip-ansi: ^6.0.0
-    tempy: ^1.0.0
-    throat: ^5.0.0
-    ts-node: ^9.0.0
-    type-fest: ^0.16.0
-    typescript: ^4.0.2
-    which: ^2.0.1
-  languageName: unknown
-  linkType: soft
 
 "rst-selector-parser@npm:^2.2.3":
   version: 2.2.3


### PR DESCRIPTION
- allows use of the `yarn workspace` command to target and run scripts defined in the root workspace

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Having a well defined name allows project tools to target the root workspace specifically. For example, the `yarn workspace` command and run a project build script from another workspace.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
