### PR TITLE
fix(worker): do not swallow errors when sending custom messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options ([#10834](https://github.com/facebook/jest/pull/10834))
 - `[jest-worker]` [**BREAKING**] Use named exports ([#10623] (https://github.com/facebook/jest/pull/10623))
+- `[jest-worker]` Do not swallow errors during serialization ([#10984] (https://github.com/facebook/jest/pull/10984))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 
 ### Chore & Maintenance

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -7,31 +7,33 @@
 
 import {PARENT_MESSAGE_CUSTOM} from '../types';
 
-const isWorkerThread = () => {
+const isWorkerThread: boolean = (() => {
   try {
     // `Require` here to support Node v10
-    const {isMainThread, parentPort} = require('worker_threads');
-    return !isMainThread && parentPort;
+    const {
+      isMainThread,
+      parentPort,
+    } = require('worker_threads') as typeof import('worker_threads');
+    return !isMainThread && parentPort != null;
   } catch {
     return false;
   }
-};
+})();
 
-const messageParent = (
+export default function messageParent(
   message: unknown,
-  parentProcess: NodeJS.Process = process,
-): void => {
-  try {
-    if (isWorkerThread()) {
-      // `Require` here to support Node v10
-      const {parentPort} = require('worker_threads');
-      parentPort.postMessage([PARENT_MESSAGE_CUSTOM, message]);
-    } else if (typeof parentProcess.send === 'function') {
-      parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
-    }
-  } catch {
+  parentProcess = process,
+): void {
+  if (isWorkerThread) {
+    // `Require` here to support Node v10
+    const {
+      parentPort,
+    } = require('worker_threads') as typeof import('worker_threads');
+    // ! is safe due to `null` check in `isWorkerThread`
+    parentPort!.postMessage([PARENT_MESSAGE_CUSTOM, message]);
+  } else if (typeof parentProcess.send === 'function') {
+    parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
+  } else {
     throw new Error('"messageParent" can only be used inside a worker');
   }
-};
-
-export default messageParent;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Extracted from #10981.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Error from the reproduction of #10577 changes from

```
  ● Test suite failed to run

    "messageParent" can only be used inside a worker

      at messageParent (packages/jest-worker/build/workers/messageParent.js:46:11)
```

to

```
  ● Test suite failed to run

    TypeError: Converting circular structure to JSON
        --> starting at object with constructor 'Object'
        --- property 'ref' closes the circle
        at stringify (<anonymous>)

      at messageParent (packages/jest-worker/build/workers/messageParent.js:42:19)
```

When using `jest-circus` which makes use of this function

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
