### PR TITLE
fix(jest-worker): Remove circular references from messages sent to workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options
+- `[jest-worker]` Remove circular references from messages sent to workers to prevent error and jest hanging ([#10881](https://github.com/facebook/jest/pull/10881))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 
 ### Chore & Maintenance

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@types/node": "*",
+    "fclone": "^1.0.11",
     "merge-stream": "^2.0.0",
     "supports-color": "^8.0.0"
   },

--- a/packages/jest-worker/src/workers/__tests__/messageParent.test.js
+++ b/packages/jest-worker/src/workers/__tests__/messageParent.test.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import {PARENT_MESSAGE_CUSTOM} from '../../types';
+
+const processSend = process.send;
+
+let messageParent;
+let mockWorkerThreads;
+
+beforeEach(() => {
+  mockWorkerThreads = {};
+  process.send = jest.fn();
+  jest.mock('worker_threads', () => mockWorkerThreads);
+  messageParent = require('../messageParent').default;
+});
+
+afterEach(() => {
+  jest.resetModules();
+  // console.log(require('worker_threads'));
+  process.send = processSend;
+});
+
+describe('with worker threads', () => {
+  beforeEach(() => {
+    mockWorkerThreads.parentPort = {
+      postMessage: jest.fn(),
+    };
+  });
+
+  it('cand send a message', () => {
+    messageParent('some-message');
+    expect(mockWorkerThreads.parentPort.postMessage).toHaveBeenCalledWith([
+      PARENT_MESSAGE_CUSTOM,
+      'some-message',
+    ]);
+  });
+
+  it('removes circular references from the message being sent', () => {
+    const circular = {ref: null, some: 'thing'};
+    circular.ref = circular;
+    messageParent(circular);
+    expect(mockWorkerThreads.parentPort.postMessage).toHaveBeenCalledWith([
+      PARENT_MESSAGE_CUSTOM,
+      {
+        ref: '[Circular]',
+        some: 'thing',
+      },
+    ]);
+  });
+});
+
+describe('without worker threads', () => {
+  it('cand send a message', () => {
+    messageParent('some-message');
+    expect(process.send).toHaveBeenCalledWith([
+      PARENT_MESSAGE_CUSTOM,
+      'some-message',
+    ]);
+  });
+
+  it('removes circular references from the message being sent', () => {
+    const circular = {ref: null, some: 'thing'};
+    circular.ref = circular;
+    messageParent(circular);
+    expect(process.send).toHaveBeenCalledWith([
+      PARENT_MESSAGE_CUSTOM,
+      {
+        ref: '[Circular]',
+        some: 'thing',
+      },
+    ]);
+  });
+});

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fclone from 'fclone';
 import {PARENT_MESSAGE_CUSTOM} from '../types';
 
 const isWorkerThread = () => {
@@ -22,12 +23,14 @@ const messageParent = (
   parentProcess: NodeJS.Process = process,
 ): void => {
   try {
+    const nonCircularMessage = fclone(message);
+
     if (isWorkerThread()) {
       // `Require` here to support Node v10
       const {parentPort} = require('worker_threads');
-      parentPort.postMessage([PARENT_MESSAGE_CUSTOM, message]);
+      parentPort.postMessage([PARENT_MESSAGE_CUSTOM, nonCircularMessage]);
     } else if (typeof parentProcess.send === 'function') {
-      parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
+      parentProcess.send([PARENT_MESSAGE_CUSTOM, nonCircularMessage]);
     }
   } catch {
     throw new Error('"messageParent" can only be used inside a worker');

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fclone from 'fclone';
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_END,
@@ -64,7 +65,7 @@ function reportSuccess(result: unknown) {
     throw new Error('Child can only be used on a forked process');
   }
 
-  process.send([PARENT_MESSAGE_OK, result]);
+  process.send([PARENT_MESSAGE_OK, fclone(result)]);
 }
 
 function reportClientError(error: Error) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9069,6 +9069,13 @@ fbjs-scripts@^1.1.0:
   languageName: node
   linkType: hard
 
+"fclone@npm:^1.0.11":
+  version: 1.0.11
+  resolution: "fclone@npm:1.0.11"
+  checksum: f4a2c63c141dd2796745acbea3858704a86aec1985a226259c2a574e4b44596197b4fe4bea8b45950d0fb577a63ceef21b5e075016ee52f6401c06f6a0396a2d
+  languageName: node
+  linkType: hard
+
 "fd-slicer@npm:~1.1.0":
   version: 1.1.0
   resolution: "fd-slicer@npm:1.1.0"
@@ -12422,6 +12429,7 @@ fsevents@~2.1.2:
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"
     "@types/supports-color": ^7.2.0
+    fclone: ^1.0.11
     get-stream: ^6.0.0
     merge-stream: ^2.0.0
     supports-color: ^8.0.0


### PR DESCRIPTION
Fixes #10577

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This fix prevents objects with circular references to be sent to worker processes. Node uses `JSON.stringify` to serialize such messages and this causes an error in case there are circular references in the messages.

Please note I added new dependency, `fclone`, though I'm not sure it's allowed or if there already is another such function in the repository.

## Test plan

This fix allows to run the tests described in the issue linked. The repro setup can be found at https://repl.it/@Frantiekiaik/jest-playground-1.

