### PR TITLE
feat: use fallback if prettier not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - `[jest-runtime]` Detect reexports from CJS as named exports in ESM ([#10988](https://github.com/facebook/jest/pull/10988))
 - `[jest-runtime]` Support for async code transformations ([#11191](https://github.com/facebook/jest/pull/11191) & [#11220](https://github.com/facebook/jest/pull/11220))
 - `[jest-reporters]` Add static filepath property to all reporters ([#11015](https://github.com/facebook/jest/pull/11015))
-- `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
+- `[jest-snapshot]` [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792) & [#11192](https://github.com/facebook/jest/pull/11192))
 - `[jest-snapshot]` [**BREAKING**] Run transforms over `snapshotResolver` ([#8751](https://github.com/facebook/jest/pull/8829))
 - `[jest-transform]` Pass config options defined in Jest's config to transformer's `process` and `getCacheKey` functions ([#10926](https://github.com/facebook/jest/pull/10926))
 - `[jest-transform]` Add support for transformers written in ESM ([#11163](https://github.com/facebook/jest/pull/11163))

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -54,7 +54,7 @@ export function saveInlineSnapshots(
     try {
       // @ts-expect-error requireOutside Babel transform
       prettier = requireOutside(prettierPath) as Prettier;
-    } catch (_) {
+    } catch {
       // Continue even if prettier is not installed.
     }
   }

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -49,7 +49,7 @@ export function saveInlineSnapshots(
   snapshots: Array<InlineSnapshot>,
   prettierPath: Config.Path,
 ): void {
-  let prettier;
+  let prettier: Prettier | null = null;
   if (prettierPath) {
     try {
       // @ts-expect-error requireOutside Babel transform

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -49,10 +49,15 @@ export function saveInlineSnapshots(
   snapshots: Array<InlineSnapshot>,
   prettierPath: Config.Path,
 ): void {
-  const prettier = prettierPath
-    ? // @ts-expect-error requireOutside Babel transform
-      (requireOutside(prettierPath) as Prettier)
-    : undefined;
+  let prettier;
+  if (prettierPath) {
+    try {
+      // @ts-expect-error requireOutside Babel transform
+      prettier = requireOutside(prettierPath) as Prettier;
+    } catch (_) {
+      // Continue even if prettier is not installed.
+    }
+  }
 
   const snapshotsByFile = groupSnapshotsByFile(snapshots);
 

--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -73,6 +73,36 @@ expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
   );
 });
 
+test('saveInlineSnapshots() with bad prettier path leaves formatting outside of snapshots alone', () => {
+  const filename = path.join(dir, 'my.test.js');
+  fs.writeFileSync(
+    filename,
+    `
+const a = [1,            2];
+expect(a).toMatchInlineSnapshot(\`an out-of-date and also multi-line
+snapshot\`);
+expect(a).toMatchInlineSnapshot();
+expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
+`.trim() + '\n',
+  );
+
+  saveInlineSnapshots(
+    [2, 4, 5].map(line => ({
+      frame: {column: 11, file: filename, line} as Frame,
+      snapshot: `[1, 2]`,
+    })),
+    'bad-prettier',
+  );
+
+  expect(fs.readFileSync(filename, 'utf8')).toBe(
+    `const a = [1,            2];
+expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
+expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
+expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
+`,
+  );
+});
+
 test('saveInlineSnapshots() can handle typescript without prettier', () => {
   const filename = path.join(dir, 'my.test.ts');
   fs.writeFileSync(


### PR DESCRIPTION
ref #11386

This allows the require for prettier to fail, without bubbling up as an error.

An alternative to this approach would be to change `Defaults.ts` to attempt setting `prettier` to `require.resolve(prettier)` (or something), but I am not familiar enough with the codebase to know if that'd be OK. The current approach works, but may hide an accidental misconfiguration if a user manually sets `prettierPath`.