### PR TITLE
fix: jest --watch fails with ambiguous argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-changed-files]` Use '--' to separate paths from revisions ([#11160](https://github.com/facebook/jest/pull/11160))
 - `[jest-circus]` [**BREAKING**] Fail tests when multiple `done()` calls are made ([#10624](https://github.com/facebook/jest/pull/10624))
 - `[jest-circus, jest-jasmine2]` [**BREAKING**] Fail the test instead of just warning when describe returns a value ([#10947](https://github.com/facebook/jest/pull/10947))
 - `[jest-config]` [**BREAKING**] Default to Node testing environment instead of browser (JSDOM) ([#9874](https://github.com/facebook/jest/pull/9874))

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -44,6 +44,10 @@ function gitInit(dir: string) {
   run(initCommand, dir);
 }
 
+function gitCreateBranch(branchName: string, dir: string) {
+  run(`git branch ${branchName}`, dir);
+}
+
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
 
@@ -171,9 +175,11 @@ test('gets changed files for git', async () => {
   gitInit(DIR);
 
   const roots = [
-    '',
+    // same first root name with existing branch name makes pitfall that
+    // causes "ambiguous argument" git error.
     'nested-dir',
     'nested-dir/second-nested-dir',
+    '',
   ].map(filename => path.resolve(DIR, filename));
 
   let {changedFiles: files} = await getChangedFilesForRoots(roots, {});
@@ -189,6 +195,8 @@ test('gets changed files for git', async () => {
   // paragraphs. This is done to ensure that `changedFiles` only
   // returns files and not parts of commit messages.
   run(`${GIT} commit --no-gpg-sign -m "test" -m "extra-line"`, DIR);
+
+  gitCreateBranch('nested-dir', DIR);
 
   ({changedFiles: files} = await getChangedFilesForRoots(roots, {}));
   expect(Array.from(files)).toEqual([]);

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -44,7 +44,7 @@ const adapter: SCMAdapter = {
 
     if (options && options.lastCommit) {
       return findChangedFilesUsingCommand(
-        ['show', '--name-only', '--pretty=format:', 'HEAD'].concat(
+        ['show', '--name-only', '--pretty=format:', 'HEAD', '--'].concat(
           includePaths,
         ),
         cwd,
@@ -53,19 +53,23 @@ const adapter: SCMAdapter = {
     if (changedSince) {
       const [committed, staged, unstaged] = await Promise.all([
         findChangedFilesUsingCommand(
-          ['diff', '--name-only', `${changedSince}...HEAD`].concat(
+          ['diff', '--name-only', `${changedSince}...HEAD`, '--'].concat(
             includePaths,
           ),
           cwd,
         ),
         findChangedFilesUsingCommand(
-          ['diff', '--cached', '--name-only'].concat(includePaths),
+          ['diff', '--cached', '--name-only', '--'].concat(includePaths),
           cwd,
         ),
         findChangedFilesUsingCommand(
-          ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
-            includePaths,
-          ),
+          [
+            'ls-files',
+            '--other',
+            '--modified',
+            '--exclude-standard',
+            '--',
+          ].concat(includePaths),
           cwd,
         ),
       ]);
@@ -73,13 +77,17 @@ const adapter: SCMAdapter = {
     }
     const [staged, unstaged] = await Promise.all([
       findChangedFilesUsingCommand(
-        ['diff', '--cached', '--name-only'].concat(includePaths),
+        ['diff', '--cached', '--name-only', '--'].concat(includePaths),
         cwd,
       ),
       findChangedFilesUsingCommand(
-        ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
-          includePaths,
-        ),
+        [
+          'ls-files',
+          '--other',
+          '--modified',
+          '--exclude-standard',
+          '--',
+        ].concat(includePaths),
         cwd,
       ),
     ]);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Hi. This PR fixes #10149.

Now `jest --watch`, `jest --lastCommit`, `--changedSince` work fine even if there are same name revision and filename.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

e2e test modified