### PR TITLE
chore: make node-notifier a peer dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - `[jest-resolve]` [**BREAKING**] Migrate to ESM ([#10688](https://github.com/facebook/jest/pull/10688))
 - `[jest-resolve-dependencies]` [**BREAKING**] Migrate to ESM ([#10876](https://github.com/facebook/jest/pull/10876))
 - `[jest-mock]` [**BREAKING**] Migrate to ESM ([#10887](https://github.com/facebook/jest/pull/10887))
+- `[jest-reporters]` [**BREAKING**] Make `node-notifier` a peer dependency ([#10977](https://github.com/facebook/jest/pull/10977))
 - `[jest-resolve, jest-runtime]` [**BREAKING**] Use `Map`s instead of objects for all cached resources ([#10968](https://github.com/facebook/jest/pull/10968))
 - `[jest-runner]` [**BREAKING**] Migrate to ESM ([#10900](https://github.com/facebook/jest/pull/10900))
 - `[jest-runtime]` [**BREAKING**] Remove deprecated and unnused `getSourceMapInfo` from Runtime ([#9969](https://github.com/facebook/jest/pull/9969))

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "micromatch": "^4.0.2",
     "mlh-tsd": "^0.14.1",
     "mock-fs": "^4.4.1",
+    "node-notifier": "^9.0.0",
     "prettier": "^2.1.1",
     "progress": "^2.0.0",
     "promise": "^8.0.2",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -32,6 +32,14 @@
     "@types/prompts": "^2.0.1",
     "@types/yargs": "^15.0.0"
   },
+  "peerDependencies": {
+    "node-notifier": "^8.0.1 || ^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-notifier": {
+      "optional": true
+    }
+  },
   "bin": {
     "jest": "./bin/jest.js"
   },

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -48,6 +48,14 @@
     "@types/rimraf": "^3.0.0",
     "jest-snapshot-serializer-raw": "^1.1.0"
   },
+  "peerDependencies": {
+    "node-notifier": "^8.0.1 || ^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-notifier": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -46,7 +46,6 @@
     "@types/istanbul-reports": "^3.0.0",
     "@types/node-notifier": "^8.0.0",
     "mock-fs": "^4.4.1",
-    "node-notifier": "^9.0.0",
     "strip-ansi": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -46,10 +46,16 @@
     "@types/istanbul-reports": "^3.0.0",
     "@types/node-notifier": "^8.0.0",
     "mock-fs": "^4.4.1",
+    "node-notifier": "^9.0.0",
     "strip-ansi": "^6.0.0"
   },
-  "optionalDependencies": {
-    "node-notifier": "^8.0.0"
+  "peerDependencies": {
+    "node-notifier": "^8.0.1 || ^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-notifier": {
+      "optional": true
+    }
   },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"

--- a/packages/jest-reporters/src/NotifyReporter.ts
+++ b/packages/jest-reporters/src/NotifyReporter.ts
@@ -145,10 +145,10 @@ function loadNotifier(): typeof import('node-notifier') {
   } catch (err) {
     if (err.code !== 'MODULE_NOT_FOUND') {
       throw err;
-    } else {
-      throw Error(
-        'notify reporter requires optional dependeny node-notifier but it was not found',
-      );
     }
+
+    throw Error(
+      'notify reporter requires optional peer dependency node-notifier but it was not found',
+    );
   }
 }

--- a/packages/jest-reporters/src/NotifyReporter.ts
+++ b/packages/jest-reporters/src/NotifyReporter.ts
@@ -148,7 +148,7 @@ function loadNotifier(): typeof import('node-notifier') {
     }
 
     throw Error(
-      'notify reporter requires optional peer dependency node-notifier but it was not found',
+      'notify reporter requires optional peer dependency "node-notifier" but it was not found',
     );
   }
 }

--- a/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
+++ b/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
@@ -224,14 +224,13 @@ describe('node-notifier is an optional dependency', () => {
 
   test('without node-notifier uses mock function that throws an error', () => {
     jest.doMock('node-notifier', () => {
-      const error: unknown = new Resolver.ModuleNotFoundError(
+      throw new Resolver.ModuleNotFoundError(
         "Cannot find module 'node-notifier'",
       );
-      throw error;
     });
 
     expect(ctor).toThrow(
-      'notify reporter requires optional dependeny node-notifier but it was not found',
+      'notify reporter requires optional peer dependency node-notifier but it was not found',
     );
   });
 

--- a/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
+++ b/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
@@ -230,7 +230,7 @@ describe('node-notifier is an optional dependency', () => {
     });
 
     expect(ctor).toThrow(
-      'notify reporter requires optional peer dependency node-notifier but it was not found',
+      'notify reporter requires optional peer dependency "node-notifier" but it was not found',
     );
   });
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,6 +14,14 @@
     "import-local": "^3.0.2",
     "jest-cli": "^27.0.0-next.2"
   },
+  "peerDependencies": {
+    "node-notifier": "^8.0.1 || ^9.0.0"
+  },
+  "peerDependenciesMeta": {
+    "node-notifier": {
+      "optional": true
+    }
+  },
   "bin": "./bin/jest.js",
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2000,14 +2000,16 @@ __metadata:
     jest-util: ^27.0.0-next.1
     jest-worker: ^27.0.0-next.2
     mock-fs: ^4.4.1
-    node-notifier: ^8.0.0
+    node-notifier: ^9.0.0
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
     terminal-link: ^2.0.0
     v8-to-istanbul: ^7.0.0
-  dependenciesMeta:
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
     node-notifier:
       optional: true
   languageName: unknown
@@ -14559,9 +14561,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-notifier@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "node-notifier@npm:8.0.0"
+"node-notifier@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "node-notifier@npm:9.0.0"
   dependencies:
     growly: ^1.3.0
     is-wsl: ^2.2.0
@@ -14569,7 +14571,7 @@ fsevents@^1.2.7:
     shellwords: ^0.1.1
     uuid: ^8.3.0
     which: ^2.0.2
-  checksum: 3016eccb32cbfc0ec26129500570a0d875c32e28c43aef9c32d4cea24617cdd870eaf39247faffed5b89f78ef69ca4506270d2f8f76f027222597b700cc8aec9
+  checksum: 10e6ba45afb246ea8bd0189960b883c4c0cb04de82a7c091b536f7652327910a4929fd3862cc32bdea20e53bb52a4ddae2ff1eb3aee751aba6e27242602193b3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1820,6 +1820,11 @@ __metadata:
     rimraf: ^3.0.0
     slash: ^3.0.0
     strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -1945,6 +1950,7 @@ __metadata:
     micromatch: ^4.0.2
     mlh-tsd: ^0.14.1
     mock-fs: ^4.4.1
+    node-notifier: ^9.0.0
     prettier: ^2.1.1
     progress: ^2.0.0
     promise: ^8.0.2
@@ -2000,7 +2006,6 @@ __metadata:
     jest-util: ^27.0.0-next.1
     jest-worker: ^27.0.0-next.2
     mock-fs: ^4.4.1
-    node-notifier: ^9.0.0
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
@@ -11593,6 +11598,11 @@ fsevents@^1.2.7:
     jest-validate: ^27.0.0-next.1
     prompts: ^2.0.1
     yargs: ^16.0.3
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
   bin:
     jest: ./bin/jest.js
   languageName: unknown
@@ -12364,6 +12374,11 @@ fsevents@^1.2.7:
     "@jest/core": ^27.0.0-next.2
     import-local: ^3.0.2
     jest-cli: ^27.0.0-next.2
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
   bin:
     jest: ./bin/jest.js
   languageName: unknown


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`node-notifier` is 5MB due to the vendored binaries.

```sh-session
$ du -d1 -h node_modules/node-notifier
256K    node_modules/node-notifier/node_modules
 20K    node_modules/node-notifier/lib
 24K    node_modules/node-notifier/notifiers
5.4M    node_modules/node-notifier/vendor
5.7M    node_modules/node-notifier
```

This is the single biggest directory in `node_modules` of a fresh Jest install, beating out the combined `@babel` directory (albeit barely)

```sh-session
$ du -d1 -h node_modules/ | sort -hr | head
 51M    node_modules/
5.7M    node_modules//node-notifier
5.7M    node_modules//@babel
4.8M    node_modules//lodash
3.8M    node_modules//jsdom
1.2M    node_modules//acorn
1.2M    node_modules//@types
1.1M    node_modules//ajv
984K    node_modules//@jest
960K    node_modules//snapdragon
```

I think this should work. Hopefully the peer dep "bubbles" up so it's enough that the end user adds the dep also in PnP. `node-notifier` is already optional (via #8918), so the code change here is pretty trivial.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤞 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
