### PR TITLE
feat(pretty-format): Enable filtering of children in DOMElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
+- `[pretty-format]` Ignore DOM nodes (except text nodes) that are serialized as an empty string (only affects usages of `pretty-format` with custom plugins). ([11130](https://github.com/facebook/jest/pull/11130))
 
 ### Fixes
 

--- a/packages/pretty-format/src/__tests__/DOMElement.test.ts
+++ b/packages/pretty-format/src/__tests__/DOMElement.test.ts
@@ -583,3 +583,50 @@ Testing.`;
     );
   });
 });
+
+describe('DOMElement Plugin with a null printer', () => {
+  beforeAll(() => {
+    setPrettyPrint([
+      {
+        serialize() {
+          return '';
+        },
+        test(value) {
+          return (
+            DOMElement.test(value) &&
+            (value.tagName === 'SCRIPT' || value.nodeType === 8)
+          );
+        },
+      },
+      DOMElement,
+    ]);
+  });
+
+  afterAll(() => {
+    setPrettyPrint([DOMElement]);
+  });
+
+  it('filters children', () => {
+    const div = document.createElement('div');
+
+    const script = document.createElement('script');
+    script.setAttribute('src', 'index.js');
+    div.appendChild(script);
+
+    const comment = document.createComment('Hello, Dave!');
+    div.appendChild(comment);
+
+    const main = document.createElement('main');
+    main.appendChild(document.createTextNode('Hello, World!'));
+    div.appendChild(main);
+
+    const expected = [
+      '<div>',
+      '  <main>',
+      '    Hello, World!',
+      '  </main>',
+      '</div>',
+    ].join('\n');
+    expect(div).toPrettyPrintTo(expected);
+  });
+});

--- a/packages/pretty-format/src/plugins/lib/markup.ts
+++ b/packages/pretty-format/src/plugins/lib/markup.ts
@@ -62,14 +62,17 @@ export const printChildren = (
   printer: Printer,
 ): string =>
   children
-    .map(
-      child =>
-        config.spacingOuter +
-        indentation +
-        (typeof child === 'string'
+    .map(child => {
+      const printedChild =
+        typeof child === 'string'
           ? printText(child, config)
-          : printer(child, config, indentation, depth, refs)),
-    )
+          : printer(child, config, indentation, depth, refs);
+
+      if (printedChild === '') {
+        return '';
+      }
+      return config.spacingOuter + indentation + printedChild;
+    })
     .join('');
 
 export const printText = (text: string, config: Config): string => {

--- a/packages/pretty-format/src/plugins/lib/markup.ts
+++ b/packages/pretty-format/src/plugins/lib/markup.ts
@@ -68,7 +68,13 @@ export const printChildren = (
           ? printText(child, config)
           : printer(child, config, indentation, depth, refs);
 
-      if (printedChild === '') {
+      if (
+        printedChild === '' &&
+        typeof child === 'object' &&
+        child !== null &&
+        (child as Node).nodeType !== 3
+      ) {
+        // A plugin serialized this element to '' meaning we should ignore it.
         return '';
       }
       return config.spacingOuter + indentation + printedChild;

--- a/packages/pretty-format/src/plugins/lib/markup.ts
+++ b/packages/pretty-format/src/plugins/lib/markup.ts
@@ -52,6 +52,9 @@ export const printProps = (
     .join('');
 };
 
+// https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType#node_type_constants
+const NodeTypeTextNode = 3;
+
 // Return empty string if children is empty.
 export const printChildren = (
   children: Array<unknown>,
@@ -72,9 +75,9 @@ export const printChildren = (
         printedChild === '' &&
         typeof child === 'object' &&
         child !== null &&
-        (child as Node).nodeType !== 3
+        (child as Node).nodeType !== NodeTypeTextNode
       ) {
-        // A plugin serialized this element to '' meaning we should ignore it.
+        // A plugin serialized this Node to '' meaning we should ignore it.
         return '';
       }
       return config.spacingOuter + indentation + printedChild;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Allow ignoring "noise" in the DOM in `pretty-format`

Given 
```html
<body>
  <script
    src="context.js"
  />
  <!-- Some comment -->
  <p>
    Hello, Dave
  </p>
</body>
```

I want to be able to pretty-format only the "relevant" parts:

```html
<body>
  <p>
    Hello, Dave
  </p>
</body>
```

"relevant" means the parts that the tested code controls. Some testing frameworks (e.g. mocha or karma) insert script tags and comments [which take up considerable space](https://app.circleci.com/pipelines/github/mui-org/material-ui/38685/workflows/83279e68-0b89-4683-8c07-748ecf9cfc64/jobs/228457/parallel-runs/0/steps/0-112).



## Test plan

- [x] CI green
- [ ] use feature to close https://github.com/testing-library/dom-testing-library/issues/902
