### PR TITLE
Switch ts-node `Register` type to `Service` due to deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,7 @@
 - `[eslint-config-fb-strict]` Move package from this repo to `fbjs` repo ([#10739](https://github.com/facebook/jest/pull/10739))
 - `[examples]` Update TypeScript example to show use of newer Jest types ([#10399](https://github.com/facebook/jest/pull/10399))
 - `[jest-cli]` chore: standardize files and folder names ([#10698](https://github.com/facebook/jest/pull/10698))
+- `[jest-config]` Switch ts-node `Register` type to `Service` due to deprecation ([#11210](https://github.com/facebook/jest/pull/11210))
 
 ## 26.6.1
 

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'path';
 import * as fs from 'graceful-fs';
-import type {Register} from 'ts-node';
+import type {Service} from 'ts-node';
 import type {Config} from '@jest/types';
 import {interopRequireDefault, requireOrImportModule} from 'jest-util';
 import {
@@ -79,7 +79,7 @@ export default async function readConfigFileAndSetRootDir(
 const loadTSConfigFile = async (
   configPath: Config.Path,
 ): Promise<Config.InitialOptions> => {
-  let registerer: Register;
+  let registerer: Service;
 
   // Register TypeScript compiler instance
   try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
`ts-node` has moved to deprecate the `Register` type in favour of `Service`. This change address that type update.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
I've run the requested commands from `CONTRIBUTING.md` and verified that all tests pass.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
