### PR TITLE
feat(jest-circus): provide testPath to custom Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-runner]` [**BREAKING**] Run transforms over `runnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runner]` [**BREAKING**] Run transforms over `testRunnner` ([#8823](https://github.com/facebook/jest/pull/8823))
+- `[jest-circus]` Provide `testPath` property in the test runner state ([#10879](https://github.com/facebook/jest/pull/10879))
 
 ### Fixes
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -64,6 +64,7 @@ export const initialize = async ({
   globals: Global.TestFrameworkGlobals;
   snapshotState: SnapshotStateType;
 }> => {
+  getRunnerState().testPath = testPath;
   if (globalConfig.testTimeout) {
     getRunnerState().testTimeout = globalConfig.testTimeout;
   }

--- a/packages/jest-circus/src/state.ts
+++ b/packages/jest-circus/src/state.ts
@@ -29,6 +29,7 @@ const INITIAL_STATE: Circus.State = {
   parentProcess: null,
   rootDescribeBlock: ROOT_DESCRIBE_BLOCK,
   testNamePattern: null,
+  testPath: null,
   testTimeout: 5000,
   unhandledErrors: [],
 };

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -208,6 +208,7 @@ export type State = {
   originalGlobalErrorHandlers?: GlobalErrorHandlers;
   parentProcess: Process | null; // process object from the outer scope
   rootDescribeBlock: DescribeBlock;
+  testPath: string | null;
   testNamePattern?: RegExp | null;
   testTimeout: number;
   unhandledErrors: Array<Exception>;


### PR DESCRIPTION
## Summary

The use scenario is related to e2e tests.

When a Jest worker picks the next test file and sets up the custom environment, we might want to know the exact test path there.

E.g., upon its init, Detox allocates a free device and prints a message like this:

```
detox[26435] INFO:  01.sanity.test.js is assigned to 8A7F4E42-4243-4029-9BC9-47B8344D5340 {"type":"iPhone 11 Pro"}
```

At the moment, talking about custom environments, this can be done only via private Symbols, and only after first two dispatches in the code:

```js
const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
const { testPath } = this.global[JEST_MATCHERS_OBJECT].state;
```

So, I wonder, if it is fine if we have it in the initial test runner state from the earliest moment possible?

## Test plan

There is no one at the moment, but as soon as I receive a confirmation that this idea is okay, I'll see what unit/e2e tests I can add for that.