### PR TITLE
fix: missing collectCoverage after init (#11348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `[jest-cli]` Use testFailureExitCode when bailing from a failed test ([#10958](https://github.com/facebook/jest/pull/10958))
 - `[jest-cli]` Print custom error if error thrown from global hooks is not an error already ([#11003](https://github.com/facebook/jest/pull/11003))
 - `[jest-cli]` Allow running multiple "projects" from programmatic API ([#11307](https://github.com/facebook/jest/pull/11307))
+- `[jest-cli]` Fix missing collectCoverage after init ([#11353](https://github.com/facebook/jest/pull/11353))
 - `[jest-config]` [**BREAKING**] Change default file extension order by moving json behind ts and tsx ([10572](https://github.com/facebook/jest/pull/10572))
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))
 - `[jest-core]` Don't report PerformanceObserver as open handle ([#11123](https://github.com/facebook/jest/pull/11123))

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -92,7 +92,10 @@ describe('init', () => {
         const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
         const evaluatedConfig = eval(writtenJestConfig);
 
-        expect(evaluatedConfig).toEqual({collectCoverage: true, coverageDirectory: 'coverage'});
+        expect(evaluatedConfig).toEqual({
+          collectCoverage: true,
+          coverageDirectory: 'coverage',
+        });
       });
 
       it('should create configuration for {coverageProvider: "babel"}', async () => {

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -92,7 +92,7 @@ describe('init', () => {
         const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
         const evaluatedConfig = eval(writtenJestConfig);
 
-        expect(evaluatedConfig).toEqual({coverageDirectory: 'coverage'});
+        expect(evaluatedConfig).toEqual({collectCoverage: true, coverageDirectory: 'coverage'});
       });
 
       it('should create configuration for {coverageProvider: "babel"}', async () => {

--- a/packages/jest-cli/src/init/generateConfigFile.ts
+++ b/packages/jest-cli/src/init/generateConfigFile.ts
@@ -47,6 +47,7 @@ const generateConfigFile = (
 
   if (coverage) {
     Object.assign(overrides, {
+      collectCoverage: true,
       coverageDirectory: 'coverage',
     });
   }


### PR DESCRIPTION
## Summary

https://github.com/facebook/jest/issues/11348

## Test plan

- `jest --init`
- reply positively to collect coverage question
- collectCoverage: true is present in jest config