### PR TITLE
fix: int keys ranging outside of [0, 4294967294] are ignored when comparing arrays together

### DIFF
--- a/e2e/to-match-inline-snapshot/__tests__/basic-support.test.js
+++ b/e2e/to-match-inline-snapshot/__tests__/basic-support.test.js
@@ -1,0 +1,6 @@
+test('inline snapshots', () =>
+expect({apple: 'updated value'}).toMatchInlineSnapshot(`
+  Object {
+    "apple": "original value",
+  }
+`));

--- a/e2e/to-match-inline-snapshot/__tests__/basic-support.test.js
+++ b/e2e/to-match-inline-snapshot/__tests__/basic-support.test.js
@@ -1,6 +1,0 @@
-test('inline snapshots', () =>
-expect({apple: 'updated value'}).toMatchInlineSnapshot(`
-  Object {
-    "apple": "original value",
-  }
-`));

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2078,6 +2078,20 @@ Expected: <g>[]</>
 Received: serializes to the same string
 `;
 
+exports[`.toEqual() {pass: false} expect([]).toEqual([]) 2`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>[]</>
+Received: serializes to the same string
+`;
+
+exports[`.toEqual() {pass: false} expect([]).toEqual([]) 3`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>[]</>
+Received: serializes to the same string
+`;
+
 exports[`.toEqual() {pass: false} expect([]).toEqual([1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2071,6 +2071,25 @@ Expected: <g>/abc/g</>
 Received: <r>/abc/gsy</>
 `;
 
+exports[`.toEqual() {pass: false} expect([]).toEqual([]) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>[]</>
+Received: serializes to the same string
+`;
+
+exports[`.toEqual() {pass: false} expect([]).toEqual([1]) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 3</>
+<r>+ Received  + 1</>
+
+<g>- Array [</>
+<g>-   1,</>
+<g>- ]</>
+<r>+ Array []</>
+`;
+
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -598,6 +598,14 @@ describe('.toEqual()', () => {
         [Symbol.for('bar')]: 1,
       },
     ],
+    [
+      Object.assign([], {4294967295: 1}),
+      Object.assign([], {4294967295: 2}), // issue 11056
+    ],
+    [
+      Object.assign([], {['-0']: 1}),
+      Object.assign([], {['0']: 1}), // issue 11056: add check for -0, 0
+    ],
   ].forEach(([a, b]) => {
     test(`{pass: false} expect(${stringify(a)}).toEqual(${stringify(
       b,

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -603,8 +603,18 @@ describe('.toEqual()', () => {
       Object.assign([], {4294967295: 2}), // issue 11056
     ],
     [
+      // eslint-disable-next-line no-useless-computed-key
       Object.assign([], {['-0']: 1}),
-      Object.assign([], {['0']: 1}), // issue 11056: add check for -0, 0
+      // eslint-disable-next-line no-useless-computed-key
+      Object.assign([], {['0']: 1}), // issue 11056: also check (-0, 0)
+    ],
+    [
+      Object.assign([], {a: 1}),
+      Object.assign([], {b: 1}), // issue 11056: also check strings
+    ],
+    [
+      Object.assign([], {[Symbol()]: 1}),
+      Object.assign([], {[Symbol()]: 1}), // issue 11056: also check symbols
     ],
   ].forEach(([a, b]) => {
     test(`{pass: false} expect(${stringify(a)}).toEqual(${stringify(

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -198,7 +198,7 @@ function keys(
   isArray: boolean,
   hasKey: (obj: object, key: string) => boolean,
 ) {
-  var allKeys = (function(o) {
+  var allKeys = (function (o) {
     var keys = [];
     for (var key in o) {
       if (hasKey(o, key)) {
@@ -224,7 +224,11 @@ function keys(
   }
 
   for (var x = 0; x < allKeys.length; x++) {
-    if (typeof allKeys[x] === 'symbol' || !allKeys[x].match(/^[0-9]+$/)) {
+    if (
+      typeof allKeys[x] === 'symbol' ||
+      !allKeys[x].match(/^[0-9]+$/) ||
+      Number(allKeys[x]) >= 4294967295
+    ) {
       extraKeys.push(allKeys[x]);
     }
   }

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -198,7 +198,7 @@ function keys(
   isArray: boolean,
   hasKey: (obj: object, key: string) => boolean,
 ) {
-  var allKeys = (function (o) {
+  var allKeys = (function(o) {
     var keys = [];
     for (var key in o) {
       if (hasKey(o, key)) {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This Pull Request fixes #11056.

`arr1` and `arr2` are now said to be different in the code below:
```js
test('should not pass', () => {
  const arr1 = [];
  arr1[4294967295] = 1;
  const arr2 = [];
  arr2[4294967295] = 2;
  expect(arr2).not.toEqual(arr1);
});
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Test added
