### PR TITLE
Fix memory leaks of jest-worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `[jest-worker]` Handle `ERR_IPC_CHANNEL_CLOSED` errors properly ([#11143](https://github.com/facebook/jest/pull/11143))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 - `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
+- `[jest-worker]` Fix memory leaks of jest-worker ([#11187](https://github.com/facebook/jest/pull/11187))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@
 - `[jest-worker]` Handle `ERR_IPC_CHANNEL_CLOSED` errors properly ([#11143](https://github.com/facebook/jest/pull/11143))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 - `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
-- `[jest-worker]` Fix memory leaks of jest-worker ([#11187](https://github.com/facebook/jest/pull/11187))
 
 ### Chore & Maintenance
 
@@ -97,6 +96,7 @@
 
 - `[jest-resolve]` Cache reading and parsing of `package.json`s ([#11076](https://github.com/facebook/jest/pull/11076))
 - `[jest-runtime]` Load `chalk` only once per worker ([#10864](https://github.com/facebook/jest/pull/10864))
+- `[jest-worker]` Fix memory leak of previous task arguments while no new task is scheduled ([#11187](https://github.com/facebook/jest/pull/11187))
 
 ## 26.6.3
 

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -22,6 +22,7 @@
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^7.2.0",
     "get-stream": "^6.0.0",
+    "jest-leak-detector": "^27.0.0-next.3",
     "worker-farm": "^1.6.0"
   },
   "engines": {

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -71,8 +71,8 @@ export default class Farm {
       // retaine args for the closure.
       ((
         args: Array<unknown>,
-        resolve: null | ((value: unknown) => void),
-        reject: null | ((reason?: any) => void),
+        resolve: (value: unknown) => void,
+        reject: (reason?: any) => void,
       ) => {
         const computeWorkerKey = this._computeWorkerKey;
         const request: ChildMessage = [CHILD_MESSAGE_CALL, false, method, args];
@@ -94,14 +94,10 @@ export default class Farm {
         const onEnd: OnEnd = (error: Error | null, result: unknown) => {
           customMessageListeners.clear();
           if (error) {
-            reject?.(error);
+            reject(error);
           } else {
-            resolve?.(result);
+            resolve(result);
           }
-
-          // Delete reference to the Promise so its result can be garbage
-          // collected after calling this method.
-          reject = resolve = null;
         };
 
         const task = {onCustomMessage, onEnd, onStart, request};

--- a/packages/jest-worker/src/__tests__/leak-integration.test.ts
+++ b/packages/jest-worker/src/__tests__/leak-integration.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {tmpdir} from 'os';
+import {join} from 'path';
+import {writeFileSync} from 'graceful-fs';
+import LeakDetector from 'jest-leak-detector';
+import {Worker} from '../..';
+
+let workerFile!: string;
+beforeAll(() => {
+  workerFile = join(tmpdir(), 'baz.js');
+  writeFileSync(workerFile, `module.exports.fn = () => {};`);
+});
+
+let worker!: Worker;
+beforeEach(() => {
+  worker = new Worker(workerFile, {
+    enableWorkerThreads: true,
+    exposedMethods: ['fn'],
+  });
+});
+afterEach(async () => {
+  await worker.end();
+});
+
+it('does not retain arguments after a task finished', async () => {
+  let leakDetector!: LeakDetector;
+  await new Promise(resolve => {
+    const obj = {};
+    leakDetector = new LeakDetector(obj);
+    (worker as any).fn(obj).then(resolve);
+  });
+
+  expect(await leakDetector.isLeaking()).toBe(false);
+});

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -206,7 +206,7 @@ export default class ExperimentalWorker implements WorkerInterface {
   send(
     request: ChildMessage,
     onProcessStart: OnStart,
-    onProcessEnd: OnEnd,
+    onProcessEnd: OnEnd | null,
     onCustomMessage: OnCustomMessage,
   ): void {
     onProcessStart(this);
@@ -214,7 +214,13 @@ export default class ExperimentalWorker implements WorkerInterface {
       // Clean the request to avoid sending past requests to workers that fail
       // while waiting for a new request (timers, unhandled rejections...)
       this._request = null;
-      return onProcessEnd(...args);
+
+      const res = onProcessEnd?.(...args);
+
+      // Clean up the reference so related closures can be garbage collected.
+      onProcessEnd = null;
+
+      return res;
     };
 
     this._onCustomMessage = (...arg) => onCustomMessage(...arg);

--- a/packages/jest-worker/tsconfig.json
+++ b/packages/jest-worker/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build"
-  }
+  },
+  "references": [{"path": "../jest-leak-detector"}]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14641,6 +14641,7 @@ fsevents@^1.2.7:
     "@types/node": "*"
     "@types/supports-color": ^7.2.0
     get-stream: ^6.0.0
+    jest-leak-detector: ^27.0.0-next.3
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
     worker-farm: ^1.6.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We noticed some closure related memory leaks in the current implementation of `jest-worker` with v8. The **arguments** and **result** of the task of each worker can't be garbage collected until a new task is assigned to that worker. If the arguments/result sizes are large, it's gonna introduce a huge memory increase.

This PR ensures that `args` and `task` are correctly scoped so they won't be claimed by other closures, and references can be cleaned once they become unneeded.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

We have an app that passes image buffers as the argument of tasks which are pretty large, and we are seeing a huge memory leak after the tasks have finished (ref: vercel/next.js#22925). Here's a screenshot for the memory dump:

![CleanShot 2021-03-13 at 02 29 23](https://user-images.githubusercontent.com/3676859/110983070-4591f280-83a4-11eb-8542-b8f432c53cc5.png)

The memory usage increased from 112MB to 145MB (+29%) after processing the task, and most of the new allocated memory was taken by the arguments and result of that task, which should have been recollected after it ends.

With this fix we are no longer to reproduce this leak with the same app:

![image](https://user-images.githubusercontent.com/3676859/110983306-8c7fe800-83a4-11eb-81ec-72a4aa020908.png)
