### PR TITLE
Fix Yarn Crowdin scripts

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -8,14 +8,12 @@
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "serve": "docusaurus serve",
-    "crowdin:upload": "cd .. && crowdin upload sources --config crowdin-v2.yaml",
-    "crowdin:downloadTranslations": "cd .. && crowdin download --config crowdin-v2.yaml",
     "write-translations": "docusaurus write-translations",
     "fetchSupporters": "node fetchSupporters.js",
     "netlify:ci:production": "yarn netlify:prepare && yarn netlify:crowdin && yarn build",
     "netlify:ci:deployPreview": "yarn netlify:prepare && yarn build -l en",
     "netlify:prepare": "yarn fetchSupporters && yarn build:js",
-    "netlify:crowdin": "yarn write-translations && yarn workspace @jest/monorepo crowdin:upload && yarn workspace @jest/monorepo crowdin:download"
+    "netlify:crowdin": "yarn write-translations && yarn crowdin:upload && yarn crowdin:download"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.dbfa256a7",

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "netlify:ci:production": "yarn netlify:prepare && yarn netlify:crowdin && yarn build",
     "netlify:ci:deployPreview": "yarn netlify:prepare && yarn build -l en",
     "netlify:prepare": "yarn fetchSupporters && yarn build:js",
-    "netlify:crowdin": "yarn write-translations && yarn crowdin:upload && yarn crowdin:download"
+    "netlify:crowdin": "yarn write-translations && yarn workspace @jest/monorepo crowdin:upload && yarn workspace @jest/monorepo crowdin:download"
   },
   "dependencies": {
     "@docusaurus/core": "2.0.0-alpha.dbfa256a7",


### PR DESCRIPTION
## Summary

@SimenB @merceyz the change made here:
https://github.com/jest-website-migration/jest/commit/fd34cd0cf64f0f1d0b0750400a65914c65b65df8

It broke Crowdin translation download (didn't notice)
Crowdin is quite sensitive to the path from which you call its cli, and it seems using the `:` and global yarn script does not run from the place where the cli is declared, unlike `yarn workspace`.

![image](https://user-images.githubusercontent.com/749374/107804368-1b78f080-6d64-11eb-849e-4513fcc45a5c.png)

![image](https://user-images.githubusercontent.com/749374/107804433-2e8bc080-6d64-11eb-94b5-1e90496667ce.png)


## Test plan

Netlify preview works
