### PR TITLE
feat(jest-util): add requireOrImportModule util for importing CJS or ESM

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -7,7 +7,6 @@
 
 import {createHash} from 'crypto';
 import * as path from 'path';
-import {pathToFileURL} from 'url';
 import {transformSync as babelTransform} from '@babel/core';
 // @ts-expect-error: should just be `require.resolve`, but the tests mess that up
 import babelPluginIstanbul from 'babel-plugin-istanbul';
@@ -21,6 +20,7 @@ import type {Config} from '@jest/types';
 import HasteMap from 'jest-haste-map';
 import {
   createDirectory,
+  importModule,
   interopRequireDefault,
   isPromise,
   tryRealpath,
@@ -252,28 +252,7 @@ class ScriptTransformer {
     await Promise.all(
       this._config.transform.map(
         async ([, transformPath, transformerConfig]) => {
-          let transformer: Transformer;
-
-          try {
-            transformer = interopRequireDefault(require(transformPath)).default;
-          } catch (error) {
-            if (error.code === 'ERR_REQUIRE_ESM') {
-              const configUrl = pathToFileURL(transformPath);
-
-              // node `import()` supports URL, but TypeScript doesn't know that
-              const importedConfig = await import(configUrl.href);
-
-              if (!importedConfig.default) {
-                throw new Error(
-                  `Jest: Failed to load ESM transformer at ${transformPath} - did you use a default export?`,
-                );
-              }
-
-              transformer = importedConfig.default;
-            } else {
-              throw error;
-            }
-          }
+          let transformer: Transformer = await importModule(transformPath);
 
           if (!transformer) {
             throw new TypeError('Jest: a transform must export something.');

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -20,9 +20,9 @@ import type {Config} from '@jest/types';
 import HasteMap from 'jest-haste-map';
 import {
   createDirectory,
-  importModule,
   interopRequireDefault,
   isPromise,
+  requireOrImportModule,
   tryRealpath,
 } from 'jest-util';
 import handlePotentialSyntaxError from './enhanceUnexpectedTokenMessage';
@@ -252,7 +252,9 @@ class ScriptTransformer {
     await Promise.all(
       this._config.transform.map(
         async ([, transformPath, transformerConfig]) => {
-          let transformer: Transformer = await importModule(transformPath);
+          let transformer: Transformer = await requireOrImportModule(
+            transformPath,
+          );
 
           if (!transformer) {
             throw new TypeError('Jest: a transform must export something.');

--- a/packages/jest-util/src/importModule.ts
+++ b/packages/jest-util/src/importModule.ts
@@ -1,0 +1,27 @@
+import {pathToFileURL} from 'url';
+import interopRequireDefault from './interopRequireDefault';
+
+export default async function importModule<T>(filePath: string): Promise<T> {
+  let module: T;
+  try {
+    module = interopRequireDefault(require(filePath)).default;
+  } catch (error) {
+    if (error.code === 'ERR_REQUIRE_ESM') {
+      const configUrl = pathToFileURL(filePath);
+
+      // node `import()` supports URL, but TypeScript doesn't know that
+      const importedConfig = await import(configUrl.href);
+
+      if (!importedConfig.default) {
+        throw new Error(
+          `Jest: Failed to load ESM at ${filePath} - did you use a default export?`,
+        );
+      }
+
+      module = importedConfig.default;
+    } else {
+      throw error;
+    }
+  }
+  return module;
+}

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -23,3 +23,4 @@ export * as preRunMessage from './preRunMessage';
 export {default as pluralize} from './pluralize';
 export {default as formatTime} from './formatTime';
 export {default as tryRealpath} from './tryRealpath';
+export {default as importModule} from './importModule';

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -23,4 +23,4 @@ export * as preRunMessage from './preRunMessage';
 export {default as pluralize} from './pluralize';
 export {default as formatTime} from './formatTime';
 export {default as tryRealpath} from './tryRealpath';
-export {default as importModule} from './importModule';
+export {default as requireOrImportModule} from './requireOrImportModule';

--- a/packages/jest-util/src/requireOrImportModule.ts
+++ b/packages/jest-util/src/requireOrImportModule.ts
@@ -1,8 +1,9 @@
 import {pathToFileURL} from 'url';
+import type {Config} from '@jest/types';
 import interopRequireDefault from './interopRequireDefault';
 
 export default async function requireOrImportModule<T>(
-  filePath: string,
+  filePath: Config.Path,
 ): Promise<T> {
   let module: T;
   try {

--- a/packages/jest-util/src/requireOrImportModule.ts
+++ b/packages/jest-util/src/requireOrImportModule.ts
@@ -1,3 +1,4 @@
+import {isAbsolute} from 'path';
 import {pathToFileURL} from 'url';
 import type {Config} from '@jest/types';
 import interopRequireDefault from './interopRequireDefault';
@@ -6,6 +7,9 @@ export default async function requireOrImportModule<T>(
   filePath: Config.Path,
 ): Promise<T> {
   let module: T;
+  if (!isAbsolute(filePath) && filePath[0] === '.') {
+    throw new Error(`Jest: requireOrImportModule path must be absolute`);
+  }
   try {
     module = interopRequireDefault(require(filePath)).default;
   } catch (error) {

--- a/packages/jest-util/src/requireOrImportModule.ts
+++ b/packages/jest-util/src/requireOrImportModule.ts
@@ -1,7 +1,9 @@
 import {pathToFileURL} from 'url';
 import interopRequireDefault from './interopRequireDefault';
 
-export default async function importModule<T>(filePath: string): Promise<T> {
+export default async function requireOrImportModule<T>(
+  filePath: string,
+): Promise<T> {
   let module: T;
   try {
     module = interopRequireDefault(require(filePath)).default;

--- a/packages/jest-util/src/requireOrImportModule.ts
+++ b/packages/jest-util/src/requireOrImportModule.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {isAbsolute} from 'path';
 import {pathToFileURL} from 'url';
 import type {Config} from '@jest/types';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

According to #11167, we will support ESM of pluggable modules.
We may use the same logic to import them, so I extract it into an util function.
I think it should be useful in later work!

Cons:
 Will lose information of which module type importing in error message
```diff
- `Jest: Failed to load ESM transformer at ${transformPath} - did you use a default export?` 
+ `Jest: Failed to load ESM at ${filePath} - did you use a default export?`
```
But I think it is ok, user can find out by file path.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- [ ] Maybe an e2e test

## TODO

- [ ] Testing
- [ ] Changelog
