### PR TITLE
Upgrade fsevents in jest-haste-map

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -36,7 +36,7 @@
     "slash": "^3.0.0"
   },
   "optionalDependencies": {
-    "fsevents": "^2.2.1"
+    "fsevents": "^2.3.2"
   },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10488,7 +10488,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@^2.1.2, fsevents@^2.2.1, fsevents@~2.3.1":
+"fsevents@^2.1.2, fsevents@^2.3.2, fsevents@~2.3.1":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -10507,7 +10507,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@^2.2.1#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>":
+"fsevents@patch:fsevents@^2.1.2#builtin<compat/fsevents>, fsevents@patch:fsevents@^2.3.2#builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.1#builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#builtin<compat/fsevents>::version=2.3.2&hash=11e9ea"
   dependencies:
@@ -12886,7 +12886,7 @@ fsevents@^1.2.7:
     "@types/node": "*"
     anymatch: ^3.0.3
     fb-watchman: ^2.0.0
-    fsevents: ^2.2.1
+    fsevents: ^2.3.2
     graceful-fs: ^4.2.4
     jest-regex-util: ^27.0.0-next.0
     jest-serializer: ^27.0.0-next.9


### PR DESCRIPTION
## Summary

The current version of `fsevents` contains bug fixes for M1 Apple Silicon chips.
Specifically, a React Native app could not be started on M1 laptops in Xcode, because of the error message `Error: EMFILE: too many open files, watch`. Quite a few people are affected by it, see: https://github.com/facebook/metro/issues/668

## Test plan

I have isolated this change and verified that upgrading fsevents is the turnkey solution.
Fast refresh, the main feature relying on file watching operations, is still working just fine.