### PR TITLE
Move jest-get-type to ESM named exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - `[jest-environment]` [**BREAKING**] Drop support for `runScript` for test environments ([#11155](https://github.com/facebook/jest/pull/11155))
 - `[jest-environment-jsdom]` Use inner realm’s `ArrayBuffer` constructor ([#10885](https://github.com/facebook/jest/pull/10885))
 - `[jest-environment-jsdom]` [**BREAKING**] Remove Node globals `setImmediate` and `clearImmediate` [#11222](https://github.com/facebook/jest/pull/11222)
+- `[jest-get-type]` [**BREAKING**] Convert to ES Module ([#11359](https://github.com/facebook/jest/pull/11359))
 - `[jest-globals]` [**BREAKING**] Disallow return values other than a `Promise` from hooks and tests ([#10512](https://github.com/facebook/jest/pull/10512))
 - `[jest-globals]` [**BREAKING**] Disallow mixing a done callback and returning a `Promise` from hooks and tests ([#10512](https://github.com/facebook/jest/pull/10512))
 - `[jest-haste-map]` Vendor `NodeWatcher` from `sane` ([#10919](https://github.com/facebook/jest/pull/10919))

--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -77,7 +77,7 @@ Module that identifies the primitive type of any JavaScript value. Exports a fun
 ### Example
 
 ```javascript
-const getType = require('jest-get-type');
+const {getType} = require('jest-get-type');
 
 const array = [1, 2, 3];
 const nullValue = null;

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -8,7 +8,7 @@
 
 /* eslint-disable local/ban-types-eventually */
 
-import getType = require('jest-get-type');
+import {getType, isPrimitive} from 'jest-get-type';
 import {
   DIM_COLOR,
   EXPECTED_COLOR,
@@ -315,8 +315,7 @@ const matchers: MatchersObject = {
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
           printExpectedConstructorName('Expected constructor', expected) +
-          (getType.isPrimitive(received) ||
-          Object.getPrototypeOf(received) === null
+          (isPrimitive(received) || Object.getPrototypeOf(received) === null
             ? `\nReceived value has no prototype\nReceived value: ${printReceived(
                 received,
               )}`

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import getType = require('jest-get-type');
+import {getType, isPrimitive} from 'jest-get-type';
 import {
   DIM_COLOR,
   EXPECTED_COLOR,
@@ -278,7 +278,7 @@ const isLineDiffableArg = (expected: unknown, received: unknown): boolean => {
     return false;
   }
 
-  if (getType.isPrimitive(expected)) {
+  if (isPrimitive(expected)) {
     return false;
   }
 

--- a/packages/jest-config/src/ReporterValidationErrors.ts
+++ b/packages/jest-config/src/ReporterValidationErrors.ts
@@ -7,7 +7,7 @@
 
 import chalk = require('chalk');
 import type {Config} from '@jest/types';
-import getType = require('jest-get-type');
+import {getType} from 'jest-get-type';
 import {ValidationError} from 'jest-validate';
 import {BULLET, DOCUMENTATION_NOTE} from './utils';
 

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk = require('chalk');
-import getType = require('jest-get-type');
+import {getType} from 'jest-get-type';
 import prettyFormat, {plugins as prettyFormatPlugins} from 'pretty-format';
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
 import {NO_DIFF_MESSAGE, SIMILAR_MESSAGE} from './constants';

--- a/packages/jest-get-type/src/__tests__/getType.test.ts
+++ b/packages/jest-get-type/src/__tests__/getType.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import getType from '../';
+import {getType} from '../';
 
 describe('.getType()', () => {
   test('null', () => expect(getType(null)).toBe('null'));

--- a/packages/jest-get-type/src/index.ts
+++ b/packages/jest-get-type/src/index.ts
@@ -23,7 +23,7 @@ type ValueType =
 
 // get the type of a value with handling the edge cases like `typeof []`
 // and `typeof null`
-function getType(value: unknown): ValueType {
+export function getType(value: unknown): ValueType {
   if (value === undefined) {
     return 'undefined';
   } else if (value === null) {
@@ -60,6 +60,4 @@ function getType(value: unknown): ValueType {
   throw new Error(`value of unknown type: ${value}`);
 }
 
-getType.isPrimitive = (value: unknown) => Object(value) !== value;
-
-export = getType;
+export const isPrimitive = (value: unknown): boolean => Object(value) !== value;

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import getType = require('jest-get-type');
+import {getType} from 'jest-get-type';
 
 const supportTypes = ['map', 'array', 'object'];
 

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -17,7 +17,7 @@ import diffDefault, {
   diffStringsRaw,
   diffStringsUnified,
 } from 'jest-diff';
-import getType = require('jest-get-type');
+import {getType, isPrimitive} from 'jest-get-type';
 import prettyFormat, {plugins as prettyFormatPlugins} from 'pretty-format';
 import Replaceable from './Replaceable';
 import deepCyclicCopyReplaceable from './deepCyclicCopyReplaceable';
@@ -264,7 +264,7 @@ const isLineDiffable = (expected: unknown, received: unknown): boolean => {
     return false;
   }
 
-  if (getType.isPrimitive(expected)) {
+  if (isPrimitive(expected)) {
     // Print generic line diff for strings only:
     // * if neither string is empty
     // * if either string has more than one line

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -24,7 +24,7 @@ import {
   diffStringsRaw,
   diffStringsUnified,
 } from 'jest-diff';
-import getType = require('jest-get-type');
+import {getType, isPrimitive} from 'jest-get-type';
 import {
   BOLD_WEIGHT,
   EXPECTED_COLOR,
@@ -171,7 +171,7 @@ const joinDiffs = (
 const isLineDiffable = (received: unknown): boolean => {
   const receivedType = getType(received);
 
-  if (getType.isPrimitive(received)) {
+  if (isPrimitive(received)) {
     return typeof received === 'string';
   }
 

--- a/packages/jest-validate/src/errors.ts
+++ b/packages/jest-validate/src/errors.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk = require('chalk');
-import getType = require('jest-get-type');
+import {getType} from 'jest-get-type';
 import {getValues} from './condition';
 import type {ValidationOptions} from './types';
 import {ERROR, ValidationError, formatPrettyObject} from './utils';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I tried using jest's `expect` together with snowpack (which converts everything to esm via rollup/plugin-commonjs), and it mostly worked okay except I was getting 

```TypeError: (0 , _jestGetType.default) is not a function```

I traced this down to a problem in how rollup/babel (or the combination of them) deal with mixed default and named exports.  The [rollup docs](https://rollupjs.org/guide/en/#outputexports) specifically talk about avoiding mixing the two, as well.  I see that all of the other jest packages (except for pretty-format, which also causes me errors) are using either default or named exports, so I chose to use named exports and convert `jest-get-type` to esm.

## Test plan

I built the code, copied all of the newly built files to my node_modules, and my error went away.  Also, existing tests continue to pass.
