### PR TITLE
chore: ./jest requires bash

### DIFF
--- a/jest
+++ b/jest
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 : '
 Copyright (c) 2014-present, Facebook, Inc. All rights reserved.


### PR DESCRIPTION
## Summary

It uses `BASH_SOURCE`, which isn't available in `dash`, ubuntu's default `sh`. Instead, specify that we need actual `bash`.

## Test plan

```
% readlink -f =sh
/usr/bin/dash

% ./jest
./jest: 10: Bad substitution

% git checkout chore/fixup-helper-script

% ./jest
yarn node v1.22.10
...
```