### PR TITLE
docs(globals-api): correct `test.concurrent.each` example to be async function

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -522,7 +522,7 @@ test.concurrent.each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])('.add(%i, %i)', (a, b, expected) => {
+])('.add(%i, %i)', async (a, b, expected) => {
   expect(a + b).toBe(expected);
 });
 ```
@@ -545,7 +545,7 @@ test.concurrent.each`
   ${1} | ${1} | ${2}
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
-`('returns $expected when $a is added $b', ({a, b, expected}) => {
+`('returns $expected when $a is added $b', async ({a, b, expected}) => {
   expect(a + b).toBe(expected);
 });
 ```

--- a/website/versioned_docs/version-26.x/GlobalAPI.md
+++ b/website/versioned_docs/version-26.x/GlobalAPI.md
@@ -522,7 +522,7 @@ test.concurrent.each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])('.add(%i, %i)', (a, b, expected) => {
+])('.add(%i, %i)', async (a, b, expected) => {
   expect(a + b).toBe(expected);
 });
 ```
@@ -545,7 +545,7 @@ test.concurrent.each`
   ${1} | ${1} | ${2}
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
-`('returns $expected when $a is added $b', ({a, b, expected}) => {
+`('returns $expected when $a is added $b', async ({a, b, expected}) => {
   expect(a + b).toBe(expected);
 });
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Example codes for `test.concurrent.each` missed `async` keyword. This PR is to correct the example codes by adding the `async` keyword.

https://jestjs.io/docs/api#testconcurrenteachtablename-fn-timeout
https://jestjs.io/docs/next/api#testconcurrenteachtablename-fn-timeout

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Start doc server and navigate to `Globals` chapter in `API` section. Check if example codes for `test.concurrent.each` have `async` keyword