### PR TITLE
feat: sequencer saving may be async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[jest-config, jest-runtime]` Support ESM for files other than `.js` and `.mjs` ([#10823](https://github.com/facebook/jest/pull/10823))
 - `[jest-config, jest-runtime]` [**BREAKING**] Use "modern" implementation as default for fake timers ([#10874](https://github.com/facebook/jest/pull/10874))
 - `[jest-core]` make `TestWatcher` extend `emittery` ([#10324](https://github.com/facebook/jest/pull/10324))
+- `[jest-core]` more `TestSequencer` methods can be async ([#10980](https://github.com/facebook/jest/pull/10980))
 - `[jest-haste-map]` Handle injected scm clocks ([#10966](https://github.com/facebook/jest/pull/10966))
 - `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -59,3 +59,23 @@ test('run prioritySequence first async', () => {
     './e.test.js',
   ]);
 });
+
+test('run failed tests async', () => {
+  const result = runJest(
+    dir,
+    [
+      '--onlyFailures',
+      '-i',
+      '--config',
+      JSON.stringify({
+        testSequencer: '<rootDir>/testSequencerAsync.js',
+      }),
+    ],
+    {},
+  );
+  expect(result.exitCode).toBe(0);
+  const sequence = extractSummary(result.stderr)
+    .rest.replace(/PASS /g, '')
+    .split('\n');
+  expect(sequence).toEqual(['./c.test.js', './d.test.js']);
+});

--- a/e2e/custom-test-sequencer/testSequencerAsync.js
+++ b/e2e/custom-test-sequencer/testSequencerAsync.js
@@ -7,16 +7,20 @@
 
 const Sequencer = require('@jest/test-sequencer').default;
 
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
 class CustomSequencer extends Sequencer {
-  sort(tests) {
-    return new Promise(resolve => {
-      setTimeout(() => {
-        const copyTests = Array.from(tests);
-        resolve(
-          copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1)),
-        );
-      }, 50);
-    });
+  async sort(tests) {
+    await sleep(50);
+    const copyTests = Array.from(tests);
+    return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1));
+  }
+
+  async allFailedTests(tests) {
+    await sleep(50);
+    return tests.filter(
+      t => t.path.endsWith('c.test.js') || t.path.endsWith('d.test.js'),
+    );
   }
 }
 

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -204,7 +204,7 @@ export default async function runJest({
     if (failedTestsCache) {
       allTests = failedTestsCache.filterTests(allTests);
     } else {
-      allTests = sequencer.allFailedTests(allTests);
+      allTests = await sequencer.allFailedTests(allTests);
     }
   }
 
@@ -272,7 +272,7 @@ export default async function runJest({
     testSchedulerContext,
   ).scheduleTests(allTests, testWatcher);
 
-  sequencer.cacheResults(allTests, results);
+  await sequencer.cacheResults(allTests, results);
 
   if (hasTests) {
     await runGlobalHook({allTests, globalConfig, moduleName: 'globalTeardown'});


### PR DESCRIPTION
## Summary

Allow a `TestSequencer` implementation to perform `async` operations during its `allFailedTests` and `cacheResults` phases.

It's already allowed for `sort`, but not for the other methods, which I believe are part of the public/extensible API.

My Sequencer wants to go to a database.

## Test plan

There's already a test for `sort`, and I've added a similar test for `allFailedTests`.

It's hard to directly test `cacheResults` is awaited, as it's void. We could attempt to catch it with sleeps and testing the implementation ordering; e.g. checking if it has completed before the `globalHook` has run? It doesn't seem to have any value.
`await`ing it is necessary, as otherwise longer `cacheResults` implementations eventually trigger the `Jest did not exit one second after the test run has completed.` failure.