### PR TITLE
Fix `jest-mock` `fn` and `spyOn`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Performance
 
+## 27.0.3
+
+### Fixes
+
+- `[jest-mock]` Fixed `fn` and `spyOn` exports ([#11480](https://github.com/facebook/jest/pull/11480))
+
 ## 27.0.2
 
 ### Features

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -9,7 +9,7 @@
 /* eslint-disable local/ban-types-eventually, local/prefer-rest-params-eventually */
 
 import vm, {Context} from 'vm';
-import {ModuleMocker} from '../';
+import {ModuleMocker, fn, spyOn} from '../';
 
 describe('moduleMocker', () => {
   let moduleMocker: ModuleMocker;
@@ -1438,4 +1438,11 @@ describe('moduleMocker', () => {
       expect(spy2.mock.calls.length).toBe(1);
     });
   });
+});
+
+test('`fn` and `spyOn` do not throw', () => {
+  expect(() => {
+    fn();
+    spyOn({apple: () => {}}, 'apple');
+  }).not.toThrow();
 });

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1112,5 +1112,5 @@ export class ModuleMocker {
 
 const JestMock = new ModuleMocker(global);
 
-export const fn = JestMock.fn;
-export const spyOn = JestMock.spyOn;
+export const fn = JestMock.fn.bind(JestMock);
+export const spyOn = JestMock.spyOn.bind(JestMock);


### PR DESCRIPTION
## Summary

The `fn` and `spyOn` exports for `jest-mock` are broken in Jest 27, see:

<img width="962" alt="Screen Shot 2021-05-29 at 21 34 49" src="https://user-images.githubusercontent.com/13352/120070556-18f99700-c0c6-11eb-8384-cc896304e10a.png">

This PR fixes it.

## Test plan

Added a new test.