### PR TITLE
docs: correct jest cards jagged edges in firefox

### DIFF
--- a/website/static/css/custom.scss
+++ b/website/static/css/custom.scss
@@ -106,6 +106,7 @@ div.jest-card {
   height: 340px;
   transition: transform 0.2s;
   transform-style: preserve-3d;
+  outline: 1px solid transparent;
 }
 
 div.jest-card-front,

--- a/website/static/css/custom.scss
+++ b/website/static/css/custom.scss
@@ -106,7 +106,6 @@ div.jest-card {
   height: 340px;
   transition: transform 0.2s;
   transform-style: preserve-3d;
-  outline: 1px solid transparent;
 }
 
 div.jest-card-front,
@@ -120,6 +119,7 @@ div.jest-card-front,
   display: flex;
   justify-content: center;
   align-items: center;
+  outline: 1px solid transparent;
 }
 
 div.jest-card-front {


### PR DESCRIPTION
## Summary

correct rendering of jest card - jagged edges in firefox

**before:**

![image](https://user-images.githubusercontent.com/625469/112194147-dff5ff80-8c08-11eb-8a61-f59c76b2f673.png)
![image](https://user-images.githubusercontent.com/625469/112194175-e5ebe080-8c08-11eb-91f4-41e793a0fa08.png)

**after:**

![image](https://user-images.githubusercontent.com/625469/112194290-fd2ace00-8c08-11eb-8449-a7c1710e42e5.png)
![image](https://user-images.githubusercontent.com/625469/112194262-f734ed00-8c08-11eb-8f16-aee456ad60a9.png)
