### PR TITLE
fix(runtime): handle async transforms of same module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
 - `[jest-runner]` [**BREAKING**] Run transforms over `runnner` ([#8823](https://github.com/facebook/jest/pull/8823))
 - `[jest-runner]` [**BREAKING**] Run transforms over `testRunnner` ([#8823](https://github.com/facebook/jest/pull/8823))
-- `[jest-runtime]` Support for async code transformations ([#11191](https://github.com/facebook/jest/pull/11191))
+- `[jest-runtime]` Support for async code transformations ([#11191](https://github.com/facebook/jest/pull/11191) & [#11220](https://github.com/facebook/jest/pull/11220))
 - `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
 - `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -261,7 +261,7 @@ onNodeVersions('^12.17.0 || >=13.2.0', () => {
       });
       expect(stderr).toMatch(/PASS/);
       expect(json.success).toBe(true);
-      expect(json.numPassedTests).toBe(1);
+      expect(json.numPassedTests).toBe(2);
     });
   });
 

--- a/e2e/transform/async-transformer/__tests__/test.js
+++ b/e2e/transform/async-transformer/__tests__/test.js
@@ -5,8 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import m from '../module-under-test';
+import m, {exportedSymbol} from '../module-under-test';
+import symbol from '../some-symbol';
 
 test('ESM transformer intercepts', () => {
   expect(m).toEqual(42);
+});
+
+test('reexported symbol is same instance', () => {
+  expect(exportedSymbol).toBe(symbol);
 });

--- a/e2e/transform/async-transformer/my-transform.cjs
+++ b/e2e/transform/async-transformer/my-transform.cjs
@@ -7,14 +7,29 @@
 
 'use strict';
 
+const {promisify} = require('util');
+
+const wait = promisify(setTimeout);
+
 const fileToTransform = require.resolve('./module-under-test');
+const fileToTransform2 = require.resolve('./some-symbol');
 
 module.exports = {
   async processAsync(src, filepath) {
-    if (filepath !== fileToTransform) {
+    if (filepath !== fileToTransform && filepath !== fileToTransform2) {
       throw new Error(`Unsupported filepath ${filepath}`);
     }
 
-    return 'export default 42;';
+    if (filepath === fileToTransform2) {
+      // we want to wait to ensure the module cache is populated with the correct module
+      await wait(100);
+
+      return src;
+    }
+
+    return src.replace(
+      "export default 'It was not transformed!!'",
+      'export default 42',
+    );
   },
 };

--- a/e2e/transform/async-transformer/package.json
+++ b/e2e/transform/async-transformer/package.json
@@ -3,7 +3,8 @@
   "jest": {
     "testEnvironment": "node",
     "transform": {
-      "module-under-test\\.js$": "<rootDir>/my-transform.cjs"
+      "module-under-test\\.js$": "<rootDir>/my-transform.cjs",
+      "some-symbol\\.js$": "<rootDir>/my-transform.cjs"
     }
   }
 }

--- a/e2e/transform/async-transformer/some-symbol.js
+++ b/e2e/transform/async-transformer/some-symbol.js
@@ -5,8 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import symbol from './some-symbol';
-
-export const exportedSymbol = symbol;
-
-export default 'It was not transformed!!';
+export default Symbol('hello!');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The code currently ends up putting duplicate modules into the module cache, leading to different instances added to the cache (or rather, newer ones overriding old ones) which breaks referential identity.

We now have a sort of mutex on the cache key as well as asserting the cache does not have an entry for the cache key before we put the module into it.

Fixes #11214.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
