### PR TITLE
Improve fatal worker error message

### DIFF
--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -41,5 +41,7 @@ test('fails a test that terminates the worker with a fatal error', () => {
   expect(exitCode).not.toBe(0);
   expect(numberOfTestsPassed).toBe(Object.keys(testFiles).length - 1);
   expect(stderr).toContain('FAIL __tests__/fatalWorkerError.test.js');
-  expect(stderr).toContain('Jest worker encountered 4 child process exceptions, exceeding retry limit');
+  expect(stderr).toContain(
+    'Jest worker encountered 4 child process exceptions, exceeding retry limit',
+  );
 });

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -41,5 +41,5 @@ test('fails a test that terminates the worker with a fatal error', () => {
   expect(exitCode).not.toBe(0);
   expect(numberOfTestsPassed).toBe(Object.keys(testFiles).length - 1);
   expect(stderr).toContain('FAIL __tests__/fatalWorkerError.test.js');
-  expect(stderr).toContain('Call retries were exceeded');
+  expect(stderr).toContain('Jest worker encountered 4 child process exceptions, exceeding retry limit');
 });

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -134,7 +134,7 @@ export default class ChildProcessWorker implements WorkerInterface {
     // coming from the child. This avoids code duplication related with cleaning
     // the queue, and scheduling the next call.
     if (this._retries > this._options.maxRetries) {
-      const error = new Error('Call retries were exceeded');
+      const error = new Error(`Jest worker encountered ${this._retries} child process exceptions, exceeding retry limit`);
 
       this._onMessage([
         PARENT_MESSAGE_CLIENT_ERROR,

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -134,7 +134,9 @@ export default class ChildProcessWorker implements WorkerInterface {
     // coming from the child. This avoids code duplication related with cleaning
     // the queue, and scheduling the next call.
     if (this._retries > this._options.maxRetries) {
-      const error = new Error(`Jest worker encountered ${this._retries} child process exceptions, exceeding retry limit`);
+      const error = new Error(
+        `Jest worker encountered ${this._retries} child process exceptions, exceeding retry limit`,
+      );
 
       this._onMessage([
         PARENT_MESSAGE_CLIENT_ERROR,


### PR DESCRIPTION
## Summary

"Call retries were exceeded" is a bit obscure, with more information users could have an easier time tracking down bugs.

See also https://github.com/facebook/jest/issues/8769

## Test plan

Tests were updated
