### PR TITLE
Ensure `toContain` only accepts strings when `received` is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
-- `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119))
+- `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))
 - `[jest-circus]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-circus]` Fix `testLocation` on Windows when using `test.each` ([#10871](https://github.com/facebook/jest/pull/10871))
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1989,6 +1989,17 @@ Received has type:  string
 Received has value: <r>"undefined"</>
 `;
 
+exports[`.toContain(), .toContainEqual() error cases 5`] = `
+<d>expect(</><r>false</><d>).</>toContain<d>(</><g>false</><d>) // indexOf</>
+
+<b>Matcher error</>: <g>expected</> value must be a string if <r>received</> value is a string
+
+Expected has type:  boolean
+Expected has value: <g>false</>
+Received has type:  string
+Received has value: <r>"false"</>
+`;
+
 exports[`.toContain(), .toContainEqual() error cases for toContainEqual 1`] = `
 <d>expect(</><r>received</><d>).</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1470,6 +1470,14 @@ describe('.toContain(), .toContainEqual()', () => {
     expect(() =>
       jestExpect('undefined').toContain(undefined),
     ).toThrowErrorMatchingSnapshot();
+    expect(() =>
+      jestExpect('false').toContain(false),
+    ).toThrowErrorMatchingSnapshot();
+    if (isBigIntDefined) {
+      expect(() => jestExpect('1').toContain(BigInt(1))).toThrowError(
+        'toContain',
+      );
+    }
   });
 
   [

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -480,18 +480,7 @@ const matchers: MatchersObject = {
         'received',
       )} value is a string`;
 
-      if (expected == null) {
-        throw new Error(
-          matcherErrorMessage(
-            matcherHint(matcherName, received, String(expected), options),
-            wrongTypeErrorMessage,
-            printWithType('Expected', expected, printExpected) +
-              '\n' +
-              printWithType('Received', received, printReceived),
-          ),
-        );
-      }
-      if (typeof expected === 'number') {
+      if (typeof expected !== 'string') {
         throw new Error(
           matcherErrorMessage(
             matcherHint(matcherName, received, String(expected), options),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The following expectations were still passing after #10119:

```js
expect("false").toContain(false);
expect("0").toContain(0n);
```

This PR ensures only strings will be accepted when received is a string itself in `toContain`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

They pass before that PR:
```js
expect("false").toContain(false);
expect("0").toContain(0n);
```

They do not pass now.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
