### PR TITLE
Move `@jest/types` to dev dependencies

### DIFF
--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -16,12 +16,12 @@
   },
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {
-    "@jest/types": "^27.0.0-next.1",
     "ansi-regex": "^5.0.0",
     "ansi-styles": "^5.0.0",
     "react-is": "^17.0.1"
   },
   "devDependencies": {
+    "@jest/types": "^27.0.0-next.1",
     "@types/react": "*",
     "@types/react-is": "^17.0.0",
     "@types/react-test-renderer": "*",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The `@jest/types` has `@types/node` as dependency. As a result, after installing the recent version of `pretty-format`, TypeScript thinks that my web app is nodejs. The main problem is the timers. In `nodejs` they return `Timeout` object. In browser it returns a number:

![image](https://user-images.githubusercontent.com/1037995/101613845-84628600-3a0c-11eb-95e7-ace7725add6c.png)
