### PR TITLE
feat: Allow random order of globs

### DIFF
--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@types/graceful-fs": "^4.1.2",
     "@types/is-ci": "^2.0.0",
-    "@types/micromatch": "^4.0.1",
     "@types/picomatch": "^2.2.2"
   },
   "engines": {

--- a/packages/jest-util/src/__tests__/globsToMatcher.test.ts
+++ b/packages/jest-util/src/__tests__/globsToMatcher.test.ts
@@ -5,94 +5,74 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import micromatch = require('micromatch');
 import globsToMatcher from '../globsToMatcher';
 
-it('works like micromatch with only positive globs', () => {
+it('works with only positive globs', () => {
   const globs = ['**/*.test.js', '**/*.test.jsx'];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
-
-  expect(matcher('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(false);
+  expect(matcher('some-module.test.js')).toBe(true);
 });
 
-it('works like micromatch with a mix of overlapping positive and negative globs', () => {
+it('works with a mix of overlapping positive and negative globs', () => {
   const globs = ['**/*.js', '!**/*.test.js', '**/*.test.js'];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
-
-  expect(matcher('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('some-module.test.js')).toBe(false);
 
   const globs2 = ['**/*.js', '!**/*.test.js', '**/*.test.js', '!**/*.test.js'];
   const matcher2 = globsToMatcher(globs2);
 
-  expect(matcher2('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs2).length > 0,
-  );
-
-  expect(matcher2('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs2).length > 0,
-  );
+  expect(matcher2('some-module.js')).toBe(true);
+  expect(matcher2('some-module.test.js')).toBe(false);
 });
 
-it('works like micromatch with only negative globs', () => {
+it('works with only negative globs', () => {
   const globs = ['!**/*.test.js', '!**/*.test.jsx'];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
-
-  expect(matcher('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('some-module.test.js')).toBe(false);
 });
 
-it('works like micromatch with empty globs', () => {
+it('works with empty globs', () => {
   const globs = [];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
-
-  expect(matcher('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(false);
+  expect(matcher('some-module.test.js')).toBe(false);
 });
 
-it('works like micromatch with pure negated extglobs', () => {
+it('works with pure negated extglobs', () => {
   const globs = ['**/*.js', '!(some-module.test.js)'];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
-
-  expect(matcher('some-module.test.js')).toBe(
-    micromatch(['some-module.test.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('some-module.test.js')).toBe(false);
 });
 
-it('works like micromatch with negated extglobs', () => {
+it('works with negated extglobs', () => {
   const globs = ['**/*.js', '!(tests|coverage)/*.js'];
   const matcher = globsToMatcher(globs);
 
-  expect(matcher('some-module.js')).toBe(
-    micromatch(['some-module.js'], globs).length > 0,
-  );
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('tests/some-module.test.js')).toBe(false);
+});
 
-  expect(matcher('tests/some-module.test.js')).toBe(
-    micromatch(['tests/some-module.test.js'], globs).length > 0,
-  );
+it('works with negated extglobs in reverse order', () => {
+  const globs = ['!(tests|coverage)/*.js', '**/*.js'];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('tests/some-module.test.js')).toBe(false);
+});
+
+it('works with negated glob in reverse order', () => {
+  const globs = ['!tests/*.js', '**/*.js'];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(true);
+  expect(matcher('tests/some-module.test.js')).toBe(false);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -14015,7 +14015,6 @@ fsevents@^1.2.7:
     "@jest/types": ^27.0.0-next.8
     "@types/graceful-fs": ^4.1.2
     "@types/is-ci": ^2.0.0
-    "@types/micromatch": ^4.0.1
     "@types/node": "*"
     "@types/picomatch": ^2.2.2
     chalk: ^4.0.0


### PR DESCRIPTION
BREAKING CHANGE: This changes the behavior of all config options with arrays of globs to not respect the order similar to how it was in jest 24 and lower.

Fixes #9464 (one or the other way)

## Summary

Some history: micromatch 3 (jest 24 and lower) allowed random order of globs (like `['!foo.js', 'foo.js']` would ignore `foo.js`), whereas micromatch 4 changed this and respects the order (`['!foo.js', 'foo.js']` would match `foo.js` because the second glob runs after the first)
Also negations work slightly different, for example `['*/**.js', '!(test)/**/*.js']` in mm 3 would match `foo.js`, in mm 4 it would not. Both versions are kinda correct because the negated glob alone only matches "any js file in at least one subfolder that is not named test", because of `!(test)/` (this is also that way in globs in bash), but combined with the first (positive) glob the behavior is outside of the "specified" scope of globbing and more like up to the libs how the combine and merge multiple globs.

Both of these changes also happened in `jest` in version 25 when `micromatch` was updated to version 4. (e.g. `collectCoverageFrom`).

Unfortunately, there is no right or wrong here and it's more based on opinion, so treat this PR more like a discussion for now.

So either jest keeps the way it does globs right now (ordered globs) which allows things like:
```js
// Match all js files in all subfolders, 
// but ignore all js files in subfolders in the folder `test` and `coverage`, 
// except for the js files in `test/utils`
[
  '**/*.js',
  '!(test|coverage)/**/*.js',
  'test/utils/*.js'
]
```
To accomplish the same with this PR:

```
[
  '**/*.js',
  '!coverage/**/*.js',
  '!test/!(utils)/**/*.js'
]
```

Or switch back to the old behavior (jest 24 or lower) where one can do:
```
// Order does not matter, once a file is ignored it stays ignored, even if it would match in a subsequent glob
[
  '!(test|coverage)/**/*.js',
  '**/*.js'
]
```

Oh and the same can independently be decided for the negated (mis)behavior, although that could actually be considered broken and be fixed, as hardly anyone will be able to take advantage of the current feature. (I will bring this also up in mm/pm itself)

## Test plan

Adjusted unit tests and added new unit tests

## TODO

- [ ] Discuss and find a preferred way
- [ ] Changelog for this PR
- [ ] Update docs for the config options with multiple globs and specify the behaviour the globs have.
