### PR TITLE
@jest/transform to allow `exports.default` transform

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -191,7 +191,9 @@ export default class ScriptTransformer {
       return cached;
     }
 
-    let transformer: Transformer = interopRequireDefault(require(transformPath));
+    let transformer: Transformer = interopRequireDefault(
+      require(transformPath),
+    );
     if ('default' in (transformer as any)) {
       transformer = (transformer as any).default;
     }

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -192,6 +192,9 @@ export default class ScriptTransformer {
     }
 
     let transformer: Transformer = require(transformPath);
+    if ('__esModule' in transformer && 'default' in transformer) {
+      transformer = transformer.default;
+    }
 
     if (!transformer) {
       throw new TypeError('Jest: a transform must export something.');

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -191,8 +191,8 @@ export default class ScriptTransformer {
       return cached;
     }
 
-    let transformer: Transformer = require(transformPath);
-    if ('__esModule' in transformer && 'default' in (transformer as any)) {
+    let transformer: Transformer = interopRequireDefault(require(transformPath));
+    if ('default' in (transformer as any)) {
       transformer = (transformer as any).default;
     }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -192,7 +192,7 @@ export default class ScriptTransformer {
     }
 
     let transformer: Transformer = require(transformPath);
-    if ('__esModule' in transformer && 'default' in transformer) {
+    if ('__esModule' in transformer && 'default' in (transformer as any)) {
       transformer = transformer.default;
     }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -193,7 +193,7 @@ export default class ScriptTransformer {
 
     let transformer: Transformer = require(transformPath);
     if ('__esModule' in transformer && 'default' in (transformer as any)) {
-      transformer = transformer.default;
+      transformer = (transformer as any).default;
     }
 
     if (!transformer) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Currently if you supply `@jest/transform` a path to a script that uses `exports.default` instead of `module.exports` it blows up:

```
TypeError: Jest: a transform must export a `process` function.

      at ScriptTransformer._getTransformer (node_modules/@jest/transform/build/ScriptTransformer.js:360:13)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:427:28)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:569:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:607:25)
```

## Test plan
N/A