### PR TITLE
Add mockFn.mock.lastCall to easily retrieve the last call arguments

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -77,6 +77,16 @@ mockFn.mock.instances[0] === a; // true
 mockFn.mock.instances[1] === b; // true
 ```
 
+### `mockFn.mock.lastCall`
+
+An array containing the call arguments of the last call that was made to this mock function. If the function was not called, it will return `undefined`.
+
+For example: A mock function `f` that has been called twice, with the arguments `f('arg1', 'arg2')`, and then with the arguments `f('arg3', 'arg4')`, would have a `mock.lastCall` array that looks like this:
+
+```js
+['arg3', 'arg4'];
+```
+
 ### `mockFn.mockClear()`
 
 Resets all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances) arrays.

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -75,6 +75,9 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
 expect(someMockFunction.mock.instances[0].name).toEqual('test');
+
+// The first argument of the last call to the function was 'test'
+expect(someMockFunction.mock.lastCall[0]).toBe('test');
 ```
 
 ## Mock Return Values

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1064,6 +1064,32 @@ describe('moduleMocker', () => {
     expect(fn.getMockName()).toBe('myMockFn');
   });
 
+  test('jest.fn should provide the correct lastCall', () => {
+    const mock = jest.fn();
+
+    expect(mock.mock.lastCall).toBeUndefined();
+
+    mock('first');
+    mock('second');
+    mock('last', 'call');
+
+    expect(mock).toHaveBeenLastCalledWith('last', 'call');
+    expect(mock.mock.lastCall).toEqual(['last', 'call']);
+  });
+
+  test('lastCall gets reset by mockReset', () => {
+    const mock = jest.fn();
+
+    mock('first');
+    mock('last', 'call');
+
+    expect(mock.mock.lastCall).toEqual(['last', 'call']);
+
+    mock.mockReset();
+
+    expect(mock.mock.lastCall).toBeUndefined();
+  });
+
   test('mockName gets reset by mockReset', () => {
     const fn = jest.fn();
     expect(fn.getMockName()).toBe('jest.fn()');

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -102,6 +102,10 @@ type MockFunctionState<T, Y extends Array<unknown>> = {
   instances: Array<T>;
   invocationCallOrder: Array<number>;
   /**
+   * Getter for retrieving the last call arguments
+   */
+  lastCall?: Y;
+  /**
    * List of results of calls to the mock function.
    */
   results: Array<MockFunctionResult>;
@@ -456,6 +460,9 @@ class ModuleMockerClass {
       state = this._defaultMockState();
       this._mockState.set(f, state);
     }
+
+    state.lastCall = state.calls[state.calls.length - 1];
+
     return state;
   }
 
@@ -476,6 +483,7 @@ class ModuleMockerClass {
       calls: [],
       instances: [],
       invocationCallOrder: [],
+      lastCall: undefined,
       results: [],
     };
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When switching from using `sinon` mocks to jest, one of the nice things that `sinon` provided was the ability to retrieve the last call arguments easily. I know that you can use `mockFn.mock.calls[mockFn.mock.calls.length - 1]` to retrieve it, but `mock.lastCall` seems a lot easier when you're doing it in a bunch of places. I wanted to at least try adding it and see what the response was. I understand if this is not needed, but it seems like a nice little improvement.

## Test plan

I've updated types, added tests for the feature and updated documentation. I ran `yarn test` for the entire test suite to verify that it was working. _(Please let me know if there is additional testing that is necessary for this change.)_

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
