### PR TITLE
fix(jest‑environment‑jsdom): Use inner realm’s ArrayBuffer constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[jest-circus]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-circus]` Fix `testLocation` on Windows when using `test.each` ([#10871](https://github.com/facebook/jest/pull/10871))
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))
+- `[jest-environment-jsdom]` Use inner realm’s `ArrayBuffer` constructor ([#10885](https://github.com/facebook/jest/pull/10885))
 - `[jest-jasmine2]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block when it has child `tests` marked as either `only` or `todo` [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-jasmine2]` Fixed the issues of child `tests` marked with `only` or `todo` getting executed even if it is inside a skipped parent `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-reporter]` Handle empty files when reporting code coverage with V8 ([#10819](https://github.com/facebook/jest/pull/10819))

--- a/e2e/env-test/__tests__/equivalent.test.js
+++ b/e2e/env-test/__tests__/equivalent.test.js
@@ -6,9 +6,31 @@
  */
 'use strict';
 
+const {isArrayBuffer} = require('util').types;
+const isJSDOM =
+  typeof window !== 'undefined' && typeof document !== 'undefined';
+
 test('Buffer', () => {
   const bufFromArray = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
-  expect(bufFromArray.buffer instanceof ArrayBuffer).toBeTruthy();
+  expect(isArrayBuffer(bufFromArray.buffer)).toBeTruthy();
   const bufFromArrayBuffer = Buffer.from(new ArrayBuffer(6));
   expect(bufFromArrayBuffer.buffer instanceof ArrayBuffer).toBeTruthy();
+});
+
+test.each([
+  ['Int8Array', Int8Array, isJSDOM],
+  ['Int16Array', Int16Array, isJSDOM],
+  ['Int32Array', Int32Array, isJSDOM],
+  ['Uint8Array', Uint8Array],
+  ['Uint8ClampedArray', Uint8ClampedArray, isJSDOM],
+  ['Uint16Array', Uint16Array, isJSDOM],
+  ['Uint32Array', Uint32Array, isJSDOM],
+  ['Float32Array', Float32Array, isJSDOM],
+  ['Float64Array', Float64Array, isJSDOM],
+])('%s', (name, ctor, testInstanceof = true) => {
+  const typedArray = ctor.of();
+  expect(isArrayBuffer(typedArray.buffer)).toBeTruthy();
+  if (testInstanceof) {
+    expect(typedArray.buffer instanceof ArrayBuffer).toBeTruthy();
+  }
 });

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -48,10 +48,6 @@ class JSDOMEnvironment implements JestEnvironment {
     // for "universal" code (code should use `globalThis`)
     global.global = global;
 
-    // In the `jsdom@16`, ArrayBuffer was not added to Window, ref: https://github.com/jsdom/jsdom/commit/3a4fd6258e6b13e9cf8341ddba60a06b9b5c7b5b
-    // Install ArrayBuffer to Window to fix it. Make sure the test is passed, ref: https://github.com/facebook/jest/pull/7626
-    global.ArrayBuffer = ArrayBuffer;
-
     // Node's error-message stack size is limited at 10, but it's pretty useful
     // to see more than that when a test fails.
     this.global.Error.stackTraceLimit = 100;


### PR DESCRIPTION
## Summary

- **Refs:** <https://github.com/facebook/jest/pull/9606#pullrequestreview-540409155>
- Fixes: <https://github.com/facebook/jest/issues/10786>
- Fixes: <https://github.com/facebook/jest/issues/10854>

## Test plan

See the changes to: [`e2e/env‑test/__tests__/equivalent.test.js`](https://github.com/ExE-Boss/jest/blob/fix/jest-environment-jsdom/use-inner-realm-arraybuffer-constructor/e2e/env-test/__tests__/equivalent.test.js).
