### PR TITLE
chore: add invariant on ESM support in dynamic import

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -403,6 +403,10 @@ export default class Runtime {
           specifier: string,
           referencingModule: VMModule,
         ) => {
+          invariant(
+            runtimeSupportsVmModules,
+            'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/en/ecmascript-modules',
+          );
           const module = await this.resolveModule(
             specifier,
             referencingModule.identifier,
@@ -495,7 +499,7 @@ export default class Runtime {
   ): Promise<void> {
     invariant(
       runtimeSupportsVmModules,
-      'You need to run with a version of node that supports ES Modules in the VM API.',
+      'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/en/ecmascript-modules',
     );
 
     const [path, query] = (moduleName ?? '').split('?');
@@ -1209,6 +1213,11 @@ export default class Runtime {
         filename: scriptFilename,
         // @ts-expect-error: Experimental ESM API
         importModuleDynamically: async (specifier: string) => {
+          invariant(
+            runtimeSupportsVmModules,
+            'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/en/ecmascript-modules',
+          );
+
           const context = this._environment.getVmContext?.();
 
           invariant(context, 'Test environment has been torn down');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Noticed in #11163 we got a really bad error in `import` usage:

![image](https://user-images.githubusercontent.com/1404810/110212593-5fab6c80-7e9c-11eb-8b92-868fb26aebbf.png)

Now it's

![image](https://user-images.githubusercontent.com/1404810/110212598-65a14d80-7e9c-11eb-9207-8723ddfd98ff.png)

Which is not beautiful, but way more useful

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

See screenshots 😀 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
