### PR TITLE
docs: Fix broken `Edit this page` link within documentation.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -34,7 +34,7 @@ module.exports = {
             if (locale !== 'en') {
               return `https://crowdin.com/project/jest-v2/${locale}`;
             }
-            return `https://github.com/facebook/jest/edit/master/docs/${versionDocsDirPath}/${docPath}`;
+            return `https://github.com/facebook/jest/edit/master/website/${versionDocsDirPath}/${docPath}`;
           },
           path: '../docs',
           sidebarPath: './sidebars.json',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Added a minor commit in order to fix the broken `Edit this page` link within docs.
Earlier, The <code><a href ='https://github.com/facebook/jest/blob/master/website/docusaurus.config.js'>docusaurus.config.js</a></code> was referring the Url to be of pattern: 
```
https://github.com/facebook/jest/edit/master/docs/${versionDocsDirPath}/${docPath}
```
which returned a 404 error while redirecting to Github. (Seems like was introduced within f73d5f6372a2570b7a38255bc0a69e0deacf67f5).

Rectified by editing the link to point the `versioned_docs` within the `website` directory rather than the `docs` directory. 
More clearly, 

Earlier: 
```
https://github.com/facebook/jest/edit/master/docs/${versionDocsDirPath}/${docPath}
```
Now:
```
https://github.com/facebook/jest/edit/master/website/${versionDocsDirPath}/${docPath}
```
 