### PR TITLE
fix(expect): resolve `message` on assertion errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))
+- `[expect]` [**BREAKING**] `matcherResult` on `JestAssertionError` are now strings rather than functions ([#10989] (https://github.com/facebook/jest/pull/10989))
 - `[jest-circus]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-circus]` Fix `testLocation` on Windows when using `test.each` ([#10871](https://github.com/facebook/jest/pull/10871))
 - `[jest-cli]` Use testFailureExitCode when bailing from a failed test ([#10958](https://github.com/facebook/jest/pull/10958))

--- a/e2e/__tests__/failureDetailsProperty.test.ts
+++ b/e2e/__tests__/failureDetailsProperty.test.ts
@@ -34,6 +34,10 @@ test('that the failureDetails property is set', () => {
               "matcherResult": Object {
                 "actual": true,
                 "expected": false,
+                "message": "expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
                 "name": "toBe",
                 "pass": false,
               },
@@ -59,6 +63,10 @@ test('that the failureDetails property is set', () => {
               "matcherResult": Object {
                 "actual": true,
                 "expected": false,
+                "message": "expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
                 "name": "toBe",
                 "pass": false,
               },
@@ -90,6 +98,18 @@ test('that the failureDetails property is set', () => {
         \\"p1\\": \\"hello\\",
         \\"p2\\": \\"sunshine\\",
       }",
+                "message": "expect(received).toMatchInlineSnapshot(snapshot)
+
+      Snapshot name: \`my test a snapshot failure 1\`
+
+      - Snapshot  - 1
+      + Received  + 1
+
+        Object {
+          \\"p1\\": \\"hello\\",
+      -   \\"p2\\": \\"sunshine\\",
+      +   \\"p2\\": \\"world\\",
+        }",
                 "name": "toMatchInlineSnapshot",
                 "pass": false,
               },
@@ -169,6 +189,10 @@ test('that the failureDetails property is set', () => {
             "matcherResult": Object {
               "actual": true,
               "expected": false,
+              "message": "expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
               "name": "toBe",
               "pass": false,
             },
@@ -179,6 +203,10 @@ test('that the failureDetails property is set', () => {
             "matcherResult": Object {
               "actual": true,
               "expected": false,
+              "message": "expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
               "name": "toBe",
               "pass": false,
             },
@@ -195,6 +223,18 @@ test('that the failureDetails property is set', () => {
         \\"p1\\": \\"hello\\",
         \\"p2\\": \\"sunshine\\",
       }",
+              "message": "expect(received).toMatchInlineSnapshot(snapshot)
+
+      Snapshot name: \`my test a snapshot failure 1\`
+
+      - Snapshot  - 1
+      + Received  + 1
+
+        Object {
+          \\"p1\\": \\"hello\\",
+      -   \\"p2\\": \\"sunshine\\",
+      +   \\"p2\\": \\"world\\",
+        }",
               "name": "toMatchInlineSnapshot",
               "pass": false,
             },

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -50,7 +50,7 @@ import type {
 import {iterableEquality, subsetEquality} from './utils';
 
 class JestAssertionError extends Error {
-  matcherResult?: SyncExpectationResult;
+  matcherResult?: Omit<SyncExpectationResult, 'message'> & {message: string};
 }
 
 const isPromise = <T extends any>(obj: any): obj is PromiseLike<T> =>
@@ -293,7 +293,7 @@ const makeThrowingMatcher = (
         // Passing the result of the matcher with the error so that a custom
         // reporter could access the actual and expected objects of the result
         // for example in order to display a custom visual diff
-        error.matcherResult = result;
+        error.matcherResult = {...result, message};
 
         if (throws) {
           throw error;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When the error is thrown from `expect`, there's not reason to keep the `message` property a function. A function is removed by `JSON.stringify`, so it's lost when transferred between workers. And the structured clone used by `worker_threads` throws as the `message` function references out of scope variables.

Extracted from #10981.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test tweaked

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
