### PR TITLE
docs: changed UsingMatchers array example

### DIFF
--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -127,12 +127,12 @@ const shoppingList = [
   'kleenex',
   'trash bags',
   'paper towels',
-  'beer',
+  'milk',
 ];
 
-test('the shopping list has beer on it', () => {
-  expect(shoppingList).toContain('beer');
-  expect(new Set(shoppingList)).toContain('beer');
+test('the shopping list has milk on it', () => {
+  expect(shoppingList).toContain('milk');
+  expect(new Set(shoppingList)).toContain('milk');
 });
 ```
 

--- a/website/versioned_docs/version-22.x/UsingMatchers.md
+++ b/website/versioned_docs/version-22.x/UsingMatchers.md
@@ -128,12 +128,12 @@ const shoppingList = [
   'kleenex',
   'trash bags',
   'paper towels',
-  'beer',
+  'milk',
 ];
 
-test('the shopping list has beer on it', () => {
-  expect(shoppingList).toContain('beer');
-  expect(new Set(shoppingList)).toContain('beer');
+test('the shopping list has milk on it', () => {
+  expect(shoppingList).toContain('milk');
+  expect(new Set(shoppingList)).toContain('milk');
 });
 ```
 


### PR DESCRIPTION
I know this isn't anything major, but given that many people suffer from alcohol-related issues, I really would like to avoid that the only array example jest provides revolves around whether beer is present in an otherwise _family oriented_ `shoppingList`.

As someone who knows plenty of people with such issues I just found it of poor taste, again, nothing major, but I see no reason to not change it, nothing changes from a functional/documentation point of view, but avoids any pointless substance-related reference.

Milk seems more fitting.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
