### PR TITLE
fix(pretty-format): handles jsdom attributes properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `[jest-worker]` Handle `ERR_IPC_CHANNEL_CLOSED` errors properly ([#11143](https://github.com/facebook/jest/pull/11143))
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 - `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
+- `[pretty-format]` Handle jsdom attributes properly ([#11189](https://github.com/facebook/jest/pull/11189))
 
 ### Chore & Maintenance
 

--- a/packages/pretty-format/src/__tests__/DOMElement.test.ts
+++ b/packages/pretty-format/src/__tests__/DOMElement.test.ts
@@ -582,4 +582,9 @@ Testing.`;
       ].join('\n'),
     );
   });
+
+  it('handles jsdom attributes properly', () => {
+    const attributes = require('jsdom/lib/jsdom/living/attributes');
+    expect(DOMElement.test(attributes)).toBe(false);
+  });
 });

--- a/packages/pretty-format/src/plugins/DOMElement.ts
+++ b/packages/pretty-format/src/plugins/DOMElement.ts
@@ -22,12 +22,20 @@ const FRAGMENT_NODE = 11;
 
 const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
 
+const testHasAttribute = (val: any) => {
+  try {
+    return typeof val.hasAttribute === 'function' && val.hasAttribute('is');
+  } catch (_) {
+    return false;
+  }
+};
+
 const testNode = (val: any) => {
   const constructorName = val.constructor.name;
   const {nodeType, tagName} = val;
   const isCustomElement =
     (typeof tagName === 'string' && tagName.includes('-')) ||
-    (typeof val.hasAttribute === 'function' && val.hasAttribute('is'));
+    testHasAttribute(val);
 
   return (
     (nodeType === ELEMENT_NODE &&

--- a/packages/pretty-format/src/plugins/DOMElement.ts
+++ b/packages/pretty-format/src/plugins/DOMElement.ts
@@ -25,7 +25,7 @@ const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
 const testHasAttribute = (val: any) => {
   try {
     return typeof val.hasAttribute === 'function' && val.hasAttribute('is');
-  } catch (_) {
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
## Summary

fixes #10770.

```js
expect(received).toMatchObject(expected)
```

When received object  mismatch with expected object, jest will copy received object with`deepCyclicCopyObject`. 

As for this issue, received object contains jsdom provided objects `AbortController`, and will encounter  `jsdom/lib/jsdom/living/attributes`.

This module also contains `hasAttribute`, `prettyFormat.plugins.DOMElement.test` will throw an exception by calling `hasAttribute`.

## Test plan

added `handles jsdom attributes properly` test.