### PR TITLE
feat(jest-transform): support transformers written in ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
+- `[jest-transform]` Add support for transformers written in ESM
+- `[jest-transform]` [**BREAKING**] Do not export `ScriptTransformer` class, instead export the async function `createScriptTransformer`
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
-- `[jest-transform]` Add support for transformers written in ESM ([#11163](https://github.com/facebook/jest/pull/7792))
+- `[jest-transform]` Add support for transformers written in ESM ([#11163](https://github.com/facebook/jest/pull/11163))
 - `[jest-transform]` [**BREAKING**] Do not export `ScriptTransformer` class, instead export the async function `createScriptTransformer` ([#11163](https://github.com/facebook/jest/pull/11163))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@
 - `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
-- `[jest-transform]` Add support for transformers written in ESM
-- `[jest-transform]` [**BREAKING**] Do not export `ScriptTransformer` class, instead export the async function `createScriptTransformer`
+- `[jest-transform]` Add support for transformers written in ESM ([#11163](https://github.com/facebook/jest/pull/7792))
+- `[jest-transform]` [**BREAKING**] Do not export `ScriptTransformer` class, instead export the async function `createScriptTransformer` ([#11163](https://github.com/facebook/jest/pull/11163))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -35,22 +35,6 @@ module.exports = {
       ],
       test: /\.tsx?$/,
     },
-    // we want this file to keep `import()`, so exclude the transform for it
-    {
-      plugins: ['@babel/plugin-syntax-dynamic-import'],
-      presets: [
-        '@babel/preset-typescript',
-        [
-          '@babel/preset-env',
-          {
-            exclude: ['@babel/plugin-proposal-dynamic-import'],
-            shippedProposals: true,
-            targets: {node: supportedNodeVersion},
-          },
-        ],
-      ],
-      test: 'packages/jest-config/src/readConfigFileAndSetRootDir.ts',
-    },
   ],
   plugins: [
     ['@babel/plugin-transform-modules-commonjs', {allowTopLevelThis: true}],
@@ -63,6 +47,8 @@ module.exports = {
       '@babel/preset-env',
       {
         bugfixes: true,
+        // a runtime error is preferable, and we need a real `import`
+        exclude: ['@babel/plugin-proposal-dynamic-import'],
         shippedProposals: true,
         targets: {node: supportedNodeVersion},
       },

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1295,6 +1295,8 @@ _Note: a transformer is only run once per file unless the file has changed. Duri
 
 _Note: when adding additional code transformers, this will overwrite the default config and `babel-jest` is no longer automatically loaded. If you want to use it to compile JavaScript or Typescript, it has to be explicitly defined by adding `{"\\.[jt]sx?$": "babel-jest"}` to the transform property. See [babel-jest plugin](https://github.com/facebook/jest/tree/master/packages/babel-jest#setup)_
 
+A transformer must be an object with at least a `process` function, and it's also recommended to include a `getCacheKey` function. If your transformer is written in ESM you should have a default export with that object.
+
 ### `transformIgnorePatterns` [array\<string>]
 
 Default: `["/node_modules/", "\\.pnp\\.[^\\\/]+$"]`

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -238,3 +238,14 @@ describe('transform-testrunner', () => {
     expect(json.numPassedTests).toBe(1);
   });
 });
+
+describe('esm-transformer', () => {
+  const dir = path.resolve(__dirname, '../transform/esm-transformer');
+
+  it('should transform with transformer written in ESM', () => {
+    const {json, stderr} = runWithJson(dir, ['--no-cache']);
+    expect(stderr).toMatch(/PASS/);
+    expect(json.success).toBe(true);
+    expect(json.numPassedTests).toBe(1);
+  });
+});

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -8,6 +8,7 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
+import {onNodeVersions} from '@jest/test-utils';
 import {
   cleanup,
   copyDir,
@@ -239,13 +240,15 @@ describe('transform-testrunner', () => {
   });
 });
 
-describe('esm-transformer', () => {
-  const dir = path.resolve(__dirname, '../transform/esm-transformer');
+onNodeVersions('^12.17.0 || >=13.2.0', () => {
+  describe('esm-transformer', () => {
+    const dir = path.resolve(__dirname, '../transform/esm-transformer');
 
-  it('should transform with transformer written in ESM', () => {
-    const {json, stderr} = runWithJson(dir, ['--no-cache']);
-    expect(stderr).toMatch(/PASS/);
-    expect(json.success).toBe(true);
-    expect(json.numPassedTests).toBe(1);
+    it('should transform with transformer written in ESM', () => {
+      const {json, stderr} = runWithJson(dir, ['--no-cache']);
+      expect(stderr).toMatch(/PASS/);
+      expect(json.success).toBe(true);
+      expect(json.numPassedTests).toBe(1);
+    });
   });
 });

--- a/e2e/transform/esm-transformer/__tests__/test.js
+++ b/e2e/transform/esm-transformer/__tests__/test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const m = require('../module');
+
+test('ESM transformer intercepts', () => {
+  expect(m).toEqual(42);
+});

--- a/e2e/transform/esm-transformer/module.js
+++ b/e2e/transform/esm-transformer/module.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'It was not transformed!!';

--- a/e2e/transform/esm-transformer/my-transform.mjs
+++ b/e2e/transform/esm-transformer/my-transform.mjs
@@ -6,10 +6,10 @@
  */
 
 import {createRequire} from 'module';
-import {fileURLToPath} from 'url';
 
-const thisFile = fileURLToPath(import.meta.url);
-const fileToTransform = createRequire(thisFile).resolve('./module')
+const require = createRequire(import.meta.url);
+
+const fileToTransform = require.resolve('./module');
 
 export default {
   process(src, filepath) {

--- a/e2e/transform/esm-transformer/my-transform.mjs
+++ b/e2e/transform/esm-transformer/my-transform.mjs
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {createRequire} from 'module';
+import {fileURLToPath} from 'url';
+
+const thisFile = fileURLToPath(import.meta.url);
+const fileToTransform = createRequire(thisFile).resolve('./module')
+
+export default {
+  process(src, filepath) {
+    if (filepath === fileToTransform) {
+      return 'module.exports = 42;';
+    }
+
+    return src;
+  },
+};

--- a/e2e/transform/esm-transformer/package.json
+++ b/e2e/transform/esm-transformer/package.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {
+      "\\.js$": "<rootDir>/my-transform.mjs"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
-    "@babel/plugin-proposal-dynamic-import": "^7.8.3",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/plugin-transform-strict-mode": "^7.0.0",
     "@babel/preset-env": "^7.1.0",

--- a/packages/jest-core/src/__tests__/watchFileChanges.test.ts
+++ b/packages/jest-core/src/__tests__/watchFileChanges.test.ts
@@ -14,6 +14,7 @@ import type {AggregatedResult} from '@jest/test-result';
 import {normalize} from 'jest-config';
 import type HasteMap from 'jest-haste-map';
 import Runtime from 'jest-runtime';
+import {interopRequireDefault} from 'jest-util';
 import {JestHook} from 'jest-watcher';
 
 describe('Watch mode flows with changed files', () => {
@@ -31,8 +32,8 @@ describe('Watch mode flows with changed files', () => {
   const cacheDirectory = path.resolve(tmpdir(), `tmp${Math.random()}`);
   let hasteMapInstance: HasteMap;
 
-  beforeEach(async () => {
-    watch = (await import('../watch')).default;
+  beforeEach(() => {
+    watch = interopRequireDefault(require('../watch')).default;
     pipe = {write: jest.fn()} as unknown;
     stdin = new MockStdin();
     rimraf.sync(cacheDirectory);

--- a/packages/jest-core/src/runGlobalHook.ts
+++ b/packages/jest-core/src/runGlobalHook.ts
@@ -7,7 +7,7 @@
 
 import * as util from 'util';
 import pEachSeries = require('p-each-series');
-import {ScriptTransformer} from '@jest/transform';
+import {createScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import type {Test} from 'jest-runner';
 import {interopRequireDefault} from 'jest-util';
@@ -45,7 +45,7 @@ export default async ({
         : // Fallback to first config
           allTests[0].context.config;
 
-      const transformer = new ScriptTransformer(projectConfig);
+      const transformer = await createScriptTransformer(projectConfig);
 
       try {
         await transformer.requireAndTranspileModule(modulePath, async m => {

--- a/packages/jest-create-cache-key-function/package.json
+++ b/packages/jest-create-cache-key-function/package.json
@@ -10,7 +10,8 @@
     "@jest/types": "^27.0.0-next.3"
   },
   "devDependencies": {
-    "@types/node": "*"
+    "@types/node": "*",
+    "jest-util": "^27.0.0-next.3"
   },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"

--- a/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
+++ b/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {interopRequireDefault} from 'jest-util';
+
 let NODE_ENV: string;
 let BABEL_ENV: string;
 
@@ -20,8 +22,9 @@ afterEach(() => {
   process.env.BABEL_ENV = BABEL_ENV;
 });
 
-test('creation of a cache key', async () => {
-  const createCacheKeyFunction = (await import('../index')).default;
+test('creation of a cache key', () => {
+  const createCacheKeyFunction = interopRequireDefault(require('../index'))
+    .default;
   const createCacheKey = createCacheKeyFunction([], ['value']);
   const hashA = createCacheKey('test', 'test.js', null, {
     config: {},

--- a/packages/jest-create-cache-key-function/tsconfig.json
+++ b/packages/jest-create-cache-key-function/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "references": [{"path": "../jest-types"}, {"path": "../jest-utils"}]
+  "references": [{"path": "../jest-types"}, {"path": "../jest-util"}]
 }

--- a/packages/jest-create-cache-key-function/tsconfig.json
+++ b/packages/jest-create-cache-key-function/tsconfig.json
@@ -4,7 +4,5 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "references": [
-    {"path":  "../jest-types"}
-  ]
+  "references": [{"path": "../jest-types"}, {"path": "../jest-utils"}]
 }

--- a/packages/jest-repl/src/cli/runtime-cli.ts
+++ b/packages/jest-repl/src/cli/runtime-cli.ts
@@ -11,7 +11,7 @@ import chalk = require('chalk');
 import yargs = require('yargs');
 import {CustomConsole} from '@jest/console';
 import type {JestEnvironment} from '@jest/environment';
-import {ScriptTransformer} from '@jest/transform';
+import {createScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import {deprecationEntries, readConfig} from 'jest-config';
 import Runtime from 'jest-runtime';
@@ -74,7 +74,7 @@ export async function run(
       watchman: globalConfig.watchman,
     });
 
-    const transformer = new ScriptTransformer(config);
+    const transformer = await createScriptTransformer(config);
     const Environment: typeof JestEnvironment = interopRequireDefault(
       transformer.requireAndTranspileModule(config.testEnvironment),
     ).default;
@@ -91,6 +91,7 @@ export async function run(
       config,
       environment,
       hasteMap.resolver,
+      transformer,
       new Map(),
       {
         changedFiles: undefined,

--- a/packages/jest-reporters/src/CoverageWorker.ts
+++ b/packages/jest-reporters/src/CoverageWorker.ts
@@ -33,7 +33,7 @@ export function worker({
   globalConfig,
   path,
   options,
-}: CoverageWorkerData): CoverageWorkerResult | null {
+}: CoverageWorkerData): Promise<CoverageWorkerResult | null> {
   return generateEmptyCoverage(
     fs.readFileSync(path, 'utf8'),
     path,

--- a/packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js
+++ b/packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js
@@ -24,7 +24,7 @@ describe('generateEmptyCoverage', () => {
   const rootDir = __dirname;
   const filepath = path.join(rootDir, './sum.js');
 
-  it('generates an empty coverage object for a file without running it', () => {
+  it('generates an empty coverage object for a file without running it', async () => {
     const src = `
     throw new Error('this should not be thrown');
 
@@ -42,7 +42,7 @@ describe('generateEmptyCoverage', () => {
 
     shouldInstrument.mockReturnValueOnce(true);
 
-    const emptyCoverage = generateEmptyCoverage(
+    const emptyCoverage = await generateEmptyCoverage(
       src,
       filepath,
       makeGlobalConfig(),
@@ -71,7 +71,7 @@ describe('generateEmptyCoverage', () => {
     });
   });
 
-  it('generates a null coverage result when using /* istanbul ignore file */', () => {
+  it('generates a null coverage result when using /* istanbul ignore file */', async () => {
     const src = `
     /* istanbul ignore file */
     const a = (b, c) => {
@@ -86,7 +86,7 @@ describe('generateEmptyCoverage', () => {
 
     shouldInstrument.mockReturnValueOnce(true);
 
-    const nullCoverage = generateEmptyCoverage(
+    const nullCoverage = await generateEmptyCoverage(
       src,
       filepath,
       makeGlobalConfig(),
@@ -101,7 +101,7 @@ describe('generateEmptyCoverage', () => {
     expect(nullCoverage).toBeNull();
   });
 
-  it('generates a null coverage result when collectCoverage global config is false', () => {
+  it('generates a null coverage result when collectCoverage global config is false', async () => {
     const src = `
     const a = (b, c) => {
       if (b) {
@@ -115,7 +115,7 @@ describe('generateEmptyCoverage', () => {
 
     shouldInstrument.mockReturnValueOnce(false);
 
-    const nullCoverage = generateEmptyCoverage(
+    const nullCoverage = await generateEmptyCoverage(
       src,
       filepath,
       makeGlobalConfig(),

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -19,7 +19,7 @@ import {
 } from '@jest/console';
 import type {JestEnvironment} from '@jest/environment';
 import type {TestResult} from '@jest/test-result';
-import {ScriptTransformer} from '@jest/transform';
+import {createScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import {getTestEnvironment} from 'jest-config';
 import * as docblock from 'jest-docblock';
@@ -103,7 +103,9 @@ async function runTestInternal(
     });
   }
 
-  const transformer = new ScriptTransformer(config);
+  const cacheFS = new Map([[path, testSource]]);
+  const transformer = await createScriptTransformer(config, cacheFS);
+
   const TestEnvironment: typeof JestEnvironment = interopRequireDefault(
     transformer.requireAndTranspileModule(testEnvironment),
   ).default;
@@ -146,13 +148,13 @@ async function runTestInternal(
     ? new LeakDetector(environment)
     : null;
 
-  const cacheFS = new Map([[path, testSource]]);
   setGlobal(environment.global, 'console', testConsole);
 
   const runtime = new Runtime(
     config,
     environment,
     resolver,
+    transformer,
     cacheFS,
     {
       changedFiles: context?.changedFiles,

--- a/packages/jest-runtime/src/__tests__/instrumentation.test.ts
+++ b/packages/jest-runtime/src/__tests__/instrumentation.test.ts
@@ -9,7 +9,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
-import {ScriptTransformer} from '@jest/transform';
+import {createScriptTransformer} from '@jest/transform';
 
 jest.mock('vm');
 
@@ -18,20 +18,19 @@ const FILE_PATH_TO_INSTRUMENT = path.resolve(
   './module_dir/to_be_instrumented.js',
 );
 
-it('instruments files', () => {
+it('instruments files', async () => {
   const config = makeProjectConfig({
     cache: false,
     cacheDirectory: os.tmpdir(),
     cwd: __dirname,
     rootDir: __dirname,
   });
-  const instrumented = new ScriptTransformer(config).transform(
-    FILE_PATH_TO_INSTRUMENT,
-    {
-      ...makeGlobalConfig({collectCoverage: true}),
-      changedFiles: undefined,
-    },
-  );
+  const scriptTransformer = await createScriptTransformer(config);
+
+  const instrumented = scriptTransformer.transform(FILE_PATH_TO_INSTRUMENT, {
+    ...makeGlobalConfig({collectCoverage: true}),
+    changedFiles: undefined,
+  });
   // We can't really snapshot the resulting coverage, because it depends on
   // absolute path of the file, which will be different on different
   // machines

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -198,6 +198,7 @@ export default class Runtime {
     config: Config.ProjectConfig,
     environment: JestEnvironment,
     resolver: Resolver,
+    transformer: ScriptTransformer,
     cacheFS: Map<string, string>,
     coverageOptions: ShouldInstrumentOptions,
     testPath: Config.Path,
@@ -226,7 +227,7 @@ export default class Runtime {
     this._esmModuleLinkingMap = new WeakMap();
     this._testPath = testPath;
     this._resolver = resolver;
-    this._scriptTransformer = new ScriptTransformer(config, this._cacheFS);
+    this._scriptTransformer = transformer;
     this._shouldAutoMock = config.automock;
     this._sourceMapRegistry = new Map();
     this._fileTransforms = new Map();

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -7,6 +7,7 @@
 
 import {createHash} from 'crypto';
 import * as path from 'path';
+import {pathToFileURL} from 'url';
 import {transformSync as babelTransform} from '@babel/core';
 // @ts-expect-error: should just be `require.resolve`, but the tests mess that up
 import babelPluginIstanbul from 'babel-plugin-istanbul';
@@ -63,7 +64,7 @@ async function waitForPromiseWithCleanup(
   }
 }
 
-export default class ScriptTransformer {
+class ScriptTransformer {
   private readonly _cache: ProjectCache;
   private readonly _cacheFS: StringMap;
   private readonly _config: Config.ProjectConfig;
@@ -71,7 +72,7 @@ export default class ScriptTransformer {
     Config.Path,
     {transformer: Transformer; transformerConfig: unknown}
   >;
-  private readonly _transformConfigCache: Map<Config.Path, unknown>;
+  private _transformsAreLoaded = false;
 
   constructor(
     config: Config.ProjectConfig,
@@ -80,7 +81,6 @@ export default class ScriptTransformer {
     this._config = config;
     this._cacheFS = cacheFS;
     this._transformCache = new Map();
-    this._transformConfigCache = new Map();
 
     const configString = stableStringify(this._config);
     let projectCache = projectCaches.get(configString);
@@ -165,18 +165,69 @@ export default class ScriptTransformer {
 
     for (let i = 0; i < transformRegExp.length; i++) {
       if (transformRegExp[i][0].test(filename)) {
-        const transformPath = transformRegExp[i][1];
-        this._transformConfigCache.set(transformPath, transformRegExp[i][2]);
-
-        return transformPath;
+        return transformRegExp[i][1];
       }
     }
 
     return undefined;
   }
 
+  async loadTransformers(): Promise<void> {
+    await Promise.all(
+      this._config.transform.map(
+        async ([, transformPath, transformerConfig]) => {
+          let transformer: Transformer;
+
+          try {
+            transformer = require(transformPath);
+          } catch (error) {
+            if (error.code === 'ERR_REQUIRE_ESM') {
+              const configUrl = pathToFileURL(transformPath);
+
+              // node `import()` supports URL, but TypeScript doesn't know that
+              const importedConfig = await import(configUrl.href);
+
+              if (!importedConfig.default) {
+                throw new Error(
+                  `Jest: Failed to load ESM transformer at ${transformPath} - did you use a default export?`,
+                );
+              }
+
+              transformer = importedConfig.default;
+            } else {
+              throw error;
+            }
+          }
+
+          if (!transformer) {
+            throw new TypeError('Jest: a transform must export something.');
+          }
+          if (typeof transformer.createTransformer === 'function') {
+            transformer = transformer.createTransformer(transformerConfig);
+          }
+          if (typeof transformer.process !== 'function') {
+            throw new TypeError(
+              'Jest: a transform must export a `process` function.',
+            );
+          }
+
+          const res = {transformer, transformerConfig};
+          this._transformCache.set(transformPath, res);
+        },
+      ),
+    );
+
+    this._transformsAreLoaded = true;
+  }
+
   private _getTransformer(filename: Config.Path) {
-    if (!this._config.transform || !this._config.transform.length) {
+    if (!this._transformsAreLoaded) {
+      throw new Error(
+        'Jest: Transformers have not been loaded yet - make sure to run `loadTransformers` and wait for it to complete before starting to transform files',
+      );
+    }
+
+    if (this._config.transform.length === 0) {
       return null;
     }
 
@@ -191,25 +242,9 @@ export default class ScriptTransformer {
       return cached;
     }
 
-    let transformer: Transformer = require(transformPath);
-
-    if (!transformer) {
-      throw new TypeError('Jest: a transform must export something.');
-    }
-    const transformerConfig =
-      this._transformConfigCache.get(transformPath) || {};
-    if (typeof transformer.createTransformer === 'function') {
-      transformer = transformer.createTransformer(transformerConfig);
-    }
-    if (typeof transformer.process !== 'function') {
-      throw new TypeError(
-        'Jest: a transform must export a `process` function.',
-      );
-    }
-    const res = {transformer, transformerConfig};
-    this._transformCache.set(transformPath, res);
-
-    return res;
+    throw new Error(
+      `Jest was unable to load the transformer defined for ${filename}. This is a bug in Jest, please open up an issue`,
+    );
   }
 
   private _instrumentFile(
@@ -255,12 +290,6 @@ export default class ScriptTransformer {
     }
 
     return input;
-  }
-
-  // We don't want to expose transformers to the outside - this function is just
-  // to warm up `this._transformCache`
-  preloadTransformer(filepath: Config.Path): void {
-    this._getTransformer(filepath);
   }
 
   transformSource(
@@ -504,10 +533,6 @@ export default class ScriptTransformer {
       supportsTopLevelAwait: false,
     },
   ): ModuleType | Promise<ModuleType> {
-    // Load the transformer to avoid a cycle where we need to load a
-    // transformer in order to transform it in the require hooks
-    this.preloadTransformer(moduleName);
-
     let transforming = false;
     const revertHook = addHook(
       (code, filename) => {
@@ -566,13 +591,15 @@ export default class ScriptTransformer {
 }
 
 // TODO: do we need to define the generics twice?
-export function createTranspilingRequire(
+export async function createTranspilingRequire(
   config: Config.ProjectConfig,
-): <TModuleType = unknown>(
-  resolverPath: string,
-  applyInteropRequireDefault?: boolean,
-) => TModuleType {
-  const transformer = new ScriptTransformer(config);
+): Promise<
+  <TModuleType = unknown>(
+    resolverPath: string,
+    applyInteropRequireDefault?: boolean,
+  ) => TModuleType
+> {
+  const transformer = await createScriptTransformer(config);
 
   return function requireAndTranspileModule<TModuleType = unknown>(
     resolverPath: string,
@@ -731,3 +758,16 @@ const calcTransformRegExp = (config: Config.ProjectConfig) => {
 
   return transformRegexp;
 };
+
+export type TransformerType = ScriptTransformer;
+
+export async function createScriptTransformer(
+  config: Config.ProjectConfig,
+  cacheFS = new Map<string, string>(),
+): Promise<ScriptTransformer> {
+  const transformer = new ScriptTransformer(config, cacheFS);
+
+  await transformer.loadTransformers();
+
+  return transformer;
+}

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -66,8 +66,6 @@ async function waitForPromiseWithCleanup(
 
 class ScriptTransformer {
   private readonly _cache: ProjectCache;
-  private readonly _cacheFS: StringMap;
-  private readonly _config: Config.ProjectConfig;
   private readonly _transformCache: Map<
     Config.Path,
     {transformer: Transformer; transformerConfig: unknown}
@@ -75,11 +73,9 @@ class ScriptTransformer {
   private _transformsAreLoaded = false;
 
   constructor(
-    config: Config.ProjectConfig,
-    cacheFS: StringMap = new Map<string, string>(),
+    private readonly _config: Config.ProjectConfig,
+    private readonly _cacheFS: StringMap,
   ) {
-    this._config = config;
-    this._cacheFS = cacheFS;
     this._transformCache = new Map();
 
     const configString = stableStringify(this._config);
@@ -763,8 +759,8 @@ export type TransformerType = ScriptTransformer;
 
 export async function createScriptTransformer(
   config: Config.ProjectConfig,
-  cacheFS = new Map<string, string>(),
-): Promise<ScriptTransformer> {
+  cacheFS: StringMap = new Map(),
+): Promise<TransformerType> {
   const transformer = new ScriptTransformer(config, cacheFS);
 
   await transformer.loadTransformers();

--- a/packages/jest-transform/src/index.ts
+++ b/packages/jest-transform/src/index.ts
@@ -6,9 +6,10 @@
  */
 
 export {
-  default as ScriptTransformer,
+  createScriptTransformer,
   createTranspilingRequire,
 } from './ScriptTransformer';
+export type {TransformerType as ScriptTransformer} from './ScriptTransformer';
 export {default as shouldInstrument} from './shouldInstrument';
 export type {
   CallerTransformOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,7 +475,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-proposal-dynamic-import@npm:^7.13.8, @babel/plugin-proposal-dynamic-import@npm:^7.8.3":
+"@babel/plugin-proposal-dynamic-import@npm:^7.13.8":
   version: 7.13.8
   resolution: "@babel/plugin-proposal-dynamic-import@npm:7.13.8"
   dependencies:
@@ -1805,8 +1805,6 @@ __metadata:
   dependencies:
     "@babel/core": ^7.3.4
     "@babel/plugin-proposal-class-properties": ^7.3.4
-    "@babel/plugin-proposal-dynamic-import": ^7.8.3
-    "@babel/plugin-syntax-dynamic-import": ^7.8.3
     "@babel/plugin-transform-modules-commonjs": ^7.1.0
     "@babel/plugin-transform-strict-mode": ^7.0.0
     "@babel/preset-env": ^7.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1749,6 +1749,7 @@ __metadata:
   dependencies:
     "@jest/types": ^27.0.0-next.3
     "@types/node": "*"
+    jest-util: ^27.0.0-next.3
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This allows people to write their transformers in ESM. This is mostly a refactor since `import()` is async, I've changed `ScriptTransformer` to load all transformers when it's created rather than on demand.

To not force all consumers to call `load`, I now expose more of a factory method which does the extra function call for the user.

This solves the use case behind #11081, but I think that issue might be useful for other async work.

~I'll need to update docs here, but I'll do that after landing docusaurus 2~ Just added a line, I think since we don't mess with versioned docs it should be fine

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

E2E test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
