### PR TITLE
docs(snapshot): specify how to disable prettier

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -134,6 +134,8 @@ it('renders correctly', () => {
 
 That's all there is to it! You can even update the snapshots with `--updateSnapshot` or using the `u` key in `--watch` mode.
 
+By default, Jest uses Prettier to format inline snapshots. To disable this, set `prettierPath: null` in the config.
+
 ### Property Matchers
 
 Often there are fields in the object you want to snapshot which are generated (like IDs and Dates). If you try to snapshot these objects, they will force the snapshot to fail on every run:


### PR DESCRIPTION
#7792 suggests that Prettier is optional, but I assumed that all I needed to do was remove `prettier` from my dependencies. That still results in Jest trying to require `prettier`, causing Jest to fail. Took awhile to learn I needed to set `prettierPath` to `null` or `''`, so I added this to the docs.
