### PR TITLE
fix: export default in test environments

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1066,7 +1066,7 @@ Example:
 
 ```js
 // my-custom-environment
-const NodeEnvironment = require('jest-environment-node');
+const NodeEnvironment = require('jest-environment-node').default;
 
 class CustomEnvironment extends NodeEnvironment {
   constructor(config, context) {

--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -83,7 +83,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const puppeteer = require('puppeteer');
-const NodeEnvironment = require('jest-environment-node');
+const NodeEnvironment = require('jest-environment-node').default;
 
 const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup');
 

--- a/e2e/test-environment-async/TestEnvironment.js
+++ b/e2e/test-environment-async/TestEnvironment.js
@@ -9,7 +9,7 @@
 
 const fs = require('fs');
 const os = require('os');
-const JSDOMEnvironment = require('jest-environment-jsdom');
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
 const {createDirectory} = require('jest-util');
 
 const DIR = os.tmpdir() + '/jest-test-environment';

--- a/e2e/test-environment-circus-async/CircusAsyncHandleTestEventEnvironment.js
+++ b/e2e/test-environment-circus-async/CircusAsyncHandleTestEventEnvironment.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const JSDOMEnvironment = require('jest-environment-jsdom');
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/e2e/test-environment-circus/CircusHandleTestEventEnvironment.js
+++ b/e2e/test-environment-circus/CircusHandleTestEventEnvironment.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const JSDOMEnvironment = require('jest-environment-jsdom');
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
 
 class TestEnvironment extends JSDOMEnvironment {
   handleTestEvent(event) {

--- a/e2e/test-environment/DocblockPragmasEnvironment.js
+++ b/e2e/test-environment/DocblockPragmasEnvironment.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const JSDOMEnvironment = require('jest-environment-jsdom');
+const JSDOMEnvironment = require('jest-environment-jsdom').default;
 
 class TestEnvironment extends JSDOMEnvironment {
   constructor(config, context) {

--- a/e2e/test-environment/EsmDefaultEnvironment.js
+++ b/e2e/test-environment/EsmDefaultEnvironment.js
@@ -8,7 +8,7 @@
 
 exports.__esModule = true;
 
-const NodeEnvironment = require('jest-environment-node');
+const NodeEnvironment = require('jest-environment-node').default;
 
 class Env extends NodeEnvironment {
   constructor(config, options) {

--- a/examples/mongodb/mongo-environment.js
+++ b/examples/mongodb/mongo-environment.js
@@ -1,5 +1,5 @@
 // mongo-environment.js
-const NodeEnvironment = require('jest-environment-node');
+const NodeEnvironment = require('jest-environment-node').default;
 
 const path = require('path');
 

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {makeProjectConfig} from '@jest/test-utils';
-import JSDomEnvironment = require('../');
+import JSDomEnvironment from '../';
 
 describe('JSDomEnvironment', () => {
   it('should configure setTimeout/setInterval to use the browser api', () => {

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -136,4 +136,4 @@ class JSDOMEnvironment implements JestEnvironment {
   }
 }
 
-export = JSDOMEnvironment;
+export default JSDOMEnvironment;

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {makeProjectConfig} from '@jest/test-utils';
-import NodeEnvironment = require('../');
+import NodeEnvironment from '../';
 
 const isTextEncoderDefined = typeof TextEncoder === 'function';
 

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -117,4 +117,4 @@ class NodeEnvironment implements JestEnvironment {
   }
 }
 
-export = NodeEnvironment;
+export default NodeEnvironment;


### PR DESCRIPTION
## Summary

Really nice that Jest 27 allows to write custom environments in TypeScript (#8751). I was playing with it. All works really well. Thanks!

Just a detail. Imports look clumsy in TS – `import NodeEnvironment = require('jest-environment-node')`. Perhaps `export default` could be used instead of `export =`? This way TS and MJS imports look good, but a breaking change for CJS users is introduced. Is there a better solution?

(Alternatively TS uses can set `"esModuleInterop": true`, but this isn’t elegant.)

## Test plan

Existing tests are updated.