### PR TITLE
fix(jest-resolve): disable `jest-pnp-resolver` for Yarn 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options
+- `[jest-resolve]` Disable `jest-pnp-resolver` for Yarn 2 ([#10847](https://github.com/facebook/jest/pull/10847))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[jest-reporter]` Handle empty files when reporting code coverage with V8 ([#10819](https://github.com/facebook/jest/pull/10819))
 - `[jest-resolve]` Replace read-pkg-up with escalade package ([#10781](https://github.com/facebook/jest/pull/10781))
+- `[jest-resolve]` Disable `jest-pnp-resolver` for Yarn 2 ([#10847](https://github.com/facebook/jest/pull/10847))
 - `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options
-- `[jest-resolve]` Disable `jest-pnp-resolver` for Yarn 2 ([#10847](https://github.com/facebook/jest/pull/10847))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/pnp.test.ts
+++ b/e2e/__tests__/pnp.test.ts
@@ -12,21 +12,21 @@ import {json as runWithJson} from '../runJest';
 const DIR = path.resolve(__dirname, '..', 'pnp');
 
 beforeEach(() => {
-  runYarnInstall(DIR, {YARN_NODE_LINKER: 'pnp'});
+  runYarnInstall(DIR, {
+    YARN_ENABLE_GLOBAL_CACHE: 'false',
+    YARN_NODE_LINKER: 'pnp',
+  });
 });
 
 it('successfully runs the tests inside `pnp/`', () => {
-  // https://github.com/facebook/jest/pull/8094#issuecomment-471220694
-  if (process.platform === 'win32') {
-    console.warn('[SKIP] Does not work on Windows');
-
-    return;
-  }
-
   const {json} = runWithJson(DIR, ['--no-cache', '--coverage'], {
-    env: {YARN_NODE_LINKER: 'pnp'},
+    env: {
+      YARN_ENABLE_GLOBAL_CACHE: 'false',
+      YARN_NODE_LINKER: 'pnp',
+    },
     nodeOptions: `--require ${DIR}/.pnp.js`,
   });
+
   expect(json.success).toBe(true);
   expect(json.numTotalTestSuites).toBe(2);
 });

--- a/e2e/pnp/__tests__/undeclared-dependency.test.js
+++ b/e2e/pnp/__tests__/undeclared-dependency.test.js
@@ -9,5 +9,5 @@
 it('should surface pnp errors', () => {
   expect(() => {
     require('undeclared');
-  }).toThrow(expect.objectContaining({pnpCode: 'UNDECLARED_DEPENDENCY'}));
+  }).toThrow(expect.objectContaining({code: 'MODULE_NOT_FOUND'}));
 });

--- a/e2e/pnp/package.json
+++ b/e2e/pnp/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "foo": "link:./lib",
-    "undeclared": "link:./undeclared-dependency"
+    "foo": "portal:./lib",
+    "undeclared": "portal:./undeclared-dependency"
   },
   "installConfig": {
     "pnp": true

--- a/e2e/pnp/yarn.lock
+++ b/e2e/pnp/yarn.lock
@@ -4,9 +4,9 @@
 __metadata:
   version: 4
 
-"foo@link:./lib::locator=root-workspace-0b6124%40workspace%3A.":
+"foo@portal:./lib::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "foo@link:./lib::locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "foo@portal:./lib::locator=root-workspace-0b6124%40workspace%3A."
   languageName: node
   linkType: soft
 
@@ -14,13 +14,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    foo: "link:./lib"
-    undeclared: "link:./undeclared-dependency"
+    foo: "portal:./lib"
+    undeclared: "portal:./undeclared-dependency"
   languageName: unknown
   linkType: soft
 
-"undeclared@link:./undeclared-dependency::locator=root-workspace-0b6124%40workspace%3A.":
+"undeclared@portal:./undeclared-dependency::locator=root-workspace-0b6124%40workspace%3A.":
   version: 0.0.0-use.local
-  resolution: "undeclared@link:./undeclared-dependency::locator=root-workspace-0b6124%40workspace%3A."
+  resolution: "undeclared@portal:./undeclared-dependency::locator=root-workspace-0b6124%40workspace%3A."
   languageName: node
   linkType: soft

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -12,7 +12,6 @@ import type {Config} from '@jest/types';
 import {tryRealpath} from 'jest-util';
 
 type ResolverOptions = {
-  allowPnp?: boolean;
   basedir: Config.Path;
   browser?: boolean;
   defaultResolver: typeof defaultResolver;
@@ -36,7 +35,9 @@ export default function defaultResolver(
   path: Config.Path,
   options: ResolverOptions,
 ): Config.Path {
-  if (process.versions.pnp && options.allowPnp !== false) {
+  // Yarn 2 adds support to `resolve` automatically so the pnpResolver is only
+  // needed for Yarn 1 which implements version 1 of the pnp spec
+  if (process.versions.pnp === '1') {
     return pnpResolver(path, options);
   }
 


### PR DESCRIPTION
## Summary

In https://github.com/facebook/jest/pull/9520 `jest-resolve` was switched to use `resolve` which, because Yarn 2 patches it, supports PnP. It can't be removed as that would be a breaking change for Yarn 1 PnP users but it can be disabled for Yarn 2.

Main reason for doing this is that `jest-pnp-resolver` doesn't support projects where there are multiple `pnpapi` instances but the patch in `resolve` does.

## Test plan

Tests should still pass