### PR TITLE
Fix runtime checks on getMessage() to match the type annotation

### DIFF
--- a/e2e/__tests__/__snapshots__/errorOnDeprecated.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/errorOnDeprecated.test.ts.snap
@@ -50,7 +50,7 @@ FAIL __tests__/jasmine.addMatchers.test.js
          |         ^
       10 |   theSpanishInquisition: () => ({
       11 |     compare: (actual, expected) => ({
-      12 |       message: 'Nobdy expects the Spanish Inquisition!',
+      12 |       message: () => 'Nobdy expects the Spanish Inquisition!',
 
       at Object.addMatchers (__tests__/jasmine.addMatchers.test.js:9:9)
 `;

--- a/e2e/error-on-deprecated/__tests__/jasmine.addMatchers.test.js
+++ b/e2e/error-on-deprecated/__tests__/jasmine.addMatchers.test.js
@@ -9,7 +9,7 @@
 jasmine.addMatchers({
   theSpanishInquisition: () => ({
     compare: (actual, expected) => ({
-      message: 'Nobdy expects the Spanish Inquisition!',
+      message: () => 'Nobdy expects the Spanish Inquisition!',
       pass: false,
     }),
   }),

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -373,14 +373,13 @@ const _validateResult = (result: any) => {
     typeof result !== 'object' ||
     typeof result.pass !== 'boolean' ||
     (result.message &&
-      typeof result.message !== 'string' &&
       typeof result.message !== 'function')
   ) {
     throw new Error(
       'Unexpected return from a matcher function.\n' +
         'Matcher functions should ' +
         'return an object in the following format:\n' +
-        '  {message?: string | function, pass: boolean}\n' +
+        '  {message?: () => string, pass: boolean}\n' +
         `'${matcherUtils.stringify(result)}' was returned`,
     );
   }


### PR DESCRIPTION
getMessage() uses a call operator on the message field, so it can't ever be a string. The type annotation on it was already correct, just fix up these runtime checks and messages.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

While debugging a matcher that was returning a string for the message field, I found this discrepancy. TS wasn't warning about the incorrect type, which is a separate bug I'll try and reduce and report to them.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
`yarn test`
There are no existing tests that verify the modified error output, but I saw it change when I had my incorrectly-written matcher trigger the new message.
