### PR TITLE
move from source-map to source-map-sync

### DIFF
--- a/e2e/coverage-handlebars/transform-handlebars.js
+++ b/e2e/coverage-handlebars/transform-handlebars.js
@@ -6,7 +6,7 @@
  */
 
 const Handlebars = require('handlebars/dist/cjs/handlebars.js');
-const {SourceMapConsumer, SourceNode} = require('source-map');
+const {SourceMapConsumer, SourceNode} = require('source-map-js');
 
 exports.process = (code, filename) => {
   const pc = Handlebars.precompile(code, {srcName: filename});

--- a/e2e/coverage-handlebars/transform-handlebars.js
+++ b/e2e/coverage-handlebars/transform-handlebars.js
@@ -6,15 +6,17 @@
  */
 
 const Handlebars = require('handlebars/dist/cjs/handlebars.js');
-const {SourceMapConsumer, SourceNode} = require('source-map-js');
+const {SourceMapConsumer, SourceNode} = require('source-map-sync');
 
 exports.process = (code, filename) => {
   const pc = Handlebars.precompile(code, {srcName: filename});
+  const consumer = new SourceMapConsumer(pc.map);
   const out = new SourceNode(null, null, null, [
     'const Handlebars = require("handlebars/dist/cjs/handlebars.runtime.js");\n',
     'module.exports = Handlebars.template(',
-    SourceNode.fromStringWithSourceMap(pc.code, new SourceMapConsumer(pc.map)),
+    SourceNode.fromStringWithSourceMap(pc.code, consumer),
     ');\n',
   ]).toStringWithSourceMap();
+  consumer.destroy();
   return {code: out.code, map: out.map.toString()};
 };

--- a/packages/jest-jasmine2/src/jasmine/Spec.ts
+++ b/packages/jest-jasmine2/src/jasmine/Spec.ts
@@ -69,6 +69,7 @@ export type SpecResult = {
   pendingReason: string;
   status: Status;
   __callsite?: {
+    destroy: () => void;
     getColumnNumber: () => number;
     getLineNumber: () => number;
   };

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -138,6 +138,7 @@ export default class Jasmine2Reporter implements Reporter {
           line: specResult.__callsite.getLineNumber(),
         }
       : null;
+    if (specResult.__callsite) specResult.__callsite.destroy();
     const results: AssertionResult = {
       ancestorTitles,
       duration,

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -29,7 +29,7 @@
     "jest-util": "^27.0.0-next.1",
     "jest-worker": "^27.0.0-next.2",
     "slash": "^3.0.0",
-    "source-map": "^0.6.0",
+    "source-map-js": "^0.6.2",
     "string-length": "^4.0.1",
     "terminal-link": "^2.0.0",
     "v8-to-istanbul": "^7.0.0"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -29,7 +29,7 @@
     "jest-util": "^27.0.0-next.1",
     "jest-worker": "^27.0.0-next.2",
     "slash": "^3.0.0",
-    "source-map-js": "^0.6.2",
+    "source-map-sync": "^0.8.0-beta.1",
     "string-length": "^4.0.1",
     "terminal-link": "^2.0.0",
     "v8-to-istanbul": "^7.0.0"

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -14,7 +14,7 @@ import istanbulCoverage = require('istanbul-lib-coverage');
 import istanbulReport = require('istanbul-lib-report');
 import libSourceMaps = require('istanbul-lib-source-maps');
 import istanbulReports = require('istanbul-reports');
-import type {RawSourceMap} from 'source-map';
+import type {RawSourceMap} from 'source-map-js';
 import v8toIstanbul = require('v8-to-istanbul');
 import type {
   AggregatedResult,

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -14,7 +14,7 @@ import istanbulCoverage = require('istanbul-lib-coverage');
 import istanbulReport = require('istanbul-lib-report');
 import libSourceMaps = require('istanbul-lib-source-maps');
 import istanbulReports = require('istanbul-reports');
-import type {RawSourceMap} from 'source-map-js';
+import type {RawSourceMap} from 'source-map-sync';
 import v8toIstanbul = require('v8-to-istanbul');
 import type {
   AggregatedResult,
@@ -35,7 +35,7 @@ import type {
 } from './types';
 
 // This is fixed in a newer versions of source-map, but our dependencies are still stuck on old versions
-interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
+interface FixedRawSourceMap extends Omit<RawSourceMap, 'version' | 'file'> {
   version: number;
   file?: string;
 }

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "callsites": "^3.0.0",
     "graceful-fs": "^4.2.4",
-    "source-map-js": "^0.6.2"
+    "source-map-sync": "^0.8.0-beta.1"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.2"

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "callsites": "^3.0.0",
     "graceful-fs": "^4.2.4",
-    "source-map": "^0.6.0"
+    "source-map-js": "^0.6.2"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.2"

--- a/packages/jest-source-map/src/__tests__/getCallsite.test.ts
+++ b/packages/jest-source-map/src/__tests__/getCallsite.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as fs from 'graceful-fs';
-import SourceMap from 'source-map';
+import SourceMap from 'source-map-js';
 import getCallsite from '../getCallsite';
 
 // Node 10.5.x compatibility

--- a/packages/jest-source-map/src/__tests__/getCallsite.test.ts
+++ b/packages/jest-source-map/src/__tests__/getCallsite.test.ts
@@ -6,7 +6,7 @@
  */
 
 import * as fs from 'graceful-fs';
-import SourceMap from 'source-map-js';
+import SourceMap from 'source-map-sync';
 import getCallsite from '../getCallsite';
 
 // Node 10.5.x compatibility

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -7,7 +7,7 @@
 
 import callsites = require('callsites');
 import {readFileSync} from 'graceful-fs';
-import {SourceMapConsumer} from 'source-map';
+import {SourceMapConsumer} from 'source-map-js';
 import type {SourceMapRegistry} from './types';
 
 // Copied from https://github.com/rexxars/sourcemap-decorate-callsites/blob/5b9735a156964973a75dc62fd2c7f0c1975458e8/lib/index.js#L113-L158

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -27,7 +27,7 @@
     "micromatch": "^4.0.2",
     "pirates": "^4.0.1",
     "slash": "^3.0.0",
-    "source-map-js": "^0.6.2",
+    "source-map-sync": "^0.8.0-beta.1",
     "write-file-atomic": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -27,7 +27,7 @@
     "micromatch": "^4.0.2",
     "pirates": "^4.0.1",
     "slash": "^3.0.0",
-    "source-map": "^0.6.1",
+    "source-map-js": "^0.6.2",
     "write-file-atomic": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {RawSourceMap} from 'source-map';
+import type {RawSourceMap} from 'source-map-js';
 import type {Config, TransformTypes} from '@jest/types';
 
 export type ShouldInstrumentOptions = Pick<

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {RawSourceMap} from 'source-map-js';
+import type {RawSourceMap} from 'source-map-sync';
 import type {Config, TransformTypes} from '@jest/types';
 
 export type ShouldInstrumentOptions = Pick<

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,7 +2007,7 @@ __metadata:
     jest-worker: ^27.0.0-next.2
     mock-fs: ^4.4.1
     slash: ^3.0.0
-    source-map: ^0.6.0
+    source-map-js: ^0.6.2
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
     terminal-link: ^2.0.0
@@ -2027,7 +2027,7 @@ __metadata:
     "@types/graceful-fs": ^4.1.2
     callsites: ^3.0.0
     graceful-fs: ^4.2.4
-    source-map: ^0.6.0
+    source-map-js: ^0.6.2
   languageName: unknown
   linkType: soft
 
@@ -2130,7 +2130,7 @@ __metadata:
     micromatch: ^4.0.2
     pirates: ^4.0.1
     slash: ^3.0.0
-    source-map: ^0.6.1
+    source-map-js: ^0.6.2
     write-file-atomic: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -18066,6 +18066,13 @@ react-native@0.63.2:
   dependencies:
     is-plain-obj: ^1.0.0
   checksum: c0437ce7fbcc35e6f255f46cc4ba350cadac3199f4af3ee8c8b305f50a35b6ead4fec814a4d86ffa49c8ec9e5bf064877232a7d45270c6e31f725209a1c4ef3d
+  languageName: node
+  linkType: hard
+
+"source-map-js@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "source-map-js@npm:0.6.2"
+  checksum: 8e2f992cfbedb71286fa6f6e011e2fa756b7f4d944ea4b0f49e9ff6ea34ad0a17dc655f067fdddb32efa7b45000e8c59e47a2e875d91744c86a56329b5f58b32
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2007,7 +2007,7 @@ __metadata:
     jest-worker: ^27.0.0-next.2
     mock-fs: ^4.4.1
     slash: ^3.0.0
-    source-map-js: ^0.6.2
+    source-map-sync: ^0.8.0-beta.1
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
     terminal-link: ^2.0.0
@@ -2027,7 +2027,7 @@ __metadata:
     "@types/graceful-fs": ^4.1.2
     callsites: ^3.0.0
     graceful-fs: ^4.2.4
-    source-map-js: ^0.6.2
+    source-map-sync: ^0.8.0-beta.1
   languageName: unknown
   linkType: soft
 
@@ -2130,7 +2130,7 @@ __metadata:
     micromatch: ^4.0.2
     pirates: ^4.0.1
     slash: ^3.0.0
-    source-map-js: ^0.6.2
+    source-map-sync: ^0.8.0-beta.1
     write-file-atomic: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -18069,13 +18069,6 @@ react-native@0.63.2:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^0.6.2":
-  version: 0.6.2
-  resolution: "source-map-js@npm:0.6.2"
-  checksum: 8e2f992cfbedb71286fa6f6e011e2fa756b7f4d944ea4b0f49e9ff6ea34ad0a17dc655f067fdddb32efa7b45000e8c59e47a2e875d91744c86a56329b5f58b32
-  languageName: node
-  linkType: hard
-
 "source-map-resolve@npm:^0.5.0":
   version: 0.5.3
   resolution: "source-map-resolve@npm:0.5.3"
@@ -18106,6 +18099,15 @@ react-native@0.63.2:
     buffer-from: ^1.0.0
     source-map: ^0.6.0
   checksum: e4877c5d653fcce19d8f1d0b697cd6f435632cb26275699b580fc7bb6d3146bb49aceee2cb9b3159fd66747ce34e8dd9b348b9aecdae22bcc41c5e841e901dfa
+  languageName: node
+  linkType: hard
+
+"source-map-sync@npm:^0.8.0-beta.1":
+  version: 0.8.0-beta.1
+  resolution: "source-map-sync@npm:0.8.0-beta.1"
+  dependencies:
+    whatwg-url: ^7.0.0
+  checksum: a45bf3b3075404b80794a890f43addd75d0eb1d7c2694f6d9c60284e5942945d051e66b13de6a7f13be5e99ca8b0b775ec334aff347a8a02cd21afc8b08268c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I made the fork of source-map that introduces sync API, but still uses WASM.
You can compare changes to original versions [here](https://github.com/7rulnik/source-map-sync/pull/1) 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

source-map-sync uses the same unit test as the original source-map, but not sure that enough