### PR TITLE
feat(pretty-format): Export Printer type

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -42,6 +42,7 @@ export type {
   NewPlugin,
   Plugin,
   Plugins,
+  Printer,
   Refs,
   Theme,
 } from './types';


### PR DESCRIPTION

## Summary

In short: Looks like the export of `Printer` was forgotten

When writing helper functions for custom plugin the printer type might be required for explicit signatures. For example, `printChildren` used by `DOMElement` already uses this type and I don't see a reason why userland implementations wouldn't be structured that way.

## Test plan

- [x] CI green
- [x] Build enables https://github.com/testing-library/dom-testing-library/pull/907/files#diff-b0f133461be07e5181ff452295d10234a5065b120afb54e011811e454df28d25R4
