### PR TITLE
Use named exports for jest-diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - `[jest-console]` `console.dir` now respects the second argument correctly ([#10638](https://github.com/facebook/jest/pull/10638))
 - `[jest-core]` Don't report PerformanceObserver as open handle ([#11123](https://github.com/facebook/jest/pull/11123))
 - `[jest-core]` Use `WeakRef` to hold timers when detecting open handles ([#11277](https://github.com/facebook/jest/pull/11277))
+- `[jest-diff]` [**BREAKING**] Use only named exports ([#11371](https://github.com/facebook/jest/pull/11371))
 - `[jest-each]` [**BREAKING**] Ignore excess words in headings ([#8766](https://github.com/facebook/jest/pull/8766))
 - `[jest-each]` Support array index with template strings ([#10763](https://github.com/facebook/jest/pull/10763))
 - `[jest-each]` Interpolate `%%` correctly ([#11364](https://github.com/facebook/jest/pull/11364))

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -156,7 +156,7 @@ There are a number of helpful tools exposed on `this.utils` primarily consisting
 The most useful ones are `matcherHint`, `printExpected` and `printReceived` to format the error messages nicely. For example, take a look at the implementation for the `toBe` matcher:
 
 ```js
-const diff = require('jest-diff');
+const {diff} = require('jest-diff');
 expect.extend({
   toBe(received, expected) {
     const options = {

--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -32,7 +32,7 @@ Tool for visualizing changes in data. Exports a function that compares two value
 ### Example
 
 ```javascript
-const diff = require('jest-diff').default;
+const {diff} = require('jest-diff');
 
 const a = {a: {b: {c: 5}}};
 const b = {a: {b: {c: 6}}};

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -2,7 +2,7 @@
 
 Display differences clearly so people can review changes confidently.
 
-The default export serializes JavaScript **values**, compares them line-by-line, and returns a string which includes comparison lines.
+The `diff` named export serializes JavaScript **values**, compares them line-by-line, and returns a string which includes comparison lines.
 
 Two named exports compare **strings** character-by-character:
 
@@ -21,9 +21,9 @@ To add this package as a dependency of a project, run either of the following co
 - `npm install jest-diff`
 - `yarn add jest-diff`
 
-## Usage of default export
+## Usage of `diff()`
 
-Given JavaScript **values**, `diffDefault(a, b, options?)` does the following:
+Given JavaScript **values**, `diff(a, b, options?)` does the following:
 
 1. **serialize** the values as strings using the `pretty-format` package
 2. **compare** the strings line-by-line using the `diff-sequences` package
@@ -31,16 +31,16 @@ Given JavaScript **values**, `diffDefault(a, b, options?)` does the following:
 
 To use this function, write either of the following:
 
-- `const diffDefault = require('jest-diff').default;` in CommonJS modules
-- `import diffDefault from 'jest-diff';` in ECMAScript modules
+- `const {diff} = require('jest-diff');` in CommonJS modules
+- `import {diff} from 'jest-diff';` in ECMAScript modules
 
-### Example of default export
+### Example of `diff()`
 
 ```js
 const a = ['delete', 'common', 'changed from'];
 const b = ['common', 'changed to', 'insert'];
 
-const difference = diffDefault(a, b);
+const difference = diff(a, b);
 ```
 
 The returned **string** consists of:
@@ -61,7 +61,7 @@ The returned **string** consists of:
   ]
 ```
 
-### Edge cases of default export
+### Edge cases of `diff()`
 
 Here are edge cases for the return value:
 
@@ -374,7 +374,7 @@ The default options are for the report when an assertion fails from the `expect`
 
 For other applications, you can provide an options object as a third argument:
 
-- `diffDefault(a, b, options)`
+- `diff(a, b, options)`
 - `diffStringsUnified(a, b, options)`
 - `diffLinesUnified(aLines, bLines, options)`
 - `diffLinesUnified2(aLinesDisplay, bLinesDisplay, aLinesCompare, bLinesCompare, options)`
@@ -452,7 +452,7 @@ const options = {
 
 ### Example of option to format trailing spaces
 
-Because the default export does not display substring differences within lines, formatting can help you see when lines differ by the presence or absence of trailing spaces found by `/\s+$/` regular expression.
+Because `diff()` does not display substring differences within lines, formatting can help you see when lines differ by the presence or absence of trailing spaces found by `/\s+$/` regular expression.
 
 - If change lines have a background color, then you can see trailing spaces.
 - If common lines have default dim color, then you cannot see trailing spaces. You might want yellowish background color to see them.
@@ -553,7 +553,7 @@ const options = {
   includeChangeCounts: true,
 };
 
-const difference = diffDefault(a, b, options);
+const difference = diff(a, b, options);
 ```
 
 ```diff

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -365,7 +365,7 @@ exports[`options omitAnnotationLines true diffStringsUnified and includeChangeCo
 
 exports[`options omitAnnotationLines true diffStringsUnified empty strings 1`] = ``;
 
-exports[`options trailingSpaceFormatter diffDefault default no color 1`] = `
+exports[`options trailingSpaceFormatter diff default no color 1`] = `
 <g>- Expected</>
 <r>+ Received</>
 
@@ -376,7 +376,7 @@ exports[`options trailingSpaceFormatter diffDefault default no color 1`] = `
 <r>+ insert 1 trailing space: </>
 `;
 
-exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
+exports[`options trailingSpaceFormatter diff middle dot 1`] = `
 <g>- Expected</>
 <r>+ Received</>
 
@@ -387,7 +387,7 @@ exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
 <r>+ insert 1 trailing space:·</>
 `;
 
-exports[`options trailingSpaceFormatter diffDefault yellowish common 1`] = `
+exports[`options trailingSpaceFormatter diff yellowish common 1`] = `
 <g>- Expected</>
 <r>+ Received</>
 

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -8,7 +8,7 @@
 import chalk = require('chalk');
 import stripAnsi = require('strip-ansi');
 import {alignedAnsiStyleSerializer} from '@jest/test-utils';
-import diff from '../';
+import {diff} from '../';
 import {NO_DIFF_MESSAGE} from '../constants';
 import {diffLinesUnified, diffLinesUnified2} from '../diffLines';
 import {noColor} from '../normalizeDiffOptions';
@@ -1072,11 +1072,11 @@ describe('options', () => {
       'insert 1 trailing space: ',
     ].join('\n');
 
-    test('diffDefault default no color', () => {
+    test('diff default no color', () => {
       expect(diff(aTrailingSpaces, bTrailingSpaces)).toMatchSnapshot();
     });
 
-    test('diffDefault middle dot', () => {
+    test('diff middle dot', () => {
       const replaceSpacesWithMiddleDot = string => '·'.repeat(string.length);
       const options = {
         changeLineTrailingSpaceColor: replaceSpacesWithMiddleDot,
@@ -1086,7 +1086,7 @@ describe('options', () => {
       expect(diff(aTrailingSpaces, bTrailingSpaces, options)).toMatchSnapshot();
     });
 
-    test('diffDefault yellowish common', () => {
+    test('diff yellowish common', () => {
       const options = {
         commonLineTrailingSpaceColor: chalk.bgYellow,
       };
@@ -1112,7 +1112,7 @@ describe('options', () => {
       '',
     ].join('\n');
 
-    test('diffDefault', () => {
+    test('diff', () => {
       expect(diff(aEmpty, bEmpty, options)).toBe(expected);
     });
 

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -60,7 +60,7 @@ const FALLBACK_FORMAT_OPTIONS_0 = {...FALLBACK_FORMAT_OPTIONS, indent: 0};
 // Generate a string that will highlight the difference between two values
 // with green and red. (similar to how github does code diffing)
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-function diff(a: any, b: any, options?: DiffOptions): string | null {
+export function diff(a: any, b: any, options?: DiffOptions): string | null {
   if (Object.is(a, b)) {
     return getCommonMessage(NO_DIFF_MESSAGE, options);
   }
@@ -190,5 +190,3 @@ function compareObjects(
 
   return difference;
 }
-
-export default diff;

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -213,7 +213,9 @@ describe('ensureNoExpected()', () => {
   });
 });
 
-jest.mock('jest-diff', () => () => 'diff output');
+jest.mock('jest-diff', () => ({
+  diff: () => 'diff output',
+}));
 describe('diff', () => {
   test('forwards to jest-diff', () => {
     [

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -8,12 +8,13 @@
 /* eslint-disable local/ban-types-eventually */
 
 import chalk = require('chalk');
-import diffDefault, {
+import {
   DIFF_DELETE,
   DIFF_EQUAL,
   DIFF_INSERT,
   Diff,
   DiffOptions as ImportDiffOptions,
+  diff as diffDefault,
   diffStringsRaw,
   diffStringsUnified,
 } from 'jest-diff';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Similar to https://github.com/facebook/jest/pull/11359 and https://github.com/facebook/jest/pull/11360, I had problems when using jest-diff together with rollup's plugin-commonjs that turns cjs back into esm.  It appears that there was originally a [desire](https://github.com/facebook/jest/pull/8873#issuecomment-528568640) to use all named exports for jest-diff, but the move was delayed originally.  This PR removes the default export for `jest-diff` and exposes `diff()` as a named export.  I also did my best to find any usages of the default export in the documentation.

## Test plan

I tested this in my own snowpack app by building jest from my branch and replacing files in my `node_modules`.  
