### PR TITLE
feat: Better print for sparse arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[jest-transform]` Support transpiled transformers ([#11193](https://github.com/facebook/jest/pull/11193))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
+- `[pretty-format]` Better print for sparse arrays ([11326](https://github.com/facebook/jest/pull/11326))
 
 ### Fixes
 

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -53,6 +53,12 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  ,\n  ,\n  4,\n]');
   });
 
+  it('prints a sparse array with value surrounded by holes', () => {
+    // eslint-disable-next-line no-sparse-arrays
+    const val = [, 5, ,];
+    expect(prettyFormat(val)).toEqual('Array [\n  ,\n  5,\n  ,\n]');
+  });
+
   it('prints a sparse array also containing undefined values', () => {
     // eslint-disable-next-line no-sparse-arrays
     const val = [1, , undefined, undefined, , 4];

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -51,6 +51,13 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  ,\n  ,\n  4,\n]');
   });
 
+  it('prints a sparse array also containing undefined values', () => {
+    const val = [1, , undefined, undefined, , 4];
+    expect(prettyFormat(val)).toEqual(
+      'Array [\n  1,\n  ,\n  undefined,\n  undefined,\n  ,\n  4,\n]',
+    );
+  });
+
   it('prints a empty typed array', () => {
     const val = new Uint32Array(0);
     expect(prettyFormat(val)).toEqual('Uint32Array []');

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -41,6 +41,16 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  2,\n  3,\n]');
   });
 
+  it('prints a sparse array with only holes', () => {
+    const val = [, , ,];
+    expect(prettyFormat(val)).toEqual('Array [\n  ,\n  ,\n  ,\n]');
+  });
+
+  it('prints a sparse array with items', () => {
+    const val = [1, , , 4];
+    expect(prettyFormat(val)).toEqual('Array [\n  1,\n  ,\n  ,\n  4,\n]');
+  });
+
   it('prints a empty typed array', () => {
     const val = new Uint32Array(0);
     expect(prettyFormat(val)).toEqual('Uint32Array []');

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -42,16 +42,19 @@ describe('prettyFormat()', () => {
   });
 
   it('prints a sparse array with only holes', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const val = [, , ,];
     expect(prettyFormat(val)).toEqual('Array [\n  ,\n  ,\n  ,\n]');
   });
 
   it('prints a sparse array with items', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const val = [1, , , 4];
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  ,\n  ,\n  4,\n]');
   });
 
   it('prints a sparse array also containing undefined values', () => {
+    // eslint-disable-next-line no-sparse-arrays
     const val = [1, , undefined, undefined, , 4];
     expect(prettyFormat(val)).toEqual(
       'Array [\n  1,\n  ,\n  undefined,\n  undefined,\n  ,\n  4,\n]',

--- a/packages/pretty-format/src/collections.ts
+++ b/packages/pretty-format/src/collections.ts
@@ -142,9 +142,11 @@ export function printListItems(
     const indentationNext = indentation + config.indent;
 
     for (let i = 0; i < list.length; i++) {
-      result +=
-        indentationNext +
-        printer(list[i], config, indentationNext, depth, refs);
+      result += indentationNext;
+
+      if (i in list) {
+        result += printer(list[i], config, indentationNext, depth, refs);
+      }
 
       if (i < list.length - 1) {
         result += ',' + config.spacingInner;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

With current version of Jest, sparse arrays are handled as any other arrays when printing them. The resulting string replaces holes by `undefined`. This PR replaces the way sparse arrays are printed to show holes as holes while keeping undefined values as undefined values.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tests have been added to check the new behaviour.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
