### PR TITLE
fix(jest-runtime): prevent global module registry from leaking into isolateModules registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 ### Fixes
 
-- `[jest-runtime]` Prevent global module registry from leaking into `isolateModules` registry ([#10963](https://github.com/facebook/jest/pull/10963))
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))
@@ -38,6 +37,7 @@
 - `[jest-runtime]` [**BREAKING**] Do not inject `global` variable into module wrapper ([#10644](https://github.com/facebook/jest/pull/10644))
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
 - `[jest-runtime]` Fix stack overflow and promise deadlock when importing mutual dependant ES module ([#10892](https://github.com/facebook/jest/pull/10892))
+- `[jest-runtime]` Prevent global module registry from leaking into `isolateModules` registry ([#10963](https://github.com/facebook/jest/pull/10963))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options ([#10834](https://github.com/facebook/jest/pull/10834))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixes
 
+- `[jest-runtime]` Prevent global module registry from leaking into `isolateModules` registry ([#10963](https://github.com/facebook/jest/pull/10963))
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
@@ -218,6 +218,33 @@ describe('resetModules', () => {
 });
 
 describe('isolateModules', () => {
+  it("keeps it's registry isolated from global one", () =>
+    createRuntime(__filename, {
+      moduleNameMapper,
+    }).then(runtime => {
+      let exports;
+      exports = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'ModuleWithState',
+      );
+      exports.increment();
+      expect(exports.getState()).toBe(2);
+
+      runtime.isolateModules(() => {
+        exports = runtime.requireModuleOrMock(
+          runtime.__mockRootPath,
+          'ModuleWithState',
+        );
+        expect(exports.getState()).toBe(1);
+      });
+
+      exports = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'ModuleWithState',
+      );
+      expect(exports.getState()).toBe(2);
+    }));
+
   it('resets all modules after the block', () =>
     createRuntime(__filename, {
       moduleNameMapper,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -610,13 +610,10 @@ export default class Runtime {
     if (options?.isInternalModule) {
       moduleRegistry = this._internalModuleRegistry;
     } else {
-      if (
-        this._moduleRegistry.get(modulePath) ||
-        !this._isolatedModuleRegistry
-      ) {
-        moduleRegistry = this._moduleRegistry;
-      } else {
+      if (this._isolatedModuleRegistry) {
         moduleRegistry = this._isolatedModuleRegistry;
+      } else {
+        moduleRegistry = this._moduleRegistry;
       }
     }
 


### PR DESCRIPTION
## Summary

`require` statement inside `isolateModules` callbacks are unpredictable since they do not always return a fresh copy of imported modules. Currently if global registry has the require module in cache, the cached instance is returned even within `isolateModules. Fixes: #7863

This PR ensures that `require` statement inside `isolateModules` always return a fresh copy of imported modules.

### Current behaviour
```js
const myModule = require('myModule');

jest.isolateModules(() => {
  const myIsolatedModule = require('myModule');
  // myIsolatedModule === myModule;
});
```

### New behaviour
```js
const myModule = require('myModule');

jest.isolateModules(() => {
  const myIsolatedModule = require('myModule');
  // myIsolatedModule !== myModule;
});
```

## Test plan

Added relevant test in: `packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js `