### PR TITLE
feat: resolve reexported CJS modules as named ESM exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - `[jest-resolve, jest-runtime]` [**BREAKING**] Use `Map`s instead of objects for all cached resources ([#10968](https://github.com/facebook/jest/pull/10968))
 - `[jest-runner]` [**BREAKING**] Migrate to ESM ([#10900](https://github.com/facebook/jest/pull/10900))
 - `[jest-runtime]` [**BREAKING**] Remove deprecated and unnused `getSourceMapInfo` from Runtime ([#9969](https://github.com/facebook/jest/pull/9969))
+- `[jest-runtime]` Detect reexports from CJS as named exports in ESM ([#10988](https://github.com/facebook/jest/pull/10988))
 - `[jest-util]` No longer checking `enumerable` when adding `process.domain` ([#10862](https://github.com/facebook/jest/pull/10862))
 - `[jest-validate]` [**BREAKING**] Remove `recursiveBlacklist ` option in favor of previously introduced `recursiveDenylist` ([#10650](https://github.com/facebook/jest/pull/10650))
 

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'url';
 import {jest as jestObject} from '@jest/globals';
 import staticImportedStatefulFromCjs from '../fromCjs.mjs';
 import {double} from '../index';
-import defaultFromCjs, {namedFunction} from '../namedExport.cjs';
+import defaultFromCjs, {half, namedFunction} from '../namedExport.cjs';
 // eslint-disable-next-line import/named
 import {bag} from '../namespaceExport.js';
 import staticImportedStateful from '../stateful.mjs';
@@ -139,10 +139,15 @@ test('varies module cache by query', () => {
 });
 
 test('supports named imports from CJS', () => {
+  expect(half(4)).toBe(2);
   expect(namedFunction()).toBe('hello from a named CJS function!');
   expect(defaultFromCjs.default()).toBe('"default" export');
 
-  expect(Object.keys(defaultFromCjs)).toEqual(['namedFunction', 'default']);
+  expect(Object.keys(defaultFromCjs)).toEqual([
+    'half',
+    'namedFunction',
+    'default',
+  ]);
 });
 
 test('supports file urls as imports', async () => {

--- a/e2e/native-esm/commonjsNamed.cjs
+++ b/e2e/native-esm/commonjsNamed.cjs
@@ -5,6 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = require('./commonjsNamed.cjs');
-module.exports.namedFunction = () => 'hello from a named CJS function!';
-module.exports.default = () => '"default" export';
+module.exports.half = require('./commonjs.cjs');

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -524,21 +524,15 @@ export default class Runtime {
     // CJS loaded via `import` should share cache with other CJS: https://github.com/nodejs/modules/issues/503
     const cjs = this.requireModuleOrMock(from, modulePath);
 
-    const transformedCode = this._fileTransforms.get(modulePath);
+    const parsedExports = this.getExportsOfCjs(modulePath);
 
-    let cjsExports: ReadonlyArray<string> = [];
-
-    if (transformedCode) {
-      const {exports} = parseCjs(transformedCode.code);
-
-      cjsExports = exports.filter(exportName => {
-        // we don't wanna respect any exports _names_ default as a named export
-        if (exportName === 'default') {
-          return false;
-        }
-        return Object.hasOwnProperty.call(cjs, exportName);
-      });
-    }
+    const cjsExports = [...parsedExports].filter(exportName => {
+      // we don't wanna respect any exports _named_ default as a named export
+      if (exportName === 'default') {
+        return false;
+      }
+      return Object.hasOwnProperty.call(cjs, exportName);
+    });
 
     const module = new SyntheticModule(
       [...cjsExports, 'default'],
@@ -554,6 +548,25 @@ export default class Runtime {
     );
 
     return evaluateSyntheticModule(module);
+  }
+
+  private getExportsOfCjs(modulePath: Config.Path) {
+    const transformedCode =
+      this._fileTransforms.get(modulePath)?.code ?? this.readFile(modulePath);
+
+    const {exports, reexports} = parseCjs(transformedCode);
+
+    let namedExports = new Set(exports);
+
+    reexports.forEach(reexport => {
+      const resolved = this._resolveModule(modulePath, reexport);
+
+      const exports = this.getExportsOfCjs(resolved);
+
+      namedExports = new Set([...namedExports, ...exports]);
+    });
+
+    return namedExports;
   }
 
   requireModule<T = unknown>(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Noticed when investigating #10814 that `import {jsx} from 'react/jsx-runtime'` didn't work as the exported function was not detected

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test for named CJS export expanded.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
