### PR TITLE
doc: update toHaveBeenCalledWith to include type of equality check

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -676,7 +676,7 @@ test('drinkEach drinks each drink', () => {
 
 Also under the alias: `.toBeCalledWith()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments.
+Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The specific arguments are checked with a `.toEqual` call.
 
 For example, let's say that you can register a beverage with a `register` function, and `applyToAll(f)` should apply the function `f` to all registered beverages. To make sure this works, you could write:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The documentation for `.toHaveBeenCalledWith` doesn't state the type of equality check performed on the argument. 

This means that anyone expecting the object argument used in the mock function `.toStrictEqual` the passed argument will be confused as the call is actually `.toEqual` and doesn't compare object classes.

```
 FAIL  ./index.test.js
  ✕ toHaveBeenCalledWith doesn't compare objects strictly (22 ms)

  ● toHaveBeenCalledWith doesn't compare objects strictly

    expect(received).toStrictEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

    - Object {
    + AClass {
        "id": 1,
        "name": "Parent A",
      }

       9 |   expect(utils.f2).toHaveBeenCalledWith(data) // passes
      10 |   expect(utils.f2.mock.calls[0][0]).toEqual(data) // passes
    > 11 |   expect(utils.f2.mock.calls[0][0]).toStrictEqual(data) // fails  
         |                                     ^
      12 | })
      13 | 
```

See https://github.com/byrne-greg/jest-toHaveBeenCalledWith-equal-example/blob/main/index.test.js as an example

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
