### PR TITLE
<C-u> to clear watch mode pattern prompt 

### DIFF
--- a/packages/jest-watcher/src/constants.ts
+++ b/packages/jest-watcher/src/constants.ts
@@ -15,6 +15,7 @@ export const KEYS = {
   BACKSPACE: Buffer.from(isWindows ? '08' : '7f', 'hex').toString(),
   CONTROL_C: '\u0003',
   CONTROL_D: '\u0004',
+  CONTROL_U: '\u0015',
   ENTER: '\r',
   ESCAPE: '\u001b',
 };

--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -73,16 +73,16 @@ export default class Prompt {
         this._onSuccess(this._selection || this._value);
         this.abort();
         break;
+      case KEYS.ESCAPE:
+        this._entering = false;
+        this._onCancel(this._value);
+        this.abort();
+        break;
       case KEYS.CONTROL_U:
         this._value = "";
         this._offset = -1;
         this._selection = null;
         this._onChange();
-        break;
-      case KEYS.ESCAPE:
-        this._entering = false;
-        this._onCancel(this._value);
-        this.abort();
         break;
       case KEYS.ARROW_DOWN:
         this._offset = Math.min(this._offset + 1, this._promptLength - 1);

--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -73,6 +73,12 @@ export default class Prompt {
         this._onSuccess(this._selection || this._value);
         this.abort();
         break;
+      case KEYS.CONTROL_U:
+        this._value = "";
+        this._offset = -1;
+        this._selection = null;
+        this._onChange();
+        break;
       case KEYS.ESCAPE:
         this._entering = false;
         this._onCancel(this._value);


### PR DESCRIPTION

## Summary

Many users will expect Ctrl+u to behave as elsewhere in their terminal environment.
The workaround requires pressing backspace a lot to clear the line manually.

