### PR TITLE
fix: `require.resolve` on default test sequencer and test environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Fixes
 
-- `[jest-config]` `require.resolve` on default test sequencer and test environment ([#11482](https://github.com/facebook/jest/pull/11482))
-
 ### Chore & Maintenance
 
 ### Performance
@@ -14,6 +12,7 @@
 
 ### Fixes
 
+- `[jest-config]` `require.resolve` on default test sequencer and test environment ([#11482](https://github.com/facebook/jest/pull/11482))
 - `[jest-mock]` Fixed `fn` and `spyOn` exports ([#11480](https://github.com/facebook/jest/pull/11480))
 
 ## 27.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-config]` `require.resolve` on default test sequencer and test environment ([#11482](https://github.com/facebook/jest/pull/11482))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -754,6 +754,19 @@ describe('testEnvironment', () => {
     );
   });
 
+  it('resolves to node environment by default', async () => {
+    const {options} = await normalize(
+      {
+        rootDir: '/root',
+      },
+      {} as Config.Argv,
+    );
+
+    expect(options.testEnvironment).toEqual(
+      require.resolve('jest-environment-node'),
+    );
+  });
+
   it('throws on invalid environment names', async () => {
     await expect(
       normalize(

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -608,7 +608,9 @@ export default async function normalize(
 
   options.testEnvironment = resolveTestEnvironment({
     rootDir: options.rootDir,
-    testEnvironment: options.testEnvironment || DEFAULT_CONFIG.testEnvironment,
+    testEnvironment:
+      options.testEnvironment ||
+      require.resolve(DEFAULT_CONFIG.testEnvironment),
   });
 
   if (!options.roots && options.testPathDirs) {
@@ -1054,7 +1056,8 @@ export default async function normalize(
   }
 
   newOptions.testSequencer = resolveSequencer(newOptions.resolver, {
-    filePath: options.testSequencer || DEFAULT_CONFIG.testSequencer,
+    filePath:
+      options.testSequencer || require.resolve(DEFAULT_CONFIG.testSequencer),
     rootDir: options.rootDir,
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

They are currently broken in yarn v2 pnp mode. See https://github.com/yarnpkg/berry/runs/2701218390
For example, I have to add `@jest/test-sequencer` and `jest-environment-node` as dependency to make the tests run in pnp mode. See https://github.com/SamChou19815/samlang/pull/522

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added test cases on test environment default resolution.
