### PR TITLE
Support default exports for runners

### DIFF
--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -193,7 +193,11 @@ export default class TestScheduler {
     contexts.forEach(context => {
       const {config} = context;
       if (!testRunners[config.runner]) {
-        const Runner: typeof TestRunner = require(config.runner);
+        let Runner: typeof TestRunner = require(config.runner);
+        if (Runner.default) {
+          Runner = Runner.default;
+        }
+
         const runner = new Runner(this._globalConfig, {
           changedFiles: this._context?.changedFiles,
           sourcesRelatedToTestsInChangedFiles: this._context


### PR DESCRIPTION
## Summary

When creating new runners I noticed I was unable to use some typescript configurations because jest wasn't looking for default exports in TestScheduler. This is a quick fix to allow for this.

## Test plan

Relevant tests pass locally. HG tests I'm looking at CI on this PR to see.
