### PR TITLE
fix(transformer): remove unused `isCoreModule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,9 @@
 - `[jest-reporters]` [**BREAKING**] Make `node-notifier` a peer dependency ([#10977](https://github.com/facebook/jest/pull/10977))
 - `[jest-resolve, jest-runtime]` [**BREAKING**] Use `Map`s instead of objects for all cached resources ([#10968](https://github.com/facebook/jest/pull/10968))
 - `[jest-runner]` [**BREAKING**] Migrate to ESM ([#10900](https://github.com/facebook/jest/pull/10900))
-- `[jest-runtime]` [**BREAKING**] Remove deprecated and unnused `getSourceMapInfo` from Runtime ([#9969](https://github.com/facebook/jest/pull/9969))
+- `[jest-runtime]` [**BREAKING**] Remove deprecated and unused `getSourceMapInfo` from Runtime ([#9969](https://github.com/facebook/jest/pull/9969))
 - `[jest-runtime]` Detect reexports from CJS as named exports in ESM ([#10988](https://github.com/facebook/jest/pull/10988))
+- `[jest-transformer]` [**BREAKING**] Remove unused `isCoreModule` option ([#11166](https://github.com/facebook/jest/pull/11166))
 - `[jest-util]` No longer checking `enumerable` when adding `process.domain` ([#10862](https://github.com/facebook/jest/pull/10862))
 - `[jest-validate]` [**BREAKING**] Remove `recursiveBlacklist ` option in favor of previously introduced `recursiveDenylist` ([#10650](https://github.com/facebook/jest/pull/10650))
 

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -278,25 +278,6 @@ describe('ScriptTransformer', () => {
     );
   });
 
-  it('does not transform Node core modules', () => {
-    jest.mock('../shouldInstrument');
-
-    const shouldInstrument = require('../shouldInstrument').default;
-    const scriptTransformer = new ScriptTransformer(config);
-    const fsSourceCode = 'muaha, fake source!';
-
-    const response = scriptTransformer.transform(
-      'fs',
-      {...getCoverageOptions(), isCoreModule: true},
-      fsSourceCode,
-    );
-
-    expect(response.code).toEqual(fsSourceCode);
-
-    // Native files should never be transformed.
-    expect(shouldInstrument).toHaveBeenCalledTimes(0);
-  });
-
   it(
     "throws an error if `process` doesn't return a string or an object" +
       'containing `code` key with processed string',

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -8,19 +8,23 @@
 import type {RawSourceMap} from 'source-map';
 import type {Config, TransformTypes} from '@jest/types';
 
-export type ShouldInstrumentOptions = Pick<
-  Config.GlobalConfig,
-  | 'collectCoverage'
-  | 'collectCoverageFrom'
-  | 'collectCoverageOnlyFrom'
-  | 'coverageProvider'
-> & {
+export interface ShouldInstrumentOptions
+  extends Pick<
+    Config.GlobalConfig,
+    | 'collectCoverage'
+    | 'collectCoverageFrom'
+    | 'collectCoverageOnlyFrom'
+    | 'coverageProvider'
+  > {
   changedFiles?: Set<Config.Path>;
   sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>;
-};
+}
 
-export type Options = ShouldInstrumentOptions &
-  CallerTransformOptions & {isInternalModule?: boolean};
+export interface Options
+  extends ShouldInstrumentOptions,
+    CallerTransformOptions {
+  isInternalModule?: boolean;
+}
 
 // This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
 interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -20,11 +20,7 @@ export type ShouldInstrumentOptions = Pick<
 };
 
 export type Options = ShouldInstrumentOptions &
-  Partial<{
-    isCoreModule: boolean;
-    isInternalModule: boolean;
-  }> &
-  CallerTransformOptions;
+  CallerTransformOptions & {isInternalModule?: boolean};
 
 // This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
 interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We never pass this flag from `runtime` as that's always the "real" modules. So we can simplify the transformer a bit by removing it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
