### PR TITLE
Fix locale issue #10014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options ([#10834](https://github.com/facebook/jest/pull/10834))
 - `[jest-types]` Fix `Config.ts` `projects` types ([#11285](https://github.com/facebook/jest/pull/11285))
 - `[jest-util]` Replace micromatch with picomatch to fix issues with negated globs ([#11287](https://github.com/facebook/jest/pull/11287))
-- `[jest-validate]` Use `en-US` locale to avoid case conversion problems while validating CLI options on machines with some certain locales(e.g. Turkish) set as default locale.    
+- `[jest-validate]` Use `en-US` locale to avoid case conversion problems while validating CLI options on machines with some certain locales(e.g. Turkish) set as default locale.  ([#11412](https://github.com/facebook/jest/pull/11412))
 - `[jest-worker]` [**BREAKING**] Use named exports ([#10623](https://github.com/facebook/jest/pull/10623))
 - `[jest-worker]` Do not swallow errors during serialization ([#10984](https://github.com/facebook/jest/pull/10984))
 - `[jest-worker]` Handle `ERR_IPC_CHANNEL_CLOSED` errors properly ([#11143](https://github.com/facebook/jest/pull/11143))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - `[jest-transform]` [**BREAKING**] Refactor API of transformers to pass an options bag rather than separate `config` and other options ([#10834](https://github.com/facebook/jest/pull/10834))
 - `[jest-types]` Fix `Config.ts` `projects` types ([#11285](https://github.com/facebook/jest/pull/11285))
 - `[jest-util]` Replace micromatch with picomatch to fix issues with negated globs ([#11287](https://github.com/facebook/jest/pull/11287))
+- `[jest-validate]` Use `en-US` locale to avoid case conversion problems while validating CLI options on machines with some certain locales(e.g. Turkish) set as default locale.    
 - `[jest-worker]` [**BREAKING**] Use named exports ([#10623](https://github.com/facebook/jest/pull/10623))
 - `[jest-worker]` Do not swallow errors during serialization ([#10984](https://github.com/facebook/jest/pull/10984))
 - `[jest-worker]` Handle `ERR_IPC_CHANNEL_CLOSED` errors properly ([#11143](https://github.com/facebook/jest/pull/11143))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ansi-regex": "^5.0.0",
     "ansi-styles": "^5.0.0",
     "babel-plugin-replace-ts-export-assignment": "^0.0.2",
-    "camelcase": "^6.0.0",
+    "camelcase": "^6.2.0",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.0",
     "codecov": "^3.0.0",

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@jest/types": "^27.0.0-next.8",
-    "camelcase": "^6.0.0",
+    "camelcase": "^6.2.0",
     "chalk": "^4.0.0",
     "jest-get-type": "^27.0.0-next.9",
     "leven": "^3.1.0",

--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -78,7 +78,7 @@ export default function validateCLIOptions(
   );
   const unrecognizedOptions = Object.keys(argv).filter(
     arg =>
-      !allowedOptions.has(camelcase(arg)) &&
+      !allowedOptions.has(camelcase(arg, {locale: 'en-US'})) &&
       !allowedOptions.has(arg) &&
       (!rawArgv.length || rawArgv.includes(arg)),
     [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,7 +2530,7 @@ __metadata:
     ansi-regex: ^5.0.0
     ansi-styles: ^5.0.0
     babel-plugin-replace-ts-export-assignment: ^0.0.2
-    camelcase: ^6.0.0
+    camelcase: ^6.2.0
     chalk: ^4.0.0
     chokidar: ^3.3.0
     codecov: ^3.0.0
@@ -13352,7 +13352,7 @@ fsevents@^1.2.7:
   dependencies:
     "@jest/types": ^27.0.0-next.8
     "@types/yargs": ^16.0.0
-    camelcase: ^6.0.0
+    camelcase: ^6.2.0
     chalk: ^4.0.0
     jest-get-type: ^27.0.0-next.9
     leven: ^3.1.0


### PR DESCRIPTION
## Summary

Fixes [#10004](https://github.com/facebook/jest/issues/10014).

As described in [this comment](https://github.com/facebook/jest/issues/10014#issuecomment-660536693), jest fails while running at machines with some non-English locales, like Turkish. 

This PR uses new `camelcase` version that offers a locale option to use while converting case, which makes default locale irrelevant; hence eliminates the problem.

Changes:
- Upgrade camelcase version for `jest-validate` workspace.
- Call `camelcase` function providing `en-US` as locale while validating CLI options.
 
## Test plan

Problem reproducible at machines using some certain locale. Following execution is on a Turkish locale machine:
```
D:\src\jest-test  (jest-test@1.0.0)
λ
node D:\src\jest\packages\jest-cli\bin\jest.js
● Unrecognized CLI Parameters:

  Following options were not recognized:
  ["run-in-band", "test-location-in-results"]

  CLI Options Documentation:
  https://jestjs.io/docs/en/cli.html
```
And this is test output with development version with fix:
```
D:\src\jest-test  (jest-test@1.0.0)
λ node D:\src\jest\packages\jest-cli\bin\jest.js
 PASS  __tests__/dummy.js
  Dummy test
    √ should pass (67 ms)

  console.info
    LANG: undefined

      at Object.info (__tests__/dummy.js:3:15)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        2.914 s, estimated 4 s
Ran all test suites.
```

 
