### PR TITLE
fix(workers): use advanced serialization by default in child process workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[jest-test-result]` Add duration property to JSON test output ([#12518](https://github.com/facebook/jest/pull/12518))
 - `[jest-watcher]` [**BREAKING**] Make `PatternPrompt` class to take `entityName` as third constructor parameter instead of `this._entityName` ([#12591](https://github.com/facebook/jest/pull/12591))
 - `[jest-worker]` [**BREAKING**] Allow only absolute `workerPath` ([#12343](https://github.com/facebook/jest/pull/12343))
+- `[jest-worker]` [**BREAKING**] Default to advanced serialization when using child process workers ([#10983] (https://github.com/facebook/jest/pull/10983))
 - `[pretty-format]` New `maxWidth` parameter ([#12402](https://github.com/facebook/jest/pull/12402))
 
 ### Fixes

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -747,6 +747,8 @@ export default class HasteMap extends EventEmitter {
         // @ts-expect-error: assignment of a worker with custom properties.
         this._worker = new Worker(require.resolve('./worker'), {
           exposedMethods: ['getSha1', 'worker'],
+          // @ts-expect-error: option does not exist on the node 12 types
+          forkOptions: {serialization: 'json'},
           maxRetries: 3,
           numWorkers: this._options.maxWorkers,
         }) as WorkerInterface;

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -144,6 +144,8 @@ export default class CoverageReporter extends BaseReporter {
     } else {
       worker = new Worker(require.resolve('./CoverageWorker'), {
         exposedMethods: ['worker'],
+        // @ts-expect-error: option does not exist on the node 12 types
+        forkOptions: {serialization: 'json'},
         maxRetries: 2,
         numWorkers: this._globalConfig.maxWorkers,
       });

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -105,7 +105,8 @@ export default class TestRunner extends EmittingTestRunner {
 
     const worker = new Worker(TEST_WORKER_PATH, {
       exposedMethods: ['worker'],
-      forkOptions: {stdio: 'pipe'},
+      // @ts-expect-error: option does not exist on the node 12 types
+      forkOptions: {serialization: 'json', stdio: 'pipe'},
       maxRetries: 3,
       numWorkers: this._globalConfig.maxWorkers,
       setupArgs: [{serializableResolvers: Array.from(resolvers.values())}],

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -73,7 +73,7 @@ List of method names that can be called on the child processes from the parent p
 
 #### `forkOptions: ForkOptions` (optional)
 
-Allow customizing all options passed to `child_process.fork`. By default, some values are set (`cwd`, `env` and `execArgv`), but you can override them and customize the rest. For a list of valid values, check [the Node documentation](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
+Allow customizing all options passed to `child_process.fork`. By default, some values are set (`cwd`, `env`, `execArgv` and `serialization`), but you can override them and customize the rest. For a list of valid values, check [the Node documentation](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options).
 
 #### `maxRetries: number` (optional)
 

--- a/packages/jest-worker/src/__tests__/leak-integration.test.ts
+++ b/packages/jest-worker/src/__tests__/leak-integration.test.ts
@@ -53,6 +53,8 @@ describe('Worker leaks', () => {
     worker = new Worker(workerFile, {
       enableWorkerThreads: false,
       exposedMethods: ['fn'],
+      // @ts-expect-error: option does not exist on the node 12 types
+      forkOptions: {serialization: 'json'},
     });
   });
   afterEach(async () => {

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -92,6 +92,9 @@ export default class ChildProcessWorker implements WorkerInterface {
       },
       // Suppress --debug / --inspect flags while preserving others (like --harmony).
       execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
+      // default to advanced serialization in order to match worker threads
+      // @ts-expect-error: option does not exist on the node 12 types
+      serialization: 'advanced',
       silent: true,
       ...this._options.forkOptions,
     });

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -70,6 +70,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
     env: {...process.env, FORCE_COLOR: supportsColor.stdout ? '1' : undefined}, // Default option.
     execArgv: ['-p'], // Filtered option.
     execPath: 'hello', // Added option.
+    serialization: 'advanced', // Default option.
     silent: true, // Default option.
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This introduces parity in serialization implementation between the child process and worker thread implementations.

Extracted from #10981.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Unit test tweaked, so green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
