### PR TITLE
feat(pretty-print): add option `printBasicPrototype`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `[jest-worker]` Add support for custom task queues and adds a `PriorityQueue` implementation. ([#10921](https://github.com/facebook/jest/pull/10921))
 - `[jest-worker]` Add in-order scheduling policy to jest worker ([10902](https://github.com/facebook/jest/pull/10902))
 - `[pretty-format]` Better print for sparse arrays ([11326](https://github.com/facebook/jest/pull/11326))
+- `[pretty-print]` Add option `printBasicPrototype` which determines whether or not the prototype should be printed for raw objects or arrays ([#11441](https://github.com/facebook/jest/pull/11441))
 
 ### Fixes
 

--- a/packages/pretty-format/README.md
+++ b/packages/pretty-format/README.md
@@ -66,18 +66,19 @@ console.log(prettyFormat(onClick, options));
 ```
 
 <!-- prettier-ignore -->
-| key                 | type      | default    | description                                             |
-| :------------------ | :-------- | :--------- | :------------------------------------------------------ |
-| `callToJSON`        | `boolean` | `true`     | call `toJSON` method (if it exists) on objects          |
-| `escapeRegex`       | `boolean` | `false`    | escape special characters in regular expressions        |
-| `escapeString`      | `boolean` | `true`     | escape special characters in strings                    |
-| `highlight`         | `boolean` | `false`    | highlight syntax with colors in terminal (some plugins) |
-| `indent`            | `number`  | `2`        | spaces in each level of indentation                     |
-| `maxDepth`          | `number`  | `Infinity` | levels to print in arrays, objects, elements, and so on |
-| `min`               | `boolean` | `false`    | minimize added space: no indentation nor line breaks    |
-| `plugins`           | `array`   | `[]`       | plugins to serialize application-specific data types    |
-| `printFunctionName` | `boolean` | `true`     | include or omit the name of a function                  |
-| `theme`             | `object`  |            | colors to highlight syntax in terminal                  |
+| key                   | type      | default    | description                                             |
+| :-------------------- | :-------- | :--------- | :------------------------------------------------------ |
+| `callToJSON`          | `boolean` | `true`     | call `toJSON` method (if it exists) on objects          |
+| `escapeRegex`         | `boolean` | `false`    | escape special characters in regular expressions        |
+| `escapeString`        | `boolean` | `true`     | escape special characters in strings                    |
+| `highlight`           | `boolean` | `false`    | highlight syntax with colors in terminal (some plugins) |
+| `indent`              | `number`  | `2`        | spaces in each level of indentation                     |
+| `maxDepth`            | `number`  | `Infinity` | levels to print in arrays, objects, elements, and so on |
+| `min`                 | `boolean` | `false`    | minimize added space: no indentation nor line breaks    |
+| `plugins`             | `array`   | `[]`       | plugins to serialize application-specific data types    |
+| `printBasicPrototype` | `boolean` | `false`    | print the prototype for plain objects and arrays        |
+| `printFunctionName`   | `boolean` | `true`     | include or omit the name of a function                  |
+| `theme`               | `object`  |            | colors to highlight syntax in terminal                  |
 
 Property values of `theme` are from [ansi-styles colors](https://github.com/chalk/ansi-styles#colors)
 

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -524,6 +524,31 @@ describe('prettyFormat()', () => {
     });
   });
 
+  it('can omit basic prototypes', () => {
+    const val = {
+      deeply: {nested: {object: {}}},
+      'empty array': {},
+      'empty object': {},
+      'nested array': [[[]]],
+      'typed array': new Uint8Array(),
+    };
+    expect(prettyFormat(val, {maxDepth: 2, printBasicPrototype: false})).toBe(
+      [
+        '{',
+        '  "deeply": {',
+        '    "nested": [Object],',
+        '  },',
+        '  "empty array": {},',
+        '  "empty object": {},',
+        '  "nested array": [',
+        '    [Array],',
+        '  ],',
+        '  "typed array": Uint8Array [],',
+        '}',
+      ].join('\n'),
+    );
+  });
+
   it('can customize the max depth', () => {
     const val = [
       {

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -504,7 +504,7 @@ const getConfig = (options?: OptionsReceived): Config => ({
     options && options.plugins !== undefined
       ? options.plugins
       : DEFAULT_OPTIONS.plugins,
-  printBasicPrototype: Boolean(options?.printBasicPrototype ?? true),
+  printBasicPrototype: options?.printBasicPrototype ?? true,
   printFunctionName: getPrintFunctionName(options),
   spacingInner: options && options.min ? ' ' : '\n',
   spacingOuter: options && options.min ? '' : '\n',

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -237,7 +237,11 @@ function printComplexValue(
   if (isToStringedArrayType(toStringed)) {
     return hitMaxDepth
       ? '[' + val.constructor.name + ']'
-      : (min ? '' : val.constructor.name + ' ') +
+      : (min
+          ? ''
+          : !config.printBasicPrototype && val.constructor.name === 'Array'
+          ? ''
+          : val.constructor.name + ' ') +
           '[' +
           printListItems(val, config, indentation, depth, refs, printer) +
           ']';
@@ -276,7 +280,11 @@ function printComplexValue(
   // For example, not even relevant if window is prop of React element.
   return hitMaxDepth || isWindow(val)
     ? '[' + getConstructorName(val) + ']'
-    : (min ? '' : getConstructorName(val) + ' ') +
+    : (min
+        ? ''
+        : !config.printBasicPrototype && getConstructorName(val) === 'Object'
+        ? ''
+        : getConstructorName(val) + ' ') +
         '{' +
         printObjectProperties(val, config, indentation, depth, refs, printer) +
         '}';
@@ -395,6 +403,7 @@ const DEFAULT_OPTIONS: Options = {
   maxDepth: Infinity,
   min: false,
   plugins: [],
+  printBasicPrototype: true,
   printFunctionName: true,
   theme: DEFAULT_THEME,
 };
@@ -495,6 +504,7 @@ const getConfig = (options?: OptionsReceived): Config => ({
     options && options.plugins !== undefined
       ? options.plugins
       : DEFAULT_OPTIONS.plugins,
+  printBasicPrototype: Boolean(options?.printBasicPrototype ?? true),
   printFunctionName: getPrintFunctionName(options),
   spacingInner: options && options.min ? ' ' : '\n',
   spacingOuter: options && options.min ? '' : '\n',

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -41,6 +41,7 @@ export type Options = {
   maxDepth: number;
   min: boolean;
   plugins: Plugins;
+  printBasicPrototype: boolean;
   printFunctionName: boolean;
   theme: Theme;
 };
@@ -54,6 +55,7 @@ export type OptionsReceived = {
   maxDepth?: number;
   min?: boolean;
   plugins?: Plugins;
+  printBasicPrototype?: boolean;
   printFunctionName?: boolean;
   theme?: ThemeReceived;
 };
@@ -67,6 +69,7 @@ export type Config = {
   maxDepth: number;
   min: boolean;
   plugins: Plugins;
+  printBasicPrototype: boolean;
   printFunctionName: boolean;
   spacingInner: string;
   spacingOuter: string;


### PR DESCRIPTION
The new option `printBasicPrototype` determines whether or not the prototype should be printed for raw objects and arrays. By default this is `true`, which is backwards compatible.

## Summary

I’m trying to create a snapshot matcher to test axios responses. In this case I’m interested pretty formatting JSON with custom matcher support, but I don’t want to print prototypes of raw objects or arrays, because I want to stay close to the original JSON data of the response.

## Test plan

```
yarn jest
```
