### PR TITLE
Use named import from pretty-format, not default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - `[pretty-format]` [**BREAKING**] Convert to ES Modules ([#10515](https://github.com/facebook/jest/pull/10515))
 - `[pretty-format]` Only call `hasAttribute` if it's a function ([#11000](https://github.com/facebook/jest/pull/11000))
 - `[pretty-format]` Handle jsdom attributes properly ([#11189](https://github.com/facebook/jest/pull/11189))
+- `[pretty-format]` Import pretty-format using named imports ([#11360](https://github.com/facebook/jest/pull/11360))
 
 ### Chore & Maintenance
 

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -14,7 +14,7 @@ import {
   printExpected,
   printReceived,
 } from 'jest-matcher-utils';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 interface AssertionErrorWithStack extends AssertionError {
   stack: string;

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -14,7 +14,7 @@ import StackUtils = require('stack-utils');
 import type {AssertionResult, Status} from '@jest/test-result';
 import type {Circus, Global} from '@jest/types';
 import {ErrorWithStack, convertDescriptorToString, formatTime} from 'jest-util';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import {ROOT_DESCRIBE_BLOCK_NAME, getState} from './state';
 
 const stackUtils = new StackUtils({cwd: 'A path that does not exist'});

--- a/packages/jest-config/src/Deprecated.ts
+++ b/packages/jest-config/src/Deprecated.ts
@@ -7,7 +7,7 @@
 
 import chalk = require('chalk');
 import type {DeprecatedOptions} from 'jest-validate';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 const format = (value: unknown) => prettyFormat(value, {min: true});
 

--- a/packages/jest-core/src/runGlobalHook.ts
+++ b/packages/jest-core/src/runGlobalHook.ts
@@ -12,7 +12,7 @@ import {createScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import type {Test} from 'jest-runner';
 import {interopRequireDefault} from 'jest-util';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 export default async ({
   allTests,

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -7,7 +7,10 @@
 
 import chalk = require('chalk');
 import {getType} from 'jest-get-type';
-import prettyFormat, {plugins as prettyFormatPlugins} from 'pretty-format';
+import {
+  format as prettyFormat,
+  plugins as prettyFormatPlugins,
+} from 'pretty-format';
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
 import {NO_DIFF_MESSAGE, SIMILAR_MESSAGE} from './constants';
 import {diffLinesRaw, diffLinesUnified, diffLinesUnified2} from './diffLines';

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -8,7 +8,7 @@
 
 import * as util from 'util';
 import type {Global} from '@jest/types';
-import pretty from 'pretty-format';
+import {format as pretty} from 'pretty-format';
 import type {EachTests} from '../bind';
 
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -8,7 +8,7 @@
 
 import type {Global} from '@jest/types';
 import {isPrimitive} from 'jest-get-type';
-import pretty from 'pretty-format';
+import {format as pretty} from 'pretty-format';
 import type {EachTests} from '../bind';
 
 type Template = Record<string, unknown>;

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -8,7 +8,7 @@
 
 import chalk = require('chalk');
 import type {Global} from '@jest/types';
-import pretty from 'pretty-format';
+import {format as pretty} from 'pretty-format';
 
 type TemplateData = Global.TemplateData;
 

--- a/packages/jest-jasmine2/src/expectationResultFactory.ts
+++ b/packages/jest-jasmine2/src/expectationResultFactory.ts
@@ -6,7 +6,7 @@
  */
 
 import type {FailedAssertion} from '@jest/test-result';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 function messageFormatter({error, message, passed}: Options) {
   if (passed) {

--- a/packages/jest-jasmine2/src/isError.ts
+++ b/packages/jest-jasmine2/src/isError.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 export default function isError(
   // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -11,7 +11,7 @@ import {promisify} from 'util';
 import {setFlagsFromString} from 'v8';
 import {runInNewContext} from 'vm';
 import {isPrimitive} from 'jest-get-type';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 const tick = promisify(setImmediate);
 

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -8,7 +8,7 @@
 
 import chalk = require('chalk');
 import {alignedAnsiStyleSerializer} from '@jest/test-utils';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import {
   MatcherHintOptions,
   diff,

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -18,7 +18,10 @@ import diffDefault, {
   diffStringsUnified,
 } from 'jest-diff';
 import {getType, isPrimitive} from 'jest-get-type';
-import prettyFormat, {plugins as prettyFormatPlugins} from 'pretty-format';
+import {
+  format as prettyFormat,
+  plugins as prettyFormatPlugins,
+} from 'pretty-format';
 import Replaceable from './Replaceable';
 import deepCyclicCopyReplaceable from './deepCyclicCopyReplaceable';
 

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -13,7 +13,7 @@ import micromatch = require('micromatch');
 import slash = require('slash');
 import StackUtils = require('stack-utils');
 import type {Config, TestResult} from '@jest/types';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import type {Frame} from './types';
 
 export type {Frame} from './types';

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -8,7 +8,7 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import * as fs from 'graceful-fs';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import serializer from '..';
 
 const objs = [

--- a/packages/jest-snapshot/src/__tests__/mockSerializer.test.ts
+++ b/packages/jest-snapshot/src/__tests__/mockSerializer.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import plugin from '../mockSerializer';
 
 test('mock with 0 calls and default name', () => {

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -34,7 +34,7 @@ import {
   getLabelPrinter,
   matcherHint,
 } from 'jest-matcher-utils';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import {
   aBackground2,
   aBackground3,

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -10,7 +10,7 @@ import chalk = require('chalk');
 import * as fs from 'graceful-fs';
 import naturalCompare = require('natural-compare');
 import type {Config} from '@jest/types';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 import {getSerializers} from './plugins';
 import type {SnapshotData} from './types';
 

--- a/packages/jest-validate/src/utils.ts
+++ b/packages/jest-validate/src/utils.ts
@@ -7,7 +7,7 @@
 
 import chalk = require('chalk');
 import leven from 'leven';
-import prettyFormat from 'pretty-format';
+import {format as prettyFormat} from 'pretty-format';
 
 const BULLET: string = chalk.bold('\u25cf');
 export const DEPRECATION = `${BULLET} Deprecation Warning`;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Similarly to https://github.com/facebook/jest/pull/11359, I was trying to run `expect` in snowpack / webtestrunner, and got errors about 

```
TypeError: (0 , _prettyFormat.default) is not a function
```

This is because `pretty-format` exports both a default export and named exports.  This confuses babel+rollup, but it sounded like it was an intentional decision in https://github.com/facebook/jest/pull/10515 to keep both.  So, this PR does not remove the default export, but it changes all of the existing default imports throughout jest into named imports instead.  This seems to compile to cjs in such a way that rollup can successfully turn it back into esm.

## Test plan

Same as in #11359, I built jest and used it in my app, and the errors were resolved.
