### PR TITLE
chore: add GH Action to lock older closed issues and PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -14,11 +14,14 @@ jobs:
           issue-lock-inactive-days: '30'
           issue-exclude-labels: 'Discussion'
           issue-lock-comment: >
-            This issue has been automatically locked since there
-            has not been any recent activity after it was closed.
-            Please open a new issue for related bugs.
+            This issue has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+            
+            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jestjs) or our [discord channel](https://discord.gg/j6FKKQQrW9) for questions.
+
+
           pr-lock-inactive-days: '30'
           pr-lock-comment: >
-            This pull request has been automatically locked since there
-            has not been any recent activity after it was closed.
-            Please open a new issue for related bugs.
+            This pull request has been automatically locked since there has not been any recent activity after it was closed. Please open a new issue for related bugs.
+            
+            Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jestjs) or our [discord channel](https://discord.gg/j6FKKQQrW9) for questions.
+

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,24 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '30'
+          issue-exclude-labels: 'Discussion'
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-lock-inactive-days: '30'
+          pr-lock-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We have issues managing the issue tracker

![image](https://user-images.githubusercontent.com/1404810/116036910-a9782e00-a667-11eb-8f47-462d3f5f3db1.png)

Personally, a part of that is that notifications on really old issues pile up. I currently have over 500 unread notifications from this repo, and looking at the first 25, 6 of them are in closed issues/PRs, and the next 25 there are 8. I hope that by locking old threads there will be less noise and possibly easier to stay on top of issues as the (draining) distraction of comments on issues that have sometimes been closed for many years bubble up. Inbox zero is probably not realistic either way, but at least the hope is that new issues will also include full reproductions etc instead of a relatively common "this is still an issue"

I considered GH discussions but

1. I don't have access to enabling it
1. I'd probably still get notifications? I don't want to create an expectation that we'll answer Qs there instead
1. StackOverflow/Discord works pretty good?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->