### PR TITLE
fix(pretty-format): only call `hasAttribute` if function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,10 @@
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options ([#10834](https://github.com/facebook/jest/pull/10834))
-- `[jest-worker]` [**BREAKING**] Use named exports ([#10623] (https://github.com/facebook/jest/pull/10623))
-- `[jest-worker]` Do not swallow errors during serialization ([#10984] (https://github.com/facebook/jest/pull/10984))
+- `[jest-worker]` [**BREAKING**] Use named exports ([#10623](https://github.com/facebook/jest/pull/10623))
+- `[jest-worker]` Do not swallow errors during serialization ([#10984](https://github.com/facebook/jest/pull/10984))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
+- `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
 
 ### Chore & Maintenance
 

--- a/packages/pretty-format/src/plugins/DOMElement.ts
+++ b/packages/pretty-format/src/plugins/DOMElement.ts
@@ -27,7 +27,7 @@ const testNode = (val: any) => {
   const {nodeType, tagName} = val;
   const isCustomElement =
     (typeof tagName === 'string' && tagName.includes('-')) ||
-    val.hasAttribute?.('is');
+    (typeof val.hasAttribute === 'function' && val.hasAttribute('is'));
 
   return (
     (nodeType === ELEMENT_NODE &&


### PR DESCRIPTION
## Summary

See https://github.com/ionic-team/stencil/pull/2789.

Stencil.js uses Jest under the hood for testing, and I ran into an issue where `pretty-format` throws an error because Stencil passes a `MockCSSStyleDeclaration` object which is proxied and returns an empty string for all unknown properties.

`pretty-format` assumes that if the given object has a `hasAttribute` property, that it's a function and just tries calling it, which fails in this case because the value of `val.hasAttribute` is `''` in this case. I know this is an edge case which is why I've suggested a fix on Stencil's side as well. However I thought it doesn't hurt to make this code more robust here as well.
