### PR TITLE
fix: add `watchAll` to Valid config

### DIFF
--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -128,6 +128,7 @@ const initialOptions: Config.InitialOptions = {
   useStderr: false,
   verbose: false,
   watch: false,
+  watchAll: false,
   watchPathIgnorePatterns: ['<rootDir>/e2e/'],
   watchPlugins: [
     'path/to/yourWatchPlugin',


### PR DESCRIPTION
add `watchAll` to valid config to avoid validation warning (Unknown option):

```● Validation Warning:

  Unknown option "watchAll" with value true was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```