### PR TITLE
Fix site inline TOC for mock functions api page

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -9,7 +9,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 import TOCInline from "@theme/TOCInline"
 
-<TOCInline toc={toc[toc.length - 1].children}/>
+<TOCInline toc={toc.slice(1)}/>
 
 ---
 

--- a/website/versioned_docs/version-25.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-25.x/MockFunctionAPI.md
@@ -9,7 +9,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 import TOCInline from "@theme/TOCInline"
 
-<TOCInline toc={toc[toc.length - 1].children}/>
+<TOCInline toc={toc.slice(1)}/>
 
 ---
 

--- a/website/versioned_docs/version-26.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-26.x/MockFunctionAPI.md
@@ -9,7 +9,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 import TOCInline from "@theme/TOCInline"
 
-<TOCInline toc={toc[toc.length - 1].children}/>
+<TOCInline toc={toc.slice(1)}/>
 
 ---
 


### PR DESCRIPTION
## Summary

The inline TOC (in Methods section) is wrong on this page and does not look like it used to in v1.

https://jestjs.netlify.app/docs/mock-function-api

![image](https://user-images.githubusercontent.com/749374/108483615-3636f200-729b-11eb-9a1c-81930ab8fd04.png)

In v1 we had a flat structure mixing references + typescript methods:

https://jestjs.io/docs/en/mock-function-api

![image](https://user-images.githubusercontent.com/749374/108483747-5c5c9200-729b-11eb-87ee-527db8105728.png)

This PR fixes the issue, but also decided that it would be better to keep the non-flat structure:

![image](https://user-images.githubusercontent.com/749374/108483864-7dbd7e00-729b-11eb-94e4-3a086066ade6.png)

## Test plan

Preview