### PR TITLE
docs: Correct mockClear api docs

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -81,11 +81,11 @@ mockFn.mock.instances[1] === b; // true
 
 ### `mockFn.mockClear()`
 
-Resets all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances) arrays.
+Resets all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`mockFn.mock.instances`](#mockfnmockinstances) and [`mockFn.mock.results`](#mockfnmockresults) arrays.
 
 Often this is useful when you want to clean up a mock's usage data between two assertions.
 
-Beware that `mockClear` will replace `mockFn.mock`, not just [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances). You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
+Beware that `mockClear` will replace `mockFn.mock`, not just these three properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically between tests.
 
@@ -94,8 +94,6 @@ The [`clearMocks`](configuration#clearmocks-boolean) configuration option is ava
 Does everything that [`mockFn.mockClear()`](#mockfnmockclear) does, and also removes any mocked return values or implementations.
 
 This is useful when you want to completely reset a _mock_ back to its initial state. (Note that resetting a _spy_ will result in a function with no return value).
-
-Beware that `mockReset` will replace `mockFn.mock`, not just [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances). You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 
 ### `mockFn.mockRestore()`
 

--- a/website/versioned_docs/version-26.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-26.x/MockFunctionAPI.md
@@ -81,11 +81,11 @@ mockFn.mock.instances[1] === b; // true
 
 ### `mockFn.mockClear()`
 
-Resets all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances) arrays.
+Resets all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`mockFn.mock.instances`](#mockfnmockinstances) and [`mockFn.mock.results`](#mockfnmockresults) arrays.
 
 Often this is useful when you want to clean up a mock's usage data between two assertions.
 
-Beware that `mockClear` will replace `mockFn.mock`, not just [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances). You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
+Beware that `mockClear` will replace `mockFn.mock`, not just these three properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically between tests.
 
@@ -94,8 +94,6 @@ The [`clearMocks`](configuration#clearmocks-boolean) configuration option is ava
 Does everything that [`mockFn.mockClear()`](#mockfnmockclear) does, and also removes any mocked return values or implementations.
 
 This is useful when you want to completely reset a _mock_ back to its initial state. (Note that resetting a _spy_ will result in a function with no return value).
-
-Beware that `mockReset` will replace `mockFn.mock`, not just [`mockFn.mock.calls`](#mockfnmockcalls) and [`mockFn.mock.instances`](#mockfnmockinstances). You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 
 ### `mockFn.mockRestore()`
 


### PR DESCRIPTION
Documentation  page:
https://jestjs.io/docs/mock-function-api#mockfnmockclear

**jest@26.6.3**

## Summary
`mock.mockClear()` and `clearMocks: true` both resets `mock.calls`, `mock.instances` and `mock.results` of a mock function not only the first two ones that doc says.

## Code
```js
// jest.config.js

module.exports = {
   clearMocks: false,
   resetMocks: false
}
```
```js
const mock = jest.fn(x => x * 2);

beforeEach(() => {
   mock.mockClear()
})

it('test1', () => {
   mock(2);
   mock(3);
   console.log(mock.mock.calls, mock.mock.instances, mock.mock.results);
   // [ [ 2 ], [ 3 ] ]
   // [ undefined, undefined ]
   // [ { type: 'return', value: 4 }, { type: 'return', value: 6 } ]
});

it('test2', () => {
   console.log(mock.mock.calls, mock.mock.instances, mock.mock.results);
   // [] [] []
});

```

Removing `beforeEach()` and toggling `clearMocks` config option won't affect the result.
