### PR TITLE
feat(jest-config): add support for `preset` written in ESM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[jest-circus, jest-jasmine2]` [**BREAKING**] Fail the test instead of just warning when describe returns a value ([#10947](https://github.com/facebook/jest/pull/10947))
 - `[jest-config]` [**BREAKING**] Default to Node testing environment instead of browser (JSDOM) ([#9874](https://github.com/facebook/jest/pull/9874))
 - `[jest-config]` [**BREAKING**] Use `jest-circus` as default test runner ([#10686](https://github.com/facebook/jest/pull/10686))
+- `[jest-config]` Add support for `preset` written in ESM ([#11200](https://github.com/facebook/jest/pull/11200))
 - `[jest-config, jest-runtime]` Support ESM for files other than `.js` and `.mjs` ([#10823](https://github.com/facebook/jest/pull/10823))
 - `[jest-config, jest-runtime]` [**BREAKING**] Use "modern" implementation as default for fake timers ([#10874](https://github.com/facebook/jest/pull/10874) & [#11197](https://github.com/facebook/jest/pull/11197))
 - `[jest-core]` make `TestWatcher` extend `emittery` ([#10324](https://github.com/facebook/jest/pull/10324))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -616,7 +616,7 @@ Specifies notification mode. Requires `notify: true`.
 
 Default: `undefined`
 
-A preset that is used as a base for Jest's configuration. A preset should point to an npm module that has a `jest-preset.json` or `jest-preset.js` file at the root.
+A preset that is used as a base for Jest's configuration. A preset should point to an npm module that has a `jest-preset.json`, `jest-preset.js`, `jest-preset.cjs` or `jest-preset.mjs` file at the root.
 
 For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 

--- a/e2e/__tests__/presets.test.ts
+++ b/e2e/__tests__/presets.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {onNodeVersions} from '@jest/test-utils';
 import runJest from '../runJest';
 
 test('supports json preset', () => {
@@ -12,7 +13,16 @@ test('supports json preset', () => {
   expect(result.exitCode).toBe(0);
 });
 
-test('supports js preset', () => {
-  const result = runJest('presets/js');
+test.each(['js', 'cjs'])('supports %s preset', presetDir => {
+  const result = runJest(`presets/${presetDir}`);
+
   expect(result.exitCode).toBe(0);
+});
+
+onNodeVersions('^12.17.0 || >=13.2.0', () => {
+  test.each(['mjs', 'js-type-module'])('supports %s preset', presetDir => {
+    const result = runJest(`presets/${presetDir}`);
+
+    expect(result.exitCode).toBe(0);
+  });
 });

--- a/e2e/presets/cjs/__tests__/index.js
+++ b/e2e/presets/cjs/__tests__/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('load file mapped by cjs preset', () => {
+  expect(require('./test.foo')).toEqual(42);
+});

--- a/e2e/presets/cjs/node_modules/jest-preset-cjs/jest-preset.cjs
+++ b/e2e/presets/cjs/node_modules/jest-preset-cjs/jest-preset.cjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  moduleNameMapper: {
+    '^.+\\.foo$': 'jest-preset-cjs/mapper.js',
+  },
+};

--- a/e2e/presets/cjs/node_modules/jest-preset-cjs/mapper.js
+++ b/e2e/presets/cjs/node_modules/jest-preset-cjs/mapper.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 42;

--- a/e2e/presets/cjs/package.json
+++ b/e2e/presets/cjs/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "preset": "jest-preset-cjs"
+  }
+}

--- a/e2e/presets/js-type-module/__tests__/index.js
+++ b/e2e/presets/js-type-module/__tests__/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('load file mapped by js preset', () => {
+  expect(require('./test.foo')).toEqual(42);
+});

--- a/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/jest-preset.js
+++ b/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/jest-preset.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  moduleNameMapper: {
+    '^.+\\.foo$': 'jest-preset-js-type-module/mapper.js',
+  },
+};

--- a/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/mapper.js
+++ b/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/mapper.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 42;

--- a/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/package.json
+++ b/e2e/presets/js-type-module/node_modules/jest-preset-js-type-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/e2e/presets/js-type-module/package.json
+++ b/e2e/presets/js-type-module/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "preset": "jest-preset-js-type-module"
+  }
+}

--- a/e2e/presets/mjs/__tests__/index.js
+++ b/e2e/presets/mjs/__tests__/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('load file mapped by mjs preset', () => {
+  expect(require('./test.foo')).toEqual(42);
+});

--- a/e2e/presets/mjs/node_modules/jest-preset-mjs/jest-preset.mjs
+++ b/e2e/presets/mjs/node_modules/jest-preset-mjs/jest-preset.mjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  moduleNameMapper: {
+    '^.+\\.foo$': 'jest-preset-mjs/mapper.js',
+  },
+};

--- a/e2e/presets/mjs/node_modules/jest-preset-mjs/mapper.js
+++ b/e2e/presets/mjs/node_modules/jest-preset-mjs/mapper.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 42;

--- a/e2e/presets/mjs/package.json
+++ b/e2e/presets/mjs/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "preset": "jest-preset-mjs"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Related to #11167

- Add `.cjs`, `.mjs` to the supported extensions for `preset` as well as logic to load them, with `.mjs` for ESM preset and `.cjs` for CommonJS preset
- Clean up some unused mocks in `normalize.test.ts` as well as fix some ts type errors.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added unit tests for happy path
Added e2e tests