### PR TITLE
chore: skip circus-only tests when using jasmine

### DIFF
--- a/e2e/__tests__/circusConcurrentEach.test.ts
+++ b/e2e/__tests__/circusConcurrentEach.test.ts
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import {skipSuiteOnJasmine} from '@jest/test-utils';
 import {json as runWithJson} from '../runJest';
 
+skipSuiteOnJasmine();
+
 it('works with concurrent.each', () => {
-  const {json} = runWithJson('circus-concurrent', [
-    'concurrent-each.test.js',
-    '--testRunner=jest-circus/runner',
-  ]);
+  const {json} = runWithJson('circus-concurrent', ['concurrent-each.test.js']);
   expect(json.numTotalTests).toBe(4);
   expect(json.numPassedTests).toBe(2);
   expect(json.numFailedTests).toBe(0);
@@ -20,7 +20,6 @@ it('works with concurrent.each', () => {
 it('works with concurrent.only.each', () => {
   const {json} = runWithJson('circus-concurrent', [
     'concurrent-only-each.test.js',
-    '--testRunner=jest-circus/runner',
   ]);
   expect(json.numTotalTests).toBe(4);
   expect(json.numPassedTests).toBe(2);

--- a/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import {skipSuiteOnJasmine} from '@jest/test-utils';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
@@ -14,6 +15,8 @@ const TESTS_DIR = path.resolve(DIR, '__tests__');
 
 beforeEach(() => cleanup(TESTS_DIR));
 afterAll(() => cleanup(TESTS_DIR));
+
+skipSuiteOnJasmine();
 
 test('works with a single snapshot', () => {
   const filename = 'basic-support.test.js';
@@ -39,12 +42,7 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
     expect(exitCode).toBe(1);
@@ -54,12 +52,7 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(exitCode).toBe(0);
   }
@@ -113,12 +106,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `with retries snapshots 1`');
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
@@ -129,12 +117,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(exitCode).toBe(0);
   }

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import {skipSuiteOnJasmine} from '@jest/test-utils';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
@@ -14,6 +15,8 @@ const TESTS_DIR = path.resolve(DIR, '__tests__');
 
 beforeEach(() => cleanup(TESTS_DIR));
 afterAll(() => cleanup(TESTS_DIR));
+
+skipSuiteOnJasmine();
 
 test('works with a single snapshot', () => {
   const filename = 'basic-support.test.js';
@@ -39,12 +42,7 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
     expect(exitCode).toBe(1);
@@ -54,12 +52,7 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(exitCode).toBe(0);
   }
@@ -92,12 +85,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
     expect(exitCode).toBe(1);
@@ -107,12 +95,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, exitCode} = runJest(DIR, [
-      '-w=1',
-      '--ci=false',
-      '--testRunner=jest-circus/runner',
-      filename,
-    ]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(exitCode).toBe(0);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

No reason to run tests with jasmine if they spawn using `testRunner` arg - just skip them to begin with

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
