### PR TITLE
Use blocklist for dependency extractor instead of worker

### DIFF
--- a/packages/jest-haste-map/src/__tests__/dependencyExtractor.js
+++ b/packages/jest-haste-map/src/__tests__/dependencyExtractor.js
@@ -12,7 +12,7 @@ const lineCommentRe = /\/\/.*/g;
 const LOAD_MODULE_RE = /(?:^|[^.]\s*)(\bloadModule\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g;
 
 export function extract(code, filePath, defaultDependencyExtractor) {
-  const dependencies = defaultDependencyExtractor(code);
+  const dependencies = defaultDependencyExtractor(code, filePath);
 
   const addDependency = (match, pre, quot, dep, post) => {
     dependencies.add(dep);

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -9,8 +9,30 @@ import {extract} from '../dependencyExtractor';
 import isRegExpSupported from '../isRegExpSupported';
 
 const COMMENT_NO_NEG_LB = isRegExpSupported('(?<!\\.\\s*)') ? '' : '//';
+const FAKE_JS_FILE_PATH = 'fakeFile.js';
 
 describe('dependencyExtractor', () => {
+  it('should not extract dependencies for blocklisted file extensions', () => {
+    const code = `
+      // Good
+      import * as depNS from 'dep1';
+      import {
+        a as aliased_a,
+        b,
+      } from 'dep2';
+      import depDefault from 'dep3';
+      import * as depNS, {
+        a as aliased_a,
+        b,
+      }, depDefault from 'dep4';
+
+      // Bad
+      ${COMMENT_NO_NEG_LB} foo . import ('inv1');
+      ${COMMENT_NO_NEG_LB} foo . export ('inv2');
+    `;
+    expect(extract(code, 'fakeFile.json')).toEqual(new Set([]));
+  });
+
   it('should not extract dependencies inside comments', () => {
     const code = `
       // import a from 'ignore-line-comment';
@@ -24,7 +46,7 @@ describe('dependencyExtractor', () => {
        * require('ignore-block-comment');
        */
     `;
-    expect(extract(code)).toEqual(new Set());
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(new Set());
   });
 
   it('should not extract dependencies inside comments (windows line endings)', () => {
@@ -35,7 +57,7 @@ describe('dependencyExtractor', () => {
       ' */',
     ].join('\r\n');
 
-    expect(extract(code)).toEqual(new Set([]));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(new Set([]));
   });
 
   it('should not extract dependencies inside comments (unicode line endings)', () => {
@@ -47,7 +69,7 @@ describe('dependencyExtractor', () => {
       ' */',
     ].join('');
 
-    expect(extract(code)).toEqual(new Set([]));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(new Set([]));
   });
 
   it('should extract dependencies from `import` statements', () => {
@@ -68,7 +90,9 @@ describe('dependencyExtractor', () => {
       ${COMMENT_NO_NEG_LB} foo . import ('inv1');
       ${COMMENT_NO_NEG_LB} foo . export ('inv2');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   // https://github.com/facebook/jest/issues/8547
@@ -83,7 +107,7 @@ describe('dependencyExtractor', () => {
         import ./inv1;
         import inv2
       `;
-    expect(extract(code)).toEqual(
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
       new Set(['./side-effect-dep1', 'side-effect-dep2']),
     );
   });
@@ -94,7 +118,7 @@ describe('dependencyExtractor', () => {
       import typeof {foo} from 'inv1';
       import type {foo} from 'inv2';
     `;
-    expect(extract(code)).toEqual(new Set([]));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(new Set([]));
   });
 
   it('should extract dependencies from `export` statements', () => {
@@ -115,7 +139,9 @@ describe('dependencyExtractor', () => {
       ${COMMENT_NO_NEG_LB} foo . export ('inv1');
       ${COMMENT_NO_NEG_LB} foo . export ('inv2');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   it('should extract dependencies from `export-from` statements', () => {
@@ -136,7 +162,9 @@ describe('dependencyExtractor', () => {
       ${COMMENT_NO_NEG_LB} foo . export ('inv1');
       ${COMMENT_NO_NEG_LB} foo . export ('inv2');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   it('should not extract dependencies from `export type/typeof` statements', () => {
@@ -145,7 +173,7 @@ describe('dependencyExtractor', () => {
       export typeof {foo} from 'inv1';
       export type {foo} from 'inv2';
     `;
-    expect(extract(code)).toEqual(new Set([]));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(new Set([]));
   });
 
   it('should extract dependencies from dynamic `import` calls', () => {
@@ -163,7 +191,9 @@ describe('dependencyExtractor', () => {
       importx('inv3');
       import('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3']),
+    );
   });
 
   it('should extract dependencies from `require` calls', () => {
@@ -181,7 +211,9 @@ describe('dependencyExtractor', () => {
       requirex('inv3');
       require('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3']),
+    );
   });
 
   it('should extract dependencies from `jest.requireActual` calls', () => {
@@ -201,7 +233,9 @@ describe('dependencyExtractor', () => {
       jest.requireActualx('inv3');
       jest.requireActual('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   it('should extract dependencies from `jest.requireMock` calls', () => {
@@ -221,7 +255,9 @@ describe('dependencyExtractor', () => {
       jest.requireMockx('inv3');
       jest.requireMock('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   it('should extract dependencies from `jest.genMockFromModule` calls', () => {
@@ -241,7 +277,9 @@ describe('dependencyExtractor', () => {
       jest.genMockFromModulex('inv3');
       jest.genMockFromModule('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 
   it('should extract dependencies from `jest.createMockFromModule` calls', () => {
@@ -261,6 +299,8 @@ describe('dependencyExtractor', () => {
       jest.createMockFromModulex('inv3');
       jest.createMockFromModule('inv4', 'inv5');
     `;
-    expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+    expect(extract(code, FAKE_JS_FILE_PATH)).toEqual(
+      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
+    );
   });
 });

--- a/packages/jest-haste-map/src/lib/blocklist.ts
+++ b/packages/jest-haste-map/src/lib/blocklist.ts
@@ -13,7 +13,7 @@
 // reflected in the list. Adding "application/" is too risky since some text
 // file formats (like ".js" and ".json") have an "application/" MIME type.
 //
-// Feel free to add any extensions that cannot be a Haste module.
+// Feel free to add any extensions that cannot extract dependencies.
 
 const extensions: Set<string> = new Set([
   // JSONs are never haste modules, except for "package.json", which is handled.

--- a/packages/jest-haste-map/src/lib/dependencyExtractor.ts
+++ b/packages/jest-haste-map/src/lib/dependencyExtractor.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import blocklist from './blocklist';
 import isRegExpSupported from './isRegExpSupported';
 
 // Negative look behind is only supported in Node 9+
@@ -73,8 +74,13 @@ const JEST_EXTENSIONS_RE = createRegExp(
   'g',
 );
 
-export function extract(code: string): Set<string> {
+export function extract(code: string, filePath: string): Set<string> {
   const dependencies = new Set<string>();
+
+  // MIME types do not have dependencies by default
+  if (blocklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
+    return dependencies;
+  }
 
   const addDependency = (match: string, _: string, dep: string) => {
     dependencies.add(dep);

--- a/packages/jest-haste-map/src/worker.ts
+++ b/packages/jest-haste-map/src/worker.ts
@@ -8,7 +8,6 @@
 import {createHash} from 'crypto';
 import * as path from 'path';
 import * as fs from 'graceful-fs';
-import blacklist from './blacklist';
 import H from './constants';
 import * as dependencyExtractor from './lib/dependencyExtractor';
 import type {HasteImpl, WorkerMessage, WorkerMetadata} from './types';
@@ -63,7 +62,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
     } catch (err) {
       throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`);
     }
-  } else if (!blacklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
+  } else {
     // Process a random file that is returned as a MODULE.
     if (hasteImpl) {
       id = hasteImpl.getHasteName(filePath);
@@ -78,7 +77,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
               filePath,
               dependencyExtractor.extract,
             )
-          : dependencyExtractor.extract(content),
+          : dependencyExtractor.extract(content, filePath),
       );
     }
 


### PR DESCRIPTION
## Summary

In response to https://github.com/facebook/jest/pull/11027

Currently, there is a config option for 'moduleFileExtensions'. This config option is used to determine which files to crawl when building the haste map. The current default is ['js', 'jsx', 'ts', 'tsx', 'json', 'node'].

However, there is then a second layer which determines if the module will be included in the module map. This layer is currently a static blocklist (https://github.com/facebook/jest/blob/master/packages/jest-haste-map/src/blacklist.ts). The current blocklist includes 'json' and some other file extensions. This means that even though 'moduleFileExtensions' includes json, the module map won't actually include json files (except for package.json which is special cased https://github.com/facebook/jest/blob/master/packages/jest-haste-map/src/worker.ts#L53).

At Facebook, we'd like to use Jest's haste map to track non-JS files such as JSON files. Due to the behavior described above, these files are not included in the module map. We'd like a way to include these file extensions in the module map without causing unexpected dependencies. To do this, there are 2 changes:
- Do not use the blocklist to determine what goes in the module map
- Use the blocklist as extensions to avoid extracting dependencies of

This causes a few minor breaking changes:
- json files are now included in the module map by default because moduleFileExtensions has json by default. This is relatively low impact, as we're not attempting to extract dependencies from the json files. It's also worth noting package.json files were already included in the module map as a special case
- The default dependency extractor now expects the file path passed down. This is needed to check the extensions. This will have a low impact effect on anyone overriding the dependency extractor module. However, the override module already takes in the file path, so it is just a matter of passing it to the default one (https://github.com/facebook/jest/blob/master/packages/jest-haste-map/src/worker.ts#L78)

## Test Plan

This new behavior is covered by unit tests.