### PR TITLE
Add support for AbortController in Jest Node environment with Node v15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[jest-core]` make `TestWatcher` extend `emittery` ([#10324](https://github.com/facebook/jest/pull/10324))
 - `[jest-core]` Run failed tests interactively the same way we do with snapshots ([#10858](https://github.com/facebook/jest/pull/10858))
 - `[jest-core]` more `TestSequencer` methods can be async ([#10980](https://github.com/facebook/jest/pull/10980))
-- `[jest-environment-node]` Add support for AbortController with Node 15 ([#11182](https://github.com/facebook/jest/pull/11182))
+- `[jest-environment-node]` Add AbortController to globals ([#11182](https://github.com/facebook/jest/pull/11182))
 - `[jest-haste-map]` Handle injected scm clocks ([#10966](https://github.com/facebook/jest/pull/10966))
 - `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[jest-core]` make `TestWatcher` extend `emittery` ([#10324](https://github.com/facebook/jest/pull/10324))
 - `[jest-core]` Run failed tests interactively the same way we do with snapshots ([#10858](https://github.com/facebook/jest/pull/10858))
 - `[jest-core]` more `TestSequencer` methods can be async ([#10980](https://github.com/facebook/jest/pull/10980))
+- `[jest-environment-node]` Add support for AbortController with Node 15 ([#11182](https://github.com/facebook/jest/pull/11182))
 - `[jest-haste-map]` Handle injected scm clocks ([#10966](https://github.com/facebook/jest/pull/10966))
 - `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -59,6 +59,10 @@ class NodeEnvironment implements JestEnvironment {
     if (typeof queueMicrotask !== 'undefined') {
       global.queueMicrotask = queueMicrotask;
     }
+    // AbortController is global in Node >= 15
+    if (typeof AbortController !== 'undefined') {
+      global.AbortController = AbortController;
+    }
     installCommonGlobals(global, config.globals);
     this.moduleMocker = new ModuleMocker(global);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR adds support for the AbortController global when using the `node` Jest environment with Node `v15`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The motivation for this pull request is to fix the error `ReferenceError: AbortController is not defined` when trying to test code that uses the AbortController in Node v15. This has previously been a Browser API but has now been introduced as a native API in Node v15.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This change is non-breaking. Node versions earlier than `v15` will behave the same as before, throwing a ` ReferenceError` if you call `AbortController` without polyfilling it or using the `jsdom` environment.
