### PR TITLE
fix(babel-plugin-jest-hoist): allow using module wrapper arguments in hoisted mock factory function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[jest-circus]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-circus]` Fix `testLocation` on Windows when using `test.each` ([#10871](https://github.com/facebook/jest/pull/10871))

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -35,6 +35,8 @@ const hoistedVariables = new WeakSet<VariableDeclarator>();
 // We also allow variables prefixed with `mock` as an escape-hatch.
 const ALLOWED_IDENTIFIERS = new Set<string>(
   [
+    '__dirname',
+    '__filename',
     'Array',
     'ArrayBuffer',
     'Boolean',

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -35,8 +35,6 @@ const hoistedVariables = new WeakSet<VariableDeclarator>();
 // We also allow variables prefixed with `mock` as an escape-hatch.
 const ALLOWED_IDENTIFIERS = new Set<string>(
   [
-    '__dirname',
-    '__filename',
     'Array',
     'ArrayBuffer',
     'Boolean',
@@ -87,7 +85,11 @@ const ALLOWED_IDENTIFIERS = new Set<string>(
     'jest',
     'parseFloat',
     'parseInt',
+    'exports',
     'require',
+    'module',
+    '__filename',
+    '__dirname',
     'undefined',
     ...Object.getOwnPropertyNames(global),
   ].sort(),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This allows several things. My specific case is using the content of a file as the return value for a mocked function:

```ts
jest.mock('some-module', () => {
  const fs = require('fs');
  const path = require('path');

  return {
    someFunction() {
      const pathToHtmlFile = path.resolve(__dirname, 'some-fixture.html');
      const html = fs.readFileSync(pathToHtmlFile);
      return html;
    },
  };
});
```

The test is located inside a Yarn workspace, and for complicated reasons I have to execute `jest` from the root of the repository. As far as I can tell, this is the only way I can avoid letting the test know about its own directory path in the repo.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

To be honest, I'm just doing what @SimenB told me would solve my problem.

I applied this patch to my own repo, and it works. Does it make sense to document this further?