### PR TITLE
fix: print underlying error when global hooks fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-circus]` Fixed the issue of beforeAll & afterAll hooks getting executed even if it is inside a skipped `describe` block [#10451](https://github.com/facebook/jest/issues/10451)
 - `[jest-circus]` Fix `testLocation` on Windows when using `test.each` ([#10871](https://github.com/facebook/jest/pull/10871))
 - `[jest-cli]` Use testFailureExitCode when bailing from a failed test ([#10958](https://github.com/facebook/jest/pull/10958))
+- `[jest-cli]` Print custom error if error thrown from global hooks is not an error already ([#11003](https://github.com/facebook/jest/pull/11003))
 - `[jest-config]` [**BREAKING**] Change default file extension order by moving json behind ts and tsx ([10572](https://github.com/facebook/jest/pull/10572))
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))
 - `[jest-each]` [**BREAKING**] Ignore excess words in headings ([#8766](https://github.com/facebook/jest/pull/8766))

--- a/e2e/__tests__/globalSetup.test.ts
+++ b/e2e/__tests__/globalSetup.test.ts
@@ -71,8 +71,9 @@ test('jest throws an error when globalSetup does not export a function', () => {
   ]);
 
   expect(exitCode).toBe(1);
-  expect(stderr).toMatch(
-    `TypeError: globalSetup file must export a function at ${setupPath}`,
+  expect(stderr).toContain('Jest: Got error running globalSetup');
+  expect(stderr).toContain(
+    `globalSetup file must export a function at ${setupPath}`,
   );
 });
 
@@ -154,8 +155,9 @@ test('globalSetup throws with named export', () => {
   ]);
 
   expect(exitCode).toBe(1);
-  expect(stderr).toMatch(
-    `TypeError: globalSetup file must export a function at ${setupPath}`,
+  expect(stderr).toContain('Jest: Got error running globalSetup');
+  expect(stderr).toContain(
+    `globalSetup file must export a function at ${setupPath}`,
   );
 });
 

--- a/e2e/__tests__/globalTeardown.test.ts
+++ b/e2e/__tests__/globalTeardown.test.ts
@@ -55,8 +55,9 @@ test('jest throws an error when globalTeardown does not export a function', () =
   ]);
 
   expect(exitCode).toBe(1);
-  expect(stderr).toMatch(
-    `TypeError: globalTeardown file must export a function at ${teardownPath}`,
+  expect(stderr).toContain('Jest: Got error running globalTeardown');
+  expect(stderr).toContain(
+    `globalTeardown file must export a function at ${teardownPath}`,
   );
 });
 
@@ -125,7 +126,8 @@ test('globalTeardown throws with named export', () => {
   ]);
 
   expect(exitCode).toBe(1);
-  expect(stderr).toMatch(
-    `TypeError: globalTeardown file must export a function at ${teardownPath}`,
+  expect(stderr).toContain('Jest: Got error running globalTeardown');
+  expect(stderr).toContain(
+    `globalTeardown file must export a function at ${teardownPath}`,
   );
 });

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -37,7 +37,7 @@ export async function run(
   } catch (error) {
     clearLine(process.stderr);
     clearLine(process.stdout);
-    if (error.stack) {
+    if (error?.stack) {
       console.error(chalk.red(error.stack));
     } else {
       console.error(chalk.red(error));

--- a/packages/jest-core/src/runGlobalHook.ts
+++ b/packages/jest-core/src/runGlobalHook.ts
@@ -61,11 +61,13 @@ export default async ({
         });
       } catch (error) {
         if (util.types.isNativeError(error)) {
+          error.message = `Jest: Got error running ${moduleName} - ${modulePath}, reason: ${error.message}`;
+
           throw error;
         }
 
         throw new Error(
-          `Got error running ${moduleName} - ${modulePath}, reason: ${prettyFormat(
+          `Jest: Got error running ${moduleName} - ${modulePath}, reason: ${prettyFormat(
             error,
             {maxDepth: 3},
           )}`,

--- a/packages/jest-core/src/runGlobalHook.ts
+++ b/packages/jest-core/src/runGlobalHook.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as util from 'util';
 import pEachSeries = require('p-each-series');
 import {ScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
@@ -59,6 +60,10 @@ export default async ({
           await globalModule(globalConfig);
         });
       } catch (error) {
+        if (util.types.isNativeError(error)) {
+          throw error;
+        }
+
         throw new Error(
           `Got error running ${moduleName} - ${modulePath}, reason: ${prettyFormat(
             error,

--- a/packages/jest-core/src/runGlobalHook.ts
+++ b/packages/jest-core/src/runGlobalHook.ts
@@ -10,6 +10,7 @@ import {ScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import type {Test} from 'jest-runner';
 import {interopRequireDefault} from 'jest-util';
+import prettyFormat from 'pretty-format';
 
 export default async ({
   allTests,
@@ -29,7 +30,7 @@ export default async ({
   }
 
   if (globalModulePaths.size > 0) {
-    await pEachSeries(Array.from(globalModulePaths), async modulePath => {
+    await pEachSeries(globalModulePaths, async modulePath => {
       if (!modulePath) {
         return;
       }
@@ -45,17 +46,26 @@ export default async ({
 
       const transformer = new ScriptTransformer(projectConfig);
 
-      await transformer.requireAndTranspileModule(modulePath, async m => {
-        const globalModule = interopRequireDefault(m).default;
+      try {
+        await transformer.requireAndTranspileModule(modulePath, async m => {
+          const globalModule = interopRequireDefault(m).default;
 
-        if (typeof globalModule !== 'function') {
-          throw new TypeError(
-            `${moduleName} file must export a function at ${modulePath}`,
-          );
-        }
+          if (typeof globalModule !== 'function') {
+            throw new TypeError(
+              `${moduleName} file must export a function at ${modulePath}`,
+            );
+          }
 
-        await globalModule(globalConfig);
-      });
+          await globalModule(globalConfig);
+        });
+      } catch (error) {
+        throw new Error(
+          `Got error running ${moduleName} - ${modulePath}, reason: ${prettyFormat(
+            error,
+            {maxDepth: 3},
+          )}`,
+        );
+      }
     });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Could probably make the error more pretty, but this is _something_

Fixes #11002

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

before:
![image](https://user-images.githubusercontent.com/1404810/104016990-9a07ce80-51b7-11eb-8e7f-1fa4a2008935.png)


after:
![image](https://user-images.githubusercontent.com/1404810/104016941-85c3d180-51b7-11eb-83ed-e91cd720bafd.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
