### PR TITLE
Fix some inaccurate types in @jest/types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[jest-worker]` Do not swallow errors during serialization ([#10984](https://github.com/facebook/jest/pull/10984))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 - `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
+- `[jest-types]` Fix inaccurate/missing types ([#11115](https://github.com/facebook/jest/pull/11115))
 
 ### Chore & Maintenance
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -176,7 +176,7 @@ export type InitialOptions = Partial<{
   preprocessorIgnorePatterns: Array<Glob>;
   preset: string | null | undefined;
   prettierPath: string | null | undefined;
-  projects: Array<Glob>;
+  projects: Array<Glob | Partial<ProjectConfig>>;
   replname: string | null | undefined;
   resetMocks: boolean;
   resetModules: boolean;
@@ -322,7 +322,7 @@ export type ProjectConfig = {
   dependencyExtractor?: string;
   detectLeaks: boolean;
   detectOpenHandles: boolean;
-  displayName?: DisplayName;
+  displayName?: string | DisplayName;
   errorOnDeprecated: boolean;
   extensionsToTreatAsEsm: Array<Path>;
   extraGlobals: Array<keyof NodeJS.Global>;
@@ -340,6 +340,7 @@ export type ProjectConfig = {
   modulePathIgnorePatterns: Array<string>;
   modulePaths?: Array<string>;
   name: string;
+  preset?: string;
   prettierPath: string;
   resetMocks: boolean;
   resetModules: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This fixes a few inaccurate types I came across while trying to use `Config.InitialOptions` from the `@jest/types` package. The fact that I came across so many leads me to believe there are others, but I don't have time to check every possible key.

- **Fixed the `projects` definition for initial options.** Instead of just accepting an array of strings, it now also accepts arrays that contain partial project configurations ([documentation](https://jestjs.io/docs/en/configuration#projects-arraystring--projectconfig)).
- **Fixed the `displayName` definition for project config.** This can now accept just a `string`, in addition to objects ([documentation](https://jestjs.io/docs/en/configuration#displayname-string-object)).
- **Added the `preset` key for project config.** This was missing ([documentation](https://jestjs.io/docs/en/configuration#preset-string)).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I modified the `Config.d.ts` file locally with these changes and ensured it fixed the errors I was encountering in the `jest.config.ts` file I was writing.