### PR TITLE
add redirect for Jest blog feed

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -27,3 +27,7 @@
 /ru/*         /ru/404.html          404
 /uk/*         /uk/404.html          404
 /zh-Hans/*    /zh-Hans/404.html     404
+
+
+# Redirect Docusaurus v1 blog RSS feed
+/blog/feed.xml   /blog/rss.xml


### PR DESCRIPTION
## Summary

- Docusaurus v1 RSS feed: https://jestjs.io/blog/feed.xml
- Docusaurus v2 RSS feed: https://jestjs.netlify.app/blog/rss.xml

Redirect /blog/feed.xml to /blog/rss.xml so that feed subscribers can keep using their feeds after the migration.

The following URL should work: https://jestjs.netlify.app/blog/feed.xml

CC @SimenB 

