### PR TITLE
chore: use a matrix to simplify test-node in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
             parameters:
               node-version: ['14']
       - test-node:
-          name: "test-node-partial"
+          name: test-node-partial
           partial: true
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,5 @@
+version: 2.1
+
 aliases:
   - &filter-ignore-gh-pages
     branches:
@@ -11,15 +13,18 @@ aliases:
 
 orbs:
   node: circleci/node@4.0.0
-version: 2.1
+
 jobs:
-  test-node-10:
+  test-node:
+    parameters:
+      node-version:
+        type: string
     working_directory: ~/jest
     executor: node/default
     steps:
       - checkout
       - node/install:
-          node-version: '10'
+          node-version: << parameters.node-version >>
           install-npm: false
       - node/install-packages: *install
       - run:
@@ -41,55 +46,12 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-node-12:
-    working_directory: ~/jest
-    executor: node/default
-    steps:
-      - checkout
-      - node/install:
-          node-version: '12'
-          install-npm: false
-      - node/install-packages: *install
-      - run:
-          command: yarn test-ci-partial
-      - store_test_results:
-          path: reports/junit
-
-  test-node-14:
-    working_directory: ~/jest
-    executor: node/default
-    steps:
-      - checkout
-      - node/install:
-          node-version: '14'
-          install-npm: false
-      - node/install-packages: *install
-      - run:
-          command: yarn test-ci
-      - store_test_results:
-          path: reports/junit
-
-  test-node-15:
-    working_directory: ~/jest
-    executor: node/default
-    steps:
-      - checkout
-      - node/install:
-          node-version: '15'
-          install-npm: false
-      - node/install-packages: *install
-      - run:
-          command: yarn test-ci-partial
-      - store_test_results:
-          path: reports/junit
-
 # Workflows enables us to run multiple jobs in parallel
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
-      - test-node-10
-      - test-node-12
-      - test-node-14
-      - test-node-15 # current
+      - test-node:
+          matrix:
+            parameters:
+              node-version: ['10', '12', '14', '15']
       - test-jest-jasmine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
             parameters:
               node-version: ['14']
       - test-node:
-          name: test-node-partial
+          name: test-node-partial-<< matrix.node-version >>
           partial: true
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
     parameters:
       node-version:
         type: string
+      partial:
+        type: boolean
+        default: false
     working_directory: ~/jest
     executor: node/default
     steps:
@@ -27,8 +30,16 @@ jobs:
           node-version: << parameters.node-version >>
           install-npm: false
       - node/install-packages: *install
-      - run:
-          command: yarn test-ci-partial
+      - when:
+          condition: << parameters.partial >>
+          steps:
+            - run:
+                command: yarn test-ci-partial
+      - unless:
+          condition: << parameters.partial >>
+          steps:
+            - run:
+                command: yarn test-ci
       - store_test_results:
           path: reports/junit
 
@@ -53,5 +64,11 @@ workflows:
       - test-node:
           matrix:
             parameters:
-              node-version: ['10', '12', '14', '15']
+              node-version: ['14']
+      - test-node:
+          name: "test-node-partial"
+          partial: true
+          matrix:
+            parameters:
+              node-version: ['10', '12', '15']
       - test-jest-jasmine


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We can simplify the current configuration of CircleCI by creating a `test-node` job that will take a `node-version` as a parameter. That way, we'll be able to easily add/remove node versions from the workflow with a matrix.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- [x] Should test node 10
- [x] Should test node 12
- [x] Should test node 14
- [x] Should test node 15
