### PR TITLE
fix: Allow searching for tests in `node_modules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-jasmine2, jest-types]` [**BREAKING**] Move all `jasmine` specific types from `@jest/types` to its own package ([#12125](https://github.com/facebook/jest/pull/12125))
 - `[jest-matcher-utils]` Pass maxWidth to `pretty-format` to avoid printing every element in arrays by default ([#12402](https://github.com/facebook/jest/pull/12402))
 - `[jest-mock]` Fix function overloads for `spyOn` to allow more correct type inference in complex object ([#12442](https://github.com/facebook/jest/pull/12442))
+- `[jest-config]` Allow searching for tests in node_modules by exposing `retainAllFiles` ([#11084](https://github.com/facebook/jest/pull/11084))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,12 +24,12 @@
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[jest-config]` Correctly detect CI environment and update snapshots accordingly ([#12378](https://github.com/facebook/jest/pull/12378))
 - `[jest-config]` Pass `moduleTypes` to `ts-node` to enforce CJS when transpiling ([#12397](https://github.com/facebook/jest/pull/12397))
+- `[jest-config, jest-haste-map]` Allow searching for tests in `node_modules` by exposing `retainAllFiles` ([#11084](https://github.com/facebook/jest/pull/11084))
 - `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
 - `[jest-haste-map]` Don't use partial results if file crawl errors ([#12420](https://github.com/facebook/jest/pull/12420))
 - `[jest-jasmine2, jest-types]` [**BREAKING**] Move all `jasmine` specific types from `@jest/types` to its own package ([#12125](https://github.com/facebook/jest/pull/12125))
 - `[jest-matcher-utils]` Pass maxWidth to `pretty-format` to avoid printing every element in arrays by default ([#12402](https://github.com/facebook/jest/pull/12402))
 - `[jest-mock]` Fix function overloads for `spyOn` to allow more correct type inference in complex object ([#12442](https://github.com/facebook/jest/pull/12442))
-- `[jest-config]` Allow searching for tests in node_modules by exposing `retainAllFiles` ([#11084](https://github.com/facebook/jest/pull/11084))
 
 ### Chore & Maintenance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -511,6 +511,8 @@ type HasteConfig = {
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;
+  /** Whether to retain all files, allowing e.g. search for tests in `node_modules`. */
+  retainAllFiles?: boolean;
 };
 ```
 

--- a/e2e/__tests__/retainAllFiles.test.ts
+++ b/e2e/__tests__/retainAllFiles.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+describe('Retain All Files Integration', () => {
+  test('valid test within node_modules', () => {
+    const {exitCode, stdout} = runJest('retain-all-files');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('I am running from within node_modules');
+  });
+});

--- a/e2e/retain-all-files/node_modules/retainAllFiles.test.js
+++ b/e2e/retain-all-files/node_modules/retainAllFiles.test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+describe('Test in node_modules', () => {
+  test('gets run', () => {
+    console.log('I am running from within node_modules');
+    expect(true).toBe(true);
+  });
+});

--- a/e2e/retain-all-files/package.json
+++ b/e2e/retain-all-files/package.json
@@ -1,0 +1,9 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [],
+    "haste": {
+      "retainAllFiles": true
+    }
+  }
+}

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -64,6 +64,7 @@ const initialOptions: Config.InitialOptions = {
     hasteImplModulePath: '<rootDir>/haste_impl.js',
     hasteMapModulePath: '',
     platforms: ['ios', 'android'],
+    retainAllFiles: false,
     throwOnModuleCollision: false,
   },
   injectGlobals: true,

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -57,6 +57,7 @@ export type WorkerMessage = {
   rootDir: string;
   filePath: string;
   hasteImplModulePath?: string;
+  retainAllFiles?: boolean;
 };
 
 export type WorkerMetadata = {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -386,7 +386,7 @@ export default class Runtime {
       name: config.name,
       platforms: config.haste.platforms || ['ios', 'android'],
       resetCache: options?.resetCache,
-      retainAllFiles: false,
+      retainAllFiles: config.haste.retainAllFiles || false,
       rootDir: config.rootDir,
       roots: config.roots,
       throwOnModuleCollision: config.haste.throwOnModuleCollision,

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -35,6 +35,8 @@ export type HasteConfig = {
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;
+  /** Whether to retain all files, allowing e.g. search for tests in `node_modules`. */
+  retainAllFiles?: boolean;
 };
 
 export type CoverageReporterName = keyof ReportOptions;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

In order to be able to inherit a common Jest test from an npm module, the user needs to be able to search for tests in the node_modules directory. The boolean "retainAllFiles" had been hard-coded to false, preventing this inheritance from being possible. The changes here expose the variable via the "haste" configuration property and allow the user to optionally scan the node_modules for test patterns.

## Test plan

```
$ npx jest --testRegex "/*(.pact.test.js)" --runInBand
 PASS  test/src/Health.pact.test.js (9.646 s)
 PASS  node_modules/@aw/node-testing/dist/test/health.pact.test.js (5.922 s)

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        15.733 s
Ran all test suites.
```
