### PR TITLE
fix(): jest should not count PerformanceObserver as an open handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixes
 
+- `[jest-core]` Don't report PerformanceObserver as open handle ([#11123](https://github.com/facebook/jest/pull/11123))
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 
 ### Fixes
 
-- `[jest-core]` Don't report PerformanceObserver as open handle ([#11123](https://github.com/facebook/jest/pull/11123))
 - `[babel-plugin-jest-hoist]` Add `__dirname` and `__filename` to whitelisted globals ([#10903](https://github.com/facebook/jest/pull/10903))
 - `[expect]` [**BREAKING**] Revise `expect.not.objectContaining()` to be the inverse of `expect.objectContaining()`, as documented. ([#10708](https://github.com/facebook/jest/pull/10708))
 - `[expect]` [**BREAKING**] Make `toContain` more strict with the received type ([#10119](https://github.com/facebook/jest/pull/10119) & [#10929](https://github.com/facebook/jest/pull/10929))
@@ -36,6 +35,7 @@
 - `[jest-cli]` Print custom error if error thrown from global hooks is not an error already ([#11003](https://github.com/facebook/jest/pull/11003))
 - `[jest-config]` [**BREAKING**] Change default file extension order by moving json behind ts and tsx ([10572](https://github.com/facebook/jest/pull/10572))
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))
+- `[jest-core]` Don't report PerformanceObserver as open handle ([#11123](https://github.com/facebook/jest/pull/11123))
 - `[jest-each]` [**BREAKING**] Ignore excess words in headings ([#8766](https://github.com/facebook/jest/pull/8766))
 - `[jest-environment-jsdom]` Use inner realm’s `ArrayBuffer` constructor ([#10885](https://github.com/facebook/jest/pull/10885))
 - `[jest-globals]` [**BREAKING**] Disallow return values other than a `Promise` from hooks and tests ([#10512](https://github.com/facebook/jest/pull/10512))

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -31,5 +31,6 @@ describe('collectHandles', () => {
     const openHandles = handleCollector();
 
     expect(openHandles.length).toEqual(0);
+    obs.disconnect();
   });
 });

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {PerformanceObserver} from 'perf_hooks';
+import collectHandles from '../collectHandles';
+
+describe('collectHandles', () => {
+  it('should collect Timeout', () => {
+    const handleCollector = collectHandles();
+
+    const interval = setInterval(() => {}, 100);
+
+    const openHandles = handleCollector();
+
+    expect(openHandles.length).toEqual(1);
+    expect(openHandles[0].message).toContain('Timeout');
+
+    clearInterval(interval);
+  });
+
+  it('should not collect the PerformanceObserver open handle', () => {
+    const handleCollector = collectHandles();
+    const obs = new PerformanceObserver((list, observer) => {});
+    obs.observe({entryTypes: ['mark']});
+
+    const openHandles = handleCollector();
+
+    expect(openHandles.length).toEqual(0);
+  });
+});

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -17,7 +17,7 @@ describe('collectHandles', () => {
 
     const openHandles = handleCollector();
 
-    expect(openHandles.length).toEqual(1);
+    expect(openHandles).toHaveLength(1);
     expect(openHandles[0].message).toContain('Timeout');
 
     clearInterval(interval);
@@ -30,7 +30,7 @@ describe('collectHandles', () => {
 
     const openHandles = handleCollector();
 
-    expect(openHandles.length).toEqual(0);
+    expect(openHandles).toHaveLength(0);
     obs.disconnect();
   });
 });

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -57,7 +57,8 @@ export default function collectHandles(): () => Array<Error> {
       if (
         type === 'PROMISE' ||
         type === 'TIMERWRAP' ||
-        type === 'ELDHISTOGRAM'
+        type === 'ELDHISTOGRAM' ||
+        type === 'PerformanceObserver'
       ) {
         return;
       }


### PR DESCRIPTION
Fixes https://github.com/facebook/jest/issues/11051


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
