### PR TITLE
fix: unable to cyclic ES modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-resolve]` Disable `jest-pnp-resolver` for Yarn 2 ([#10847](https://github.com/facebook/jest/pull/10847))
 - `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
+- `[jest-runtime]` Fix stack overflow and promise deadlock when importing mutual dependant ES module
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `[jest-resolve]` Disable `jest-pnp-resolver` for Yarn 2 ([#10847](https://github.com/facebook/jest/pull/10847))
 - `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
-- `[jest-runtime]` Fix stack overflow and promise deadlock when importing mutual dependant ES module
+- `[jest-runtime]` Fix stack overflow and promise deadlock when importing mutual dependant ES module ([#10892](https://github.com/facebook/jest/pull/10892))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -10,7 +10,7 @@ Ran all test suites matching /native-esm.tla.test.js/i.
 
 exports[`on node ^12.16.0 || >=13.7.0 runs test with native ESM 1`] = `
 Test Suites: 1 passed, 1 total
-Tests:       17 passed, 17 total
+Tests:       18 passed, 18 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /native-esm.test.js/i.

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -156,3 +156,10 @@ test('supports file urls as imports', async () => {
 test('namespace export', () => {
   expect(bag.double).toBe(double);
 });
+
+test('handle circular dependency', async () => {
+  const moduleA = (await import('../circularDependentA.mjs')).default;
+  expect(moduleA.id).toBe('circularDependentA');
+  expect(moduleA.moduleB.id).toBe('circularDependentB');
+  expect(moduleA.moduleB.moduleA).toBe(moduleA);
+});

--- a/e2e/native-esm/circularDependentA.mjs
+++ b/e2e/native-esm/circularDependentA.mjs
@@ -1,0 +1,8 @@
+import circularDependentB from './circularDependentB.mjs';
+
+export default {
+    id: 'circularDependentA',
+    get moduleB() {
+        return circularDependentB;
+    }
+};

--- a/e2e/native-esm/circularDependentA.mjs
+++ b/e2e/native-esm/circularDependentA.mjs
@@ -1,8 +1,8 @@
 import circularDependentB from './circularDependentB.mjs';
 
 export default {
-    id: 'circularDependentA',
-    get moduleB() {
-        return circularDependentB;
-    }
+  id: 'circularDependentA',
+  get moduleB() {
+    return circularDependentB;
+  },
 };

--- a/e2e/native-esm/circularDependentA.mjs
+++ b/e2e/native-esm/circularDependentA.mjs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import circularDependentB from './circularDependentB.mjs';
 
 export default {

--- a/e2e/native-esm/circularDependentB.mjs
+++ b/e2e/native-esm/circularDependentB.mjs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import circularDependentA from './circularDependentA.mjs';
 
 export default {

--- a/e2e/native-esm/circularDependentB.mjs
+++ b/e2e/native-esm/circularDependentB.mjs
@@ -1,0 +1,8 @@
+import circularDependentA from './circularDependentA.mjs';
+
+export default {
+    id: 'circularDependentB',
+    get moduleA() {
+        return circularDependentA;
+    }
+};

--- a/e2e/native-esm/circularDependentB.mjs
+++ b/e2e/native-esm/circularDependentB.mjs
@@ -1,8 +1,8 @@
 import circularDependentA from './circularDependentA.mjs';
 
 export default {
-    id: 'circularDependentB',
-    get moduleA() {
-        return circularDependentA;
-    }
+  id: 'circularDependentB',
+  get moduleA() {
+    return circularDependentA;
+  },
 };

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -57,6 +57,11 @@ import type {Context} from './types';
 
 export type {Context} from './types';
 
+interface EsmModuleCache {
+  beforeEvaluation: Promise<VMModule>;
+  fullyEvaluated: Promise<VMModule>;
+}
+
 const esmIsAvailable = typeof SourceTextModule === 'function';
 
 interface JestGlobals extends Global.TestFrameworkGlobals {
@@ -172,7 +177,7 @@ export default class Runtime {
   private _moduleMocker: typeof jestMock;
   private _isolatedModuleRegistry: ModuleRegistry | null;
   private _moduleRegistry: ModuleRegistry;
-  private _esmoduleRegistry: Map<string, Promise<VMModule>>;
+  private _esmoduleRegistry: Map<string, EsmModuleCache>;
   private _testPath: Config.Path | undefined;
   private _resolver: Resolver;
   private _shouldAutoMock: boolean;
@@ -363,6 +368,7 @@ export default class Runtime {
   private async loadEsmModule(
     modulePath: Config.Path,
     query = '',
+    isStaticImport = false
   ): Promise<VMModule> {
     const cacheKey = modulePath + query;
 
@@ -378,7 +384,10 @@ export default class Runtime {
 
       if (this._resolver.isCoreModule(modulePath)) {
         const core = this._importCoreModule(modulePath, context);
-        this._esmoduleRegistry.set(cacheKey, core);
+        this._esmoduleRegistry.set(cacheKey, {
+          beforeEvaluation: core,
+          fullyEvaluated: core
+        });
         return core;
       }
 
@@ -401,31 +410,48 @@ export default class Runtime {
             specifier,
             referencingModule.identifier,
             referencingModule.context,
+            false
           ),
         initializeImportMeta(meta: ImportMeta) {
           meta.url = pathToFileURL(modulePath).href;
         },
       });
 
+      let resolve: (value: VMModule) => void;
+      let reject: (value: any) => void;
+      let promise = new Promise<VMModule>((_resolve, _reject) => { resolve = _resolve; reject = _reject });
+
+      // add to registry before link so that circular import won't end up stack overflow
       this._esmoduleRegistry.set(
         cacheKey,
         // we wanna put the linking promise in the cache so modules loaded in
         // parallel can all await it. We then await it synchronously below, so
         // we shouldn't get any unhandled rejections
-        module
-          .link((specifier: string, referencingModule: VMModule) =>
-            this.linkModules(
-              specifier,
-              referencingModule.identifier,
-              referencingModule.context,
-            ),
-          )
-          .then(() => module.evaluate())
-          .then(() => module),
+        {
+          beforeEvaluation: Promise.resolve(module),
+          fullyEvaluated: promise
+        }
       );
+
+      module
+        .link((specifier: string, referencingModule: VMModule) =>
+          this.linkModules(
+            specifier,
+            referencingModule.identifier,
+            referencingModule.context,
+            true
+          ),
+        )
+        .then(() => module.evaluate())
+        .then(() => resolve(module), (e: any) => reject(e));
     }
 
-    const module = this._esmoduleRegistry.get(cacheKey);
+    const entry = this._esmoduleRegistry.get(cacheKey);
+
+    // return the already resolved, pre-evaluation promise
+    // is loaded through static import to prevent promise deadlock
+    // because module is evaluated after all static import is resolved
+    const module = isStaticImport ? entry?.beforeEvaluation : entry?.fullyEvaluated;
 
     invariant(module);
 
@@ -436,15 +462,19 @@ export default class Runtime {
     specifier: string,
     referencingIdentifier: string,
     context: VMContext,
+    isStaticImport: boolean
   ) {
     if (specifier === '@jest/globals') {
       const fromCache = this._esmoduleRegistry.get('@jest/globals');
 
       if (fromCache) {
-        return fromCache;
+        return isStaticImport ? fromCache.beforeEvaluation : fromCache.fullyEvaluated;
       }
       const globals = this.getGlobalsForEsm(referencingIdentifier, context);
-      this._esmoduleRegistry.set('@jest/globals', globals);
+      this._esmoduleRegistry.set('@jest/globals', {
+        beforeEvaluation: globals,
+        fullyEvaluated: globals
+      });
 
       return globals;
     }
@@ -461,7 +491,7 @@ export default class Runtime {
       this._resolver.isCoreModule(resolved) ||
       this.unstable_shouldLoadAsEsm(resolved)
     ) {
-      return this.loadEsmModule(resolved, query);
+      return this.loadEsmModule(resolved, query, isStaticImport);
     }
 
     return this.loadCjsAsEsm(referencingIdentifier, resolved, context);
@@ -1169,7 +1199,7 @@ export default class Runtime {
 
           invariant(context);
 
-          return this.linkModules(specifier, scriptFilename, context);
+          return this.linkModules(specifier, scriptFilename, context, false);
         },
       });
     } catch (e) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In current implementation, when importing a mutually dependent ES module, stack overflow and promise deadlock occur.

For a circular dependency like follow:

`moduleA.js`:
`import moduleB from './moduleB.js'; export default {}; `

`moduleB.js`:
`import moduleA from './moduleA.js'; export default {};`

Loading `moduleA.js` will trigger `loadEsmModule` of `moduleB.js` recursively from `module.link` before the promise for `moduleA.js` is set to  `_esmoduleRegistry`; which in turn will recursively trigger `loadEsmModule` of `moduleA.js`, having a cache miss. Thus this will continue until stack overflow.

Another issue is that since the current cache registry is containing a promise that is resolved **after** the module is evaluated.
If there are circular dependencies, the promise in registry will never resolves because module evaluation is only done when all promises acquired through `module.link` are resolved.

Promise of `moduleA.js` is waiting for promise `moduleB.js` to resolve while promise of `moduleB.js` is also waiting for promise of `moduleA.js` to resolve.



## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Test with `moduleA` and `moduleB` above.
