### PR TITLE
feat: add support for <C-u> to clear line in prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[jest-transform]` [**BREAKING**] Do not export `ScriptTransformer` class, instead export the async function `createScriptTransformer` ([#11163](https://github.com/facebook/jest/pull/11163))
 - `[jest-transform]` Async code transformations ([#9889](https://github.com/facebook/jest/pull/9889))
 - `[jest-transform]` Support transpiled transformers ([#11193](https://github.com/facebook/jest/pull/11193))
+- `[jest-watcher]` Added support for clearing the line when `<C-u>` is pressed in a watch mode pattern prompt ([#11358](https://github.com/facebook/jest/pull/11358))
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
 - `[pretty-format]` Better print for sparse arrays ([11326](https://github.com/facebook/jest/pull/11326))

--- a/packages/jest-watcher/src/constants.ts
+++ b/packages/jest-watcher/src/constants.ts
@@ -15,6 +15,7 @@ export const KEYS = {
   BACKSPACE: Buffer.from(isWindows ? '08' : '7f', 'hex').toString(),
   CONTROL_C: '\u0003',
   CONTROL_D: '\u0004',
+  CONTROL_U: '\u0015',
   ENTER: '\r',
   ESCAPE: '\u001b',
 };

--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -89,6 +89,12 @@ export default class Prompt {
       case KEYS.ARROW_LEFT:
       case KEYS.ARROW_RIGHT:
         break;
+      case KEYS.CONTROL_U:
+        this._value = '';
+        this._offset = -1;
+        this._selection = null;
+        this._onChange();
+        break;
       default:
         this._value =
           key === KEYS.BACKSPACE ? this._value.slice(0, -1) : this._value + key;

--- a/packages/jest-watcher/src/lib/__tests__/prompt.test.ts
+++ b/packages/jest-watcher/src/lib/__tests__/prompt.test.ts
@@ -62,3 +62,20 @@ it('calls handler on cancel prompt', () => {
 
   expect(onCancel).toHaveBeenCalled();
 });
+
+it('clears the line when CONTROL_U is pressed', () => {
+  const prompt = new Prompt();
+  const onChange = jest.fn();
+  const options = {max: 10, offset: -1};
+
+  prompt.enter(onChange, jest.fn(), jest.fn());
+
+  prompt.put('t');
+  prompt.put('e');
+  prompt.put('s');
+  prompt.put('t');
+  expect(onChange).toHaveBeenLastCalledWith('test', options);
+
+  prompt.put(KEYS.CONTROL_U);
+  expect(onChange).toHaveBeenLastCalledWith('', options);
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Added support for clearing the line when `<C-u>` is pressed in a watch mode pattern prompt. Resolves #11296 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Added a test case that tests this change. Wasn't able to test it manually because of the `jest-watch-typeahead` plugin that uses the published version of `jest-watcher` Refer: https://github.com/facebook/jest/issues/11296#issuecomment-829263394

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
