### PR TITLE
feat: add global config to test environment

### DIFF
--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -18,6 +18,7 @@ type JestMockSpyOn = typeof jestMock.spyOn;
 export type EnvironmentContext = Partial<{
   console: Console;
   docblockPragmas: Record<string, string | Array<string>>;
+  globalConfig: Pick<Config.GlobalConfig, 'updateSnapshot'>;
   testPath: Config.Path;
 }>;
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -142,6 +142,9 @@ async function runTestInternal(
   const environment = new TestEnvironment(config, {
     console: testConsole,
     docblockPragmas,
+    globalConfig: {
+      updateSnapshot: globalConfig.updateSnapshot,
+    },
     testPath: path,
   });
   const leakDetector = config.detectLeaks


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I am working on a custom snapshot tool and want to access the `-updateSnapshot` flag from the custom test environment. I added a `globalConfig` key to the `EnvironmentContext` parameter of the constructor. Having the config key defined this way should make it easy to add more options in the future if needed. 

Fixes #10841 