### PR TITLE
refactor: use nullish coalescing operator on getProjectDisplayName

### DIFF
--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -350,9 +350,7 @@ export const partition = <T>(
 export const isError = (value: unknown): value is Error => {
   switch (Object.prototype.toString.call(value)) {
     case '[object Error]':
-      return true;
     case '[object Exception]':
-      return true;
     case '[object DOMException]':
       return true;
     default:

--- a/packages/jest-core/src/getProjectDisplayName.ts
+++ b/packages/jest-core/src/getProjectDisplayName.ts
@@ -10,5 +10,5 @@ import type {Config} from '@jest/types';
 export default function getProjectDisplayName(
   projectConfig: Config.ProjectConfig,
 ): string | undefined {
-  return projectConfig?.displayName?.name ?? undefined;
+  return projectConfig?.displayName?.name || undefined;
 }

--- a/packages/jest-core/src/getProjectDisplayName.ts
+++ b/packages/jest-core/src/getProjectDisplayName.ts
@@ -10,9 +10,5 @@ import type {Config} from '@jest/types';
 export default function getProjectDisplayName(
   projectConfig: Config.ProjectConfig,
 ): string | undefined {
-  const {displayName} = projectConfig;
-  if (!displayName) {
-    return undefined;
-  }
-  return displayName.name;
+  return projectConfig?.displayName?.name ?? undefined;
 }

--- a/packages/jest-core/src/getProjectDisplayName.ts
+++ b/packages/jest-core/src/getProjectDisplayName.ts
@@ -10,5 +10,5 @@ import type {Config} from '@jest/types';
 export default function getProjectDisplayName(
   projectConfig: Config.ProjectConfig,
 ): string | undefined {
-  return projectConfig?.displayName?.name || undefined;
+  return projectConfig.displayName?.name || undefined;
 }

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -526,9 +526,8 @@ export default class FakeTimers<TimerRef> {
 
     switch (timer.type) {
       case 'timeout':
-        const callback = timer.callback;
         this._timers.delete(timerHandle);
-        callback();
+        timer.callback();
         break;
 
       case 'interval':


### PR DESCRIPTION
## Summary

- Delete an unnecessary variable in the [utils.js](https://github.com/ftonato/jest/blob/4453901c0239939cc2c1c8b7c7d121447f6f5f52/packages/expect/src/utils.ts) file
- Use the nullish coalescing operator in the [getProjectDisplayName](https://github.com/ftonato/jest/blob/4453901c0239939cc2c1c8b7c7d121447f6f5f52/packages/jest-core/src/getProjectDisplayName.ts) method
- Refactor the method using [switch / case that all return the same value](https://github.com/ftonato/jest/blob/4453901c0239939cc2c1c8b7c7d121447f6f5f52/packages/expect/src/utils.ts#L352)
