### PR TITLE
ci: only fetch dependencies once

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14.x
+
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -34,10 +38,6 @@ jobs:
           key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn2-
-
-      - uses: actions/setup-node@v2.1.2
-        with:
-          node-version: 14.x
 
       - name: Validate cache
         env:
@@ -54,6 +54,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 12.x
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -63,9 +66,6 @@ jobs:
           key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn2-
-      - uses: actions/setup-node@v2.1.4
-        with:
-          node-version: 12.x
       - name: install
         run: yarn --immutable
       - name: build
@@ -98,6 +98,10 @@ jobs:
           git config --global core.symlinks true
         if: runner.os == 'Windows'
       - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -107,10 +111,6 @@ jobs:
           key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn2-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: install
         run: yarn --immutable
       - name: build
@@ -140,6 +140,10 @@ jobs:
           git config --global core.symlinks true
         if: runner.os == 'Windows'
       - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.1.4
+        with:
+          node-version: 14.x
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -149,10 +153,6 @@ jobs:
           key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             yarn2-
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v2.1.4
-        with:
-          node-version: 14.x
       - name: install
         run: yarn --immutable
       - name: build

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,9 +29,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ubuntu-latest-node-12.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ubuntu-latest-node-12.x-yarn-
+            yarn2-
       - uses: actions/setup-node@v2.1.4
         with:
           node-version: 12.x
@@ -72,9 +72,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.node-version }}-yarn-
+            yarn2-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2.1.4
         with:
@@ -113,9 +113,9 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-node-14.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: yarn2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-node-14.x-yarn-
+            yarn2-
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2.1.4
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -129,5 +129,3 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v1
       - name: run tests using jest-jasmine
         run: yarn jest-jasmine-ci --max-workers ${{ steps.cpu-cores.outputs.count }}
-        env:
-          CI: true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -120,8 +120,6 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v1
       - name: run tests
         run: yarn test-ci-partial:parallel --max-workers ${{ steps.cpu-cores.outputs.count }}
-        env:
-          CI: true
 
   test-jasmine:
     name: Node LTS on ${{ matrix.os }} using jest-jasmine2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,9 +17,40 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
+  prepare-yarn-cache:
+    name: Prepare yarn cache
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: yarn2-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            yarn2-
+
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14.x
+
+      - name: Validate cache
+        env:
+          # Use PnP and disable postinstall scripts as this just needs to
+          # populate the cache for the other jobs
+          YARN_NODE_LINKER: pnp
+          YARN_ENABLE_SCRIPTS: false
+        run: yarn --immutable
+
   lint-and-typecheck:
     name: Running TypeScript compiler & ESLint
     runs-on: ubuntu-latest
+    needs: prepare-yarn-cache
 
     steps:
       - uses: actions/checkout@v2
@@ -57,6 +88,7 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 15.x]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    needs: prepare-yarn-cache
 
     steps:
       - name: Set git config
@@ -98,6 +130,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    needs: prepare-yarn-cache
 
     steps:
       - name: Set git config


### PR DESCRIPTION
## Summary

When the lockfile changes, the changed dependencies will be fetched 4x3 + 3 + 1 = 16 times which wastes resources. To solve this I added a `prepare-yarn-cache` job that all the other jobs wait for to make sure they always get a cache hit.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

CI passes