### PR TITLE
feat(reporters): add static filepath property to all reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - `[jest-runner]` [**BREAKING**] Run transforms over `runnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runner]` [**BREAKING**] Run transforms over `testRunnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runtime, jest-transform]` share `cacheFS` between runtime and transformer ([#10901](https://github.com/facebook/jest/pull/10901))
-- `[jest-reporters]` Add static filepath property to all reporters
+- `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@
 - `[jest-haste-map]` Handle injected scm clocks ([#10966](https://github.com/facebook/jest/pull/10966))
 - `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
-- `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-runner]` [**BREAKING**] Run transforms over `runnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runner]` [**BREAKING**] Run transforms over `testRunnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runtime, jest-transform]` share `cacheFS` between runtime and transformer ([#10901](https://github.com/facebook/jest/pull/10901))
+- `[jest-reporters]` Add static filepath property to all reporters
+- `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -458,11 +458,11 @@ const createAggregatedResults = (numTotalTestSuites: number) => {
 };
 
 const getEstimatedTime = (timings: Array<number>, workers: number) => {
-  if (!timings.length) {
+  if (timings.length === 0) {
     return 0;
   }
 
-  const max = Math.max.apply(null, timings);
+  const max = Math.max(...timings);
   return timings.length <= workers
     ? max
     : Math.max(timings.reduce((sum, time) => sum + time) / workers, max);

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -50,6 +50,8 @@ export default class CoverageReporter extends BaseReporter {
   private _options: CoverageReporterOptions;
   private _v8CoverageResults: Array<V8CoverageResult>;
 
+  static readonly filename = __filename;
+
   constructor(
     globalConfig: Config.GlobalConfig,
     options?: CoverageReporterOptions,

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -33,6 +33,8 @@ export default class DefaultReporter extends BaseReporter {
   private _status: Status;
   private _bufferedOutput: Set<FlushBufferedOutput>;
 
+  static readonly filename = __filename;
+
   constructor(globalConfig: Config.GlobalConfig) {
     super();
     this._globalConfig = globalConfig;

--- a/packages/jest-reporters/src/NotifyReporter.ts
+++ b/packages/jest-reporters/src/NotifyReporter.ts
@@ -24,6 +24,8 @@ export default class NotifyReporter extends BaseReporter {
   private _globalConfig: Config.GlobalConfig;
   private _context: TestSchedulerContext;
 
+  static readonly filename = __filename;
+
   constructor(
     globalConfig: Config.GlobalConfig,
     startRun: (globalConfig: Config.GlobalConfig) => unknown,

--- a/packages/jest-reporters/src/SummaryReporter.ts
+++ b/packages/jest-reporters/src/SummaryReporter.ts
@@ -54,6 +54,8 @@ export default class SummaryReporter extends BaseReporter {
   private _estimatedTime: number;
   private _globalConfig: Config.GlobalConfig;
 
+  static readonly filename = __filename;
+
   constructor(globalConfig: Config.GlobalConfig) {
     super();
     this._globalConfig = globalConfig;

--- a/packages/jest-reporters/src/VerboseReporter.ts
+++ b/packages/jest-reporters/src/VerboseReporter.ts
@@ -22,6 +22,8 @@ const {ICONS} = specialChars;
 export default class VerboseReporter extends DefaultReporter {
   protected _globalConfig: Config.GlobalConfig;
 
+  static readonly filename = __filename;
+
   constructor(globalConfig: Config.GlobalConfig) {
     super(globalConfig);
     this._globalConfig = globalConfig;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://github.com/jevakallio/jest-clean-console-reporter documents a pattern of doing

```
    // Overriding config.reporters wipes out default reporters, so
    // we need to restore the summary reporter
    "@jest/reporters/build/SummaryReporter",
```

This won't work in Jest 27 due to #9921.

```sh-session
$ node -p 'require("@jest/reporters/build/SummaryReporter")'

internal/modules/cjs/loader.js:438
      throw e;
      ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './build/SummaryReporter' is not defined by "exports" in /Users/simen/repos/jest/node_modules/@jest/reporters/package.json
    at throwExportsNotFound (internal/modules/esm/resolve.js:290:9)
    at packageExportsResolve (internal/modules/esm/resolve.js:513:3)
    at resolveExports (internal/modules/cjs/loader.js:432:36)
    at Function.Module._findPath (internal/modules/cjs/loader.js:472:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:867:27)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at [eval]:1:1
    at Script.runInThisContext (vm.js:133:18) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

This change allows one to do

```js
const {SummaryReporter} = require('@jest/reporters');

// this absolute path can be passed to `require`
const path = SummaryReporter.filepath;
```

/cc @jevakallio

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tested in the shell 😅 

```sh-session
$ node -p 'require("@jest/reporters").SummaryReporter.filename'

/Users/simen/repos/jest/packages/jest-reporters/build/SummaryReporter.js
```

```sh-session
$ node -p 'require(require("@jest/reporters").SummaryReporter.filename)'

{
  default: [class SummaryReporter extends BaseReporter] {
    filename: '/Users/simen/repos/jest/packages/jest-reporters/build/SummaryReporter.js'
  }
}
```

And since we handle `default` "export" from CJS, this should work fine 👍 

https://github.com/facebook/jest/blob/f0dc9932cba828a1c51ef842c00c1ca51b7f2796/packages/jest-core/src/TestScheduler.ts#L392

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
