### PR TITLE
test(e2e): exclude several sub folders in `e2e/presets` from clean e2e

### DIFF
--- a/scripts/cleanE2e.js
+++ b/scripts/cleanE2e.js
@@ -13,8 +13,11 @@ const {sync: rimraf} = require('rimraf');
 
 const excludedModules = [
   'e2e/global-setup-node-modules/node_modules/',
+  'e2e/presets/cjs/node_modules/',
   'e2e/presets/js/node_modules/',
+  'e2e/presets/js-type-module/node_modules/',
   'e2e/presets/json/node_modules/',
+  'e2e/presets/mjs/node_modules/',
 ].map(dir => normalize(dir));
 
 const e2eNodeModules = glob('e2e/*/node_modules/')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Exclude several sub folders under `e2e/presets` from clean e2e script.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Clean e2e script should not delete `node_modules` folders in several sub folders under `e2e/presets`
