### PR TITLE
use already read cpus variable only once and improve code  little usi…

### DIFF
--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -23,7 +23,7 @@ export default function getMaxWorkers(
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
     const cpusInfo = cpus();
-    const numCpus = cpusInfo ? cpusInfo.length : 1;
+    const numCpus = cpusInfo?.length ?? 1;
     const isWatchModeEnabled = argv.watch || argv.watchAll;
     return Math.max(
       isWatchModeEnabled ? Math.floor(numCpus / 2) : numCpus - 1,

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -22,7 +22,8 @@ export default function getMaxWorkers(
     return parseWorkers(defaultOptions.maxWorkers);
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
-    const numCpus = cpus() ? cpus().length : 1;
+    const cpusInfo = cpus();
+    const numCpus = cpusInfo ? cpusInfo.length : 1;
     const isWatchModeEnabled = argv.watch || argv.watchAll;
     return Math.max(
       isWatchModeEnabled ? Math.floor(numCpus / 2) : numCpus - 1,
@@ -42,7 +43,7 @@ const parseWorkers = (maxWorkers: string | number): number => {
   ) {
     const numCpus = cpus().length;
     const workers = Math.floor((parsed / 100) * numCpus);
-    return workers >= 1 ? workers : 1;
+    return Math.max(workers, 1);
   }
 
   return parsed > 0 ? parsed : 1;


### PR DESCRIPTION
…ng Math.max

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
This PR improves the code of `getMaxWorkers.ts` a little bit, use already read cpus variable only once and improve code  little using Math.max
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Unfortunately I am getting a typescript issue at the `yarn build` stage, 
```node_modules/fsevents/fsevents.d.ts:18:25 - error TS7010: 'watch', which lacks return-type annotation, implicitly has an 'any' return type.

18 export declare function watch(path: string, since: number, handler: WatchHandler);
 ```
So unable to run tests. Could someone who has the environment set up checkout this branch and run the tests ?
Anyways the code change is really small   

Thanks
Saikat Guha
sktguha@gmail.com
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
