### PR TITLE
feat(reporters): re-expose getResultHeader as a util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-reporters]` Expose the `getResultHeader` util, for e.g. [fingers-crossed](https://github.com/mozilla/addons-frontend/blob/master/tests/jest-reporters/fingers-crossed.js) ([#11460](https://github.com/facebook/jest/pull/11460))
+
 ### Fixes
 
 - `[jest-worker]` Loosen engine requirement to `>= 10.13.0` ([#11451](https://github.com/facebook/jest/pull/11451))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-reporters]` Expose the `getResultHeader` util, for e.g. [fingers-crossed](https://github.com/mozilla/addons-frontend/blob/master/tests/jest-reporters/fingers-crossed.js) ([#11460](https://github.com/facebook/jest/pull/11460))
+- `[jest-reporters]` Expose the `getResultHeader` util ([#11460](https://github.com/facebook/jest/pull/11460))
 
 ### Fixes
 

--- a/packages/jest-reporters/src/index.ts
+++ b/packages/jest-reporters/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import getResultHeader from './getResultHeader';
 import {
   formatTestPath,
   printDisplayName,
@@ -33,6 +34,7 @@ export type {
 } from './types';
 export const utils = {
   formatTestPath,
+  getResultHeader,
   printDisplayName,
   relativePath,
   trimAndFormatPath,


### PR DESCRIPTION
## Summary

Multiple reporters, including Mozilla's famous [`fingers-crossed`](https://github.com/mozilla/addons-frontend/blob/49bf2bb95ea0f67c11b8dab49bc57e265f8a6b8d/tests/jest-reporters/fingers-crossed.js), rely on importing the `getResultHeader` method. As of Jest 27, ESM (correcctly) stops this deep import from working.

I believe this is a reasonable method to export, as:
 * nearly every in-built reporter, and every reporter I've used or written, seems to rely on it
 * it only deals in terms of public objects (`TestResult` and config), and returns a string
 * it seems to only rely on already exposed utilities, but isn't really small enough that it would be reasonable for everyone to copy-paste it into their reporters?
