### PR TITLE
feat: interactive failure runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[jest-config, jest-runtime]` Support ESM for files other than `.js` and `.mjs` ([#10823](https://github.com/facebook/jest/pull/10823))
 - `[jest-config, jest-runtime]` [**BREAKING**] Use "modern" implementation as default for fake timers ([#10874](https://github.com/facebook/jest/pull/10874))
 - `[jest-core]` make `TestWatcher` extend `emittery` ([#10324](https://github.com/facebook/jest/pull/10324))
+- `[jest-core]` Run failed tests interactively the same way we do with snapshots ([#10858](https://github.com/facebook/jest/pull/10858))
 - `[jest-core]` more `TestSequencer` methods can be async ([#10980](https://github.com/facebook/jest/pull/10980))
 - `[jest-haste-map]` Handle injected scm clocks ([#10966](https://github.com/facebook/jest/pull/10966))
 - `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))

--- a/packages/jest-core/src/FailedTestsInteractiveMode.ts
+++ b/packages/jest-core/src/FailedTestsInteractiveMode.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import ansiEscapes = require('ansi-escapes');
 import chalk = require('chalk');
 import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
@@ -30,7 +37,9 @@ export default class FailedTestsInteractiveMode {
   put(key: string): void {
     switch (key) {
       case 's':
-        if (this._skippedNum === this._testAssertions.length) break;
+        if (this._skippedNum === this._testAssertions.length) {
+          break;
+        }
 
         this._skippedNum += 1;
         // move skipped test to the end
@@ -61,12 +70,12 @@ export default class FailedTestsInteractiveMode {
   }
 
   run(
-    failedSnapshotTestAssertions: Array<AssertionLocation>,
+    failedTestAssertions: Array<AssertionLocation>,
     updateConfig: RunnerUpdateFunction,
   ): void {
-    if (!failedSnapshotTestAssertions.length) return;
+    if (failedTestAssertions.length === 0) return;
 
-    this._testAssertions = [...failedSnapshotTestAssertions];
+    this._testAssertions = [...failedTestAssertions];
     this._countPaths = this._testAssertions.length;
     this._updateTestRunnerConfig = updateConfig;
     this._isActive = true;
@@ -74,7 +83,7 @@ export default class FailedTestsInteractiveMode {
   }
 
   updateWithResults(results: AggregatedResult): void {
-    if (!results.snapshot.failure && results.numFailedTests) {
+    if (!results.snapshot.failure && results.numFailedTests > 0) {
       return this._drawUIOverlay();
     }
 
@@ -108,9 +117,9 @@ export default class FailedTestsInteractiveMode {
 
     let stats = `${pluralize('test', this._countPaths)} reviewed`;
 
-    if (this._skippedNum) {
+    if (this._skippedNum > 0) {
       const skippedText = chalk.bold.yellow(
-        pluralize('snapshot', this._skippedNum) + ' skipped',
+        pluralize('test', this._skippedNum) + ' skipped',
       );
 
       stats = `${stats}, ${skippedText}`;
@@ -136,9 +145,9 @@ export default class FailedTestsInteractiveMode {
     const numRemaining = this._countPaths - numPass - this._skippedNum;
     let stats = `${pluralize('test', numRemaining)} remaining`;
 
-    if (this._skippedNum) {
+    if (this._skippedNum > 0) {
       const skippedText = chalk.bold.yellow(
-        pluralize('snapshot', this._skippedNum) + ' skipped',
+        pluralize('test', this._skippedNum) + ' skipped',
       );
 
       stats = `${stats}, ${skippedText}`;

--- a/packages/jest-core/src/FailedTestsInteractiveMode.ts
+++ b/packages/jest-core/src/FailedTestsInteractiveMode.ts
@@ -1,0 +1,186 @@
+import ansiEscapes = require('ansi-escapes');
+import chalk = require('chalk');
+import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
+import {pluralize, specialChars} from 'jest-util';
+import {KEYS} from 'jest-watcher';
+
+type RunnerUpdateFunction = (failure?: AssertionLocation) => void;
+
+const {ARROW, CLEAR} = specialChars;
+
+function describeKey(key: string, description: string) {
+  return `${chalk.dim(ARROW + 'Press')} ${key} ${chalk.dim(description)}`;
+}
+
+const TestProgressLabel = chalk.bold('Interactive Test Progress');
+
+export default class FailedTestsInteractiveMode {
+  private _isActive = false;
+  private _countPaths = 0;
+  private _skippedNum = 0;
+  private _testAssertions: Array<AssertionLocation> = [];
+  private _updateTestRunnerConfig?: RunnerUpdateFunction;
+
+  constructor(private _pipe: NodeJS.WritableStream) {}
+
+  isActive(): boolean {
+    return this._isActive;
+  }
+
+  put(key: string): void {
+    switch (key) {
+      case 's':
+        if (this._skippedNum === this._testAssertions.length) break;
+
+        this._skippedNum += 1;
+        // move skipped test to the end
+        this._testAssertions.push(this._testAssertions.shift()!);
+        if (this._testAssertions.length - this._skippedNum > 0) {
+          this._run();
+        } else {
+          this._drawUIDoneWithSkipped();
+        }
+
+        break;
+      case 'q':
+      case KEYS.ESCAPE:
+        this.abort();
+        break;
+      case 'r':
+        this.restart();
+        break;
+      case KEYS.ENTER:
+        if (this._testAssertions.length === 0) {
+          this.abort();
+        } else {
+          this._run();
+        }
+        break;
+      default:
+    }
+  }
+
+  run(
+    failedSnapshotTestAssertions: Array<AssertionLocation>,
+    updateConfig: RunnerUpdateFunction,
+  ): void {
+    if (!failedSnapshotTestAssertions.length) return;
+
+    this._testAssertions = [...failedSnapshotTestAssertions];
+    this._countPaths = this._testAssertions.length;
+    this._updateTestRunnerConfig = updateConfig;
+    this._isActive = true;
+    this._run();
+  }
+
+  updateWithResults(results: AggregatedResult): void {
+    if (!results.snapshot.failure && results.numFailedTests) {
+      return this._drawUIOverlay();
+    }
+
+    this._testAssertions.shift();
+    if (this._testAssertions.length === 0) {
+      return this._drawUIOverlay();
+    }
+
+    // Go to the next test
+    return this._run();
+  }
+
+  private _clearTestSummary() {
+    this._pipe.write(ansiEscapes.cursorUp(6));
+    this._pipe.write(ansiEscapes.eraseDown);
+  }
+
+  private _drawUIDone() {
+    this._pipe.write(CLEAR);
+
+    const messages: Array<string> = [
+      chalk.bold('Watch Usage'),
+      describeKey('Enter', 'to return to watch mode.'),
+    ];
+
+    this._pipe.write(messages.join('\n') + '\n');
+  }
+
+  private _drawUIDoneWithSkipped() {
+    this._pipe.write(CLEAR);
+
+    let stats = `${pluralize('test', this._countPaths)} reviewed`;
+
+    if (this._skippedNum) {
+      const skippedText = chalk.bold.yellow(
+        pluralize('snapshot', this._skippedNum) + ' skipped',
+      );
+
+      stats = `${stats}, ${skippedText}`;
+    }
+
+    const message = [
+      TestProgressLabel,
+      `${ARROW}${stats}`,
+      '\n',
+      chalk.bold('Watch Usage'),
+      describeKey('r', 'to restart Interactive Mode.'),
+      describeKey('q', 'to quit Interactive Mode.'),
+      describeKey('Enter', 'to return to watch mode.'),
+    ];
+
+    this._pipe.write(`\n${message.join('\n')}`);
+  }
+
+  private _drawUIProgress() {
+    this._clearTestSummary();
+
+    const numPass = this._countPaths - this._testAssertions.length;
+    const numRemaining = this._countPaths - numPass - this._skippedNum;
+    let stats = `${pluralize('test', numRemaining)} remaining`;
+
+    if (this._skippedNum) {
+      const skippedText = chalk.bold.yellow(
+        pluralize('snapshot', this._skippedNum) + ' skipped',
+      );
+
+      stats = `${stats}, ${skippedText}`;
+    }
+
+    const message = [
+      TestProgressLabel,
+      `${ARROW}${stats}`,
+      '\n',
+      chalk.bold('Watch Usage'),
+      describeKey('s', 'to skip the current test.'),
+      describeKey('q', 'to quit Interactive Mode.'),
+      describeKey('Enter', 'to return to watch mode.'),
+    ];
+
+    this._pipe.write(`\n${message.join('\n')}`);
+  }
+
+  private _drawUIOverlay() {
+    if (this._testAssertions.length === 0) return this._drawUIDone();
+
+    return this._drawUIProgress();
+  }
+
+  private _run() {
+    if (this._updateTestRunnerConfig) {
+      this._updateTestRunnerConfig(this._testAssertions[0]);
+    }
+  }
+
+  private abort() {
+    this._isActive = false;
+    this._skippedNum = 0;
+
+    if (this._updateTestRunnerConfig) {
+      this._updateTestRunnerConfig();
+    }
+  }
+
+  private restart(): void {
+    this._skippedNum = 0;
+    this._countPaths = this._testAssertions.length;
+    this._run();
+  }
+}

--- a/packages/jest-core/src/__tests__/FailedTestsInteractiveMode.test.js
+++ b/packages/jest-core/src/__tests__/FailedTestsInteractiveMode.test.js
@@ -1,0 +1,38 @@
+import chalk from 'chalk';
+import {specialChars} from 'jest-util';
+import FailedTestsInteractiveMode from '../FailedTestsInteractiveMode';
+
+const {ARROW} = specialChars;
+
+describe('FailedTestsInteractiveMode', () => {
+  describe('updateWithResults', () => {
+    it('renders usage information when all failures resolved', () => {
+      const mockWrite = jest.fn();
+
+      new FailedTestsInteractiveMode({write: mockWrite}).updateWithResults({
+        numFailedTests: 1,
+        snapshot: {},
+      });
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        `${chalk.bold('Watch Usage')}\n${chalk.dim(
+          ARROW + 'Press',
+        )} Enter ${chalk.dim('to return to watch mode.')}\n`,
+      );
+    });
+  });
+
+  it('is inactive at construction', () => {
+    expect(new FailedTestsInteractiveMode().isActive()).toBeFalsy();
+  });
+
+  it('skips activation when no failed tests are present', () => {
+    const plugin = new FailedTestsInteractiveMode();
+
+    plugin.run([]);
+    expect(plugin.isActive()).toBeFalsy();
+
+    plugin.run([{}]);
+    expect(plugin.isActive()).toBeTruthy();
+  });
+});

--- a/packages/jest-core/src/__tests__/FailedTestsInteractiveMode.test.js
+++ b/packages/jest-core/src/__tests__/FailedTestsInteractiveMode.test.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import chalk from 'chalk';
 import {specialChars} from 'jest-util';
 import FailedTestsInteractiveMode from '../FailedTestsInteractiveMode';

--- a/packages/jest-core/src/plugins/FailedTestsInteractive.ts
+++ b/packages/jest-core/src/plugins/FailedTestsInteractive.ts
@@ -1,0 +1,87 @@
+import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
+import type {Config} from '@jest/types';
+import {
+  BaseWatchPlugin,
+  JestHookSubscriber,
+  UpdateConfigCallback,
+  UsageData,
+} from 'jest-watcher';
+import FailedTestsInteractiveMode from '../FailedTestsInteractiveMode';
+
+export default class FailedTestsInteractivePlugin extends BaseWatchPlugin {
+  private _failedTestAssertions?: Array<AssertionLocation>;
+  private readonly _manager = new FailedTestsInteractiveMode(this._stdout);
+
+  apply(hooks: JestHookSubscriber): void {
+    hooks.onTestRunComplete(results => {
+      this._failedTestAssertions = this.getFailedSnapshotTestAssertions(
+        results,
+      );
+
+      if (this._manager.isActive()) this._manager.updateWithResults(results);
+    });
+  }
+
+  getUsageInfo(): UsageData | null {
+    if (this._failedTestAssertions?.length) {
+      return {key: 'i', prompt: 'run failing tests interactively'};
+    }
+
+    return null;
+  }
+
+  onKey(key: string): void {
+    if (this._manager.isActive()) {
+      this._manager.put(key);
+    }
+  }
+
+  run(
+    _: Config.GlobalConfig,
+    updateConfigAndRun: UpdateConfigCallback,
+  ): Promise<void> {
+    return new Promise(resolve => {
+      if (!this._failedTestAssertions?.length) return resolve();
+
+      this._manager.run(this._failedTestAssertions, failure => {
+        updateConfigAndRun({
+          mode: 'watch',
+          testNamePattern: failure ? `^${failure.fullName}$` : '',
+          testPathPattern: failure?.path || '',
+        });
+
+        if (!this._manager.isActive()) resolve();
+      });
+    });
+  }
+
+  private getFailedSnapshotTestAssertions(
+    results: AggregatedResult,
+  ): Array<AssertionLocation> {
+    const failedTestPaths: Array<AssertionLocation> = [];
+
+    if (
+      // skip if no failed tests
+      results.numFailedTests === 0 ||
+      // skip if missing test results
+      !results.testResults ||
+      // skip if unmatched snapshots are present
+      results.snapshot.unmatched
+    ) {
+      return failedTestPaths;
+    }
+
+    results.testResults.forEach(testResult => {
+      testResult.testResults.forEach(result => {
+        if (result.status === 'failed') {
+          failedTestPaths.push({
+            fullName: result.fullName,
+            path: testResult.testFilePath,
+          });
+        }
+      });
+    });
+
+    return failedTestPaths;
+  }
+}

--- a/packages/jest-core/src/plugins/__tests__/FailedTestsInteractive.test.js
+++ b/packages/jest-core/src/plugins/__tests__/FailedTestsInteractive.test.js
@@ -1,0 +1,57 @@
+import FailedTestsInteractivePlugin from '../FailedTestsInteractive';
+
+describe('FailedTestsInteractive', () => {
+  it('returns usage info when failing tests are present', () => {
+    expect(new FailedTestsInteractivePlugin({}).getUsageInfo()).toBeNull();
+
+    const activateablePlugin = new FailedTestsInteractivePlugin({});
+    let mockCallback;
+
+    activateablePlugin.apply({
+      onTestRunComplete: callback => {
+        mockCallback = callback;
+      },
+    });
+
+    mockCallback({
+      snapshot: {},
+      testResults: [{testResults: [{status: 'failed'}]}],
+    });
+
+    expect(activateablePlugin.getUsageInfo()).toEqual({
+      key: 'i',
+      prompt: 'run failing tests interactively',
+    });
+  });
+
+  it('calls config update when receiving failed tests', () => {
+    const mockUpdate = jest.fn();
+    const plugin = new FailedTestsInteractivePlugin({});
+    const testAggregate = {
+      snapshot: {},
+      testResults: [
+        {
+          testFilePath: '/tmp/mock-path',
+          testResults: [{fullName: 'test-name', status: 'failed'}],
+        },
+      ],
+    };
+    let mockCallback;
+
+    plugin.apply({
+      onTestRunComplete: callback => {
+        mockCallback = callback;
+      },
+    });
+
+    mockCallback(testAggregate);
+
+    plugin.run(null, mockUpdate);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      mode: 'watch',
+      testNamePattern: `^${testAggregate.testResults[0].testResults[0].fullName}$`,
+      testPathPattern: testAggregate.testResults[0].testFilePath,
+    });
+  });
+});

--- a/packages/jest-core/src/plugins/__tests__/FailedTestsInteractive.test.js
+++ b/packages/jest-core/src/plugins/__tests__/FailedTestsInteractive.test.js
@@ -1,32 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import FailedTestsInteractivePlugin from '../FailedTestsInteractive';
 
 describe('FailedTestsInteractive', () => {
   it('returns usage info when failing tests are present', () => {
     expect(new FailedTestsInteractivePlugin({}).getUsageInfo()).toBeNull();
 
-    const activateablePlugin = new FailedTestsInteractivePlugin({});
-    let mockCallback;
-
-    activateablePlugin.apply({
-      onTestRunComplete: callback => {
-        mockCallback = callback;
-      },
-    });
-
-    mockCallback({
-      snapshot: {},
-      testResults: [{testResults: [{status: 'failed'}]}],
-    });
-
-    expect(activateablePlugin.getUsageInfo()).toEqual({
-      key: 'i',
-      prompt: 'run failing tests interactively',
-    });
-  });
-
-  it('calls config update when receiving failed tests', () => {
     const mockUpdate = jest.fn();
-    const plugin = new FailedTestsInteractivePlugin({});
+    const activateablePlugin = new FailedTestsInteractivePlugin({});
     const testAggregate = {
       snapshot: {},
       testResults: [
@@ -38,16 +24,19 @@ describe('FailedTestsInteractive', () => {
     };
     let mockCallback;
 
-    plugin.apply({
+    activateablePlugin.apply({
       onTestRunComplete: callback => {
         mockCallback = callback;
       },
     });
 
     mockCallback(testAggregate);
+    activateablePlugin.run(null, mockUpdate);
 
-    plugin.run(null, mockUpdate);
-
+    expect(activateablePlugin.getUsageInfo()).toEqual({
+      key: 'i',
+      prompt: 'run failing tests interactively',
+    });
     expect(mockUpdate).toHaveBeenCalledWith({
       mode: 'watch',
       testNamePattern: `^${testAggregate.testResults[0].testResults[0].fullName}$`,

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -39,6 +39,7 @@ import {
   filterInteractivePlugins,
   getSortedUsageRows,
 } from './lib/watchPluginsHelpers';
+import FailedTestsInteractivePlugin from './plugins/FailedTestsInteractive';
 import QuitPlugin from './plugins/Quit';
 import TestNamePatternPlugin from './plugins/TestNamePattern';
 import TestPathPatternPlugin from './plugins/TestPathPattern';
@@ -61,6 +62,7 @@ const {print: preRunMessagePrint} = preRunMessage;
 let hasExitListener = false;
 
 const INTERNAL_PLUGINS = [
+  FailedTestsInteractivePlugin,
   TestPathPatternPlugin,
   TestNamePatternPlugin,
   UpdateSnapshotsPlugin,

--- a/packages/jest-watcher/src/BaseWatchPlugin.ts
+++ b/packages/jest-watcher/src/BaseWatchPlugin.ts
@@ -13,7 +13,7 @@ import type {
   WatchPlugin,
 } from './types';
 
-class BaseWatchPlugin implements WatchPlugin {
+abstract class BaseWatchPlugin implements WatchPlugin {
   protected _stdin: NodeJS.ReadStream;
   protected _stdout: NodeJS.WriteStream;
 


### PR DESCRIPTION
Closes #7685.

## Summary

When running multiple failed tests we may end up with a lot of noise in tests (console logs, deprecation warnings, etc.). Using an interactive mode would allow us to run and fix each test in isolation without having to manually run and re-run tests.

## Test plan

![demo-7685](https://user-images.githubusercontent.com/1067221/100120365-8d861b80-2e80-11eb-92bc-5d594e0aed77.gif)
