### PR TITLE
docs: Clarify CLI param testPathIgnorePatterns usage

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -321,9 +321,11 @@ Note that `column` is 0-indexed while `line` is not.
 
 A regexp pattern string that is matched against all tests paths before executing the test. On Windows, you will need to use `/` as a path separator or escape `\` as `\\`.
 
-### `--testPathIgnorePatterns=[array]`
+### `--testPathIgnorePatterns=<regex>|[array]`
 
-An array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+A single or array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+
+To pass as an array use escaped parentheses and space delimited regexps such as `\(/node_modules/ /tests/e2e/\)`. Alternatively, you can omit parentheses by combining regexps into a single regexp like `/node_modules/|/tests/e2e/`. These two examples are equivalent.
 
 ### `--testRunner=<path>`
 

--- a/website/versioned_docs/version-25.x/CLI.md
+++ b/website/versioned_docs/version-25.x/CLI.md
@@ -305,9 +305,11 @@ Note that `column` is 0-indexed while `line` is not.
 
 A regexp pattern string that is matched against all tests paths before executing the test. On Windows, you will need to use `/` as a path separator or escape `\` as `\\`.
 
-### `--testPathIgnorePatterns=[array]`
+### `--testPathIgnorePatterns=<regex>|[array]`
 
-An array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+A single or array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+
+To pass as an array use escaped parentheses and space delimited regexps such as `\(/node_modules/ /tests/e2e/\)`. Alternatively, you can omit parentheses by combining regexps into a single regexp like `/node_modules/|/tests/e2e/`. These two examples are equivalent.
 
 ### `--testRunner=<path>`
 

--- a/website/versioned_docs/version-26.x/CLI.md
+++ b/website/versioned_docs/version-26.x/CLI.md
@@ -321,9 +321,11 @@ Note that `column` is 0-indexed while `line` is not.
 
 A regexp pattern string that is matched against all tests paths before executing the test. On Windows, you will need to use `/` as a path separator or escape `\` as `\\`.
 
-### `--testPathIgnorePatterns=[array]`
+### `--testPathIgnorePatterns=<regex>|[array]`
 
-An array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+A single or array of regexp pattern strings that are tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those tests with a path that does not match with the provided regexp expressions.
+
+To pass as an array use escaped parentheses and space delimited regexps such as `\(/node_modules/ /tests/e2e/\)`. Alternatively, you can omit parentheses by combining regexps into a single regexp like `/node_modules/|/tests/e2e/`. These two examples are equivalent.
 
 ### `--testRunner=<path>`
 


### PR DESCRIPTION
## Summary

It took me way too long to figure out the correct way to pass multiple regexps as an array. Update the docs with more information and examples.

Also clarify the testPathIgnorePatterns param accepts either a string or an array.

## Test plan

Ran examples I added to docs in my local environment.
