### PR TITLE
Support default exports for runners

### DIFF
--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -193,7 +193,7 @@ export default class TestScheduler {
     contexts.forEach(context => {
       const {config} = context;
       if (!testRunners[config.runner]) {
-        const Runner: typeof TestRunner = require(config.runner);
+        let Runner: typeof TestRunner = require(config.runner).default || require(config.runner);
         const runner = new Runner(this._globalConfig, {
           changedFiles: this._context?.changedFiles,
           sourcesRelatedToTestsInChangedFiles: this._context

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -193,7 +193,8 @@ export default class TestScheduler {
     contexts.forEach(context => {
       const {config} = context;
       if (!testRunners[config.runner]) {
-        const Runner: typeof TestRunner = require(config.runner).default || require(config.runner);
+        const Runner: typeof TestRunner =
+          require(config.runner).default || require(config.runner);
         const runner = new Runner(this._globalConfig, {
           changedFiles: this._context?.changedFiles,
           sourcesRelatedToTestsInChangedFiles: this._context

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -193,7 +193,7 @@ export default class TestScheduler {
     contexts.forEach(context => {
       const {config} = context;
       if (!testRunners[config.runner]) {
-        let Runner: typeof TestRunner = require(config.runner).default || require(config.runner);
+        const Runner: typeof TestRunner = require(config.runner).default || require(config.runner);
         const runner = new Runner(this._globalConfig, {
           changedFiles: this._context?.changedFiles,
           sourcesRelatedToTestsInChangedFiles: this._context


### PR DESCRIPTION
## Summary

When writing a new runner recently I noticed I couldn't use some TypeScript/bundler configurations because Jest was never looking for default exports. This is a small change which will allow for that.

## Test plan

Tests pass locally apart from some irrelevant snapshot tests and hg tests.
