### PR TITLE
expect: Export expect as default export

### DIFF
--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -9,7 +9,7 @@ const chalk = require('chalk');
 const Immutable = require('immutable');
 const {alignedAnsiStyleSerializer} = require('@jest/test-utils');
 const {stringify} = require('jest-matcher-utils');
-const jestExpect = require('../');
+const {default: jestExpect} = require('../');
 const chalkEnabled = chalk.enabled;
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer);

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -39,8 +39,7 @@ import type {
   AsyncExpectationResult,
   Expect,
   ExpectationResult,
-  MatcherState as JestMatcherState,
-  Matchers as MatcherInterface,
+  MatcherState,
   MatchersObject,
   PromiseMatcherFn,
   RawMatcherFn,
@@ -62,7 +61,7 @@ const createToThrowErrorMatchingSnapshotMatcher = function (
   matcher: RawMatcherFn,
 ) {
   return function (
-    this: JestMatcherState,
+    this: MatcherState,
     received: any,
     testNameOrInlineSnapshot?: string,
   ) {
@@ -251,7 +250,7 @@ const makeThrowingMatcher = (
     let throws = true;
     const utils = {...matcherUtils, iterableEquality, subsetEquality};
 
-    const matcherContext: JestMatcherState = {
+    const matcherContext: MatcherState = {
       // When throws is disabled, the matcher will not throw errors during test
       // execution but instead add them to the global matcher state. If a
       // matcher throws, test execution is normally stopped immediately. The
@@ -422,11 +421,5 @@ expect.getState = getState;
 expect.setState = setState;
 expect.extractExpectedAssertionsErrors = extractExpectedAssertionsErrors;
 
-const expectExport = expect as Expect;
-
-declare namespace expectExport {
-  export type MatcherState = JestMatcherState;
-  export interface Matchers<R> extends MatcherInterface<R> {}
-}
-
-export = expectExport;
+export default expect as Expect;
+export * from './types';

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -15,7 +15,7 @@ import {
   createEmptyTestResult,
 } from '@jest/test-result';
 import type {Circus, Config, Global} from '@jest/types';
-import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
+import expect, {Expect} from 'expect';
 import {bind} from 'jest-each';
 import {formatExecError, formatResultsErrors} from 'jest-message-util';
 import {
@@ -34,7 +34,7 @@ import {
 } from '../state';
 import testCaseReportHandler from '../testCaseReportHandler';
 import {getTestID} from '../utils';
-import createExpect, {Expect} from './jestExpect';
+import createExpect from './jestExpect';
 
 type Process = NodeJS.Process;
 
@@ -159,7 +159,7 @@ export const initialize = async ({
     updateSnapshot,
   });
   // @ts-expect-error: snapshotState is a jest extension of `expect`
-  setState({snapshotState, testPath});
+  expect.setState({snapshotState, testPath});
 
   addEventHandler(handleSnapshotStateAfterRetry(snapshotState));
   if (sendMessageToJest) {
@@ -276,7 +276,7 @@ const handleSnapshotStateAfterRetry =
 const eventHandler = async (event: Circus.Event) => {
   switch (event.name) {
     case 'test_start': {
-      setState({currentTestName: getTestID(event.test)});
+      expect.setState({currentTestName: getTestID(event.test)});
       break;
     }
     case 'test_done': {
@@ -288,7 +288,7 @@ const eventHandler = async (event: Circus.Event) => {
 };
 
 const _addExpectedAssertionErrors = (test: Circus.TestEntry) => {
-  const failures = extractExpectedAssertionsErrors();
+  const failures = expect.extractExpectedAssertionsErrors();
   const errors = failures.map(failure => failure.error);
   test.errors = test.errors.concat(errors);
 };
@@ -297,8 +297,8 @@ const _addExpectedAssertionErrors = (test: Circus.TestEntry) => {
 // test execution and add them to the test result, potentially failing
 // a passing test.
 const _addSuppressedErrors = (test: Circus.TestEntry) => {
-  const {suppressedErrors} = getState();
-  setState({suppressedErrors: []});
+  const {suppressedErrors} = expect.getState();
+  expect.setState({suppressedErrors: []});
   if (suppressedErrors.length) {
     test.errors = test.errors.concat(suppressedErrors);
   }

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Config} from '@jest/types';
-import expect = require('expect');
+import expect, {Expect} from 'expect';
 import {
   addSerializer,
   toMatchInlineSnapshot,
@@ -14,8 +14,6 @@ import {
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
-
-export type Expect = typeof expect;
 
 export default (config: Pick<Config.GlobalConfig, 'expand'>): Expect => {
   expect.setState({expand: config.expand});

--- a/packages/jest-globals/src/index.ts
+++ b/packages/jest-globals/src/index.ts
@@ -7,7 +7,7 @@
 
 import type {Jest} from '@jest/environment';
 import type {Global} from '@jest/types';
-import importedExpect = require('expect');
+import type importedExpect from 'expect';
 
 export declare const jest: Jest;
 

--- a/packages/jest-jasmine2/src/jestExpect.ts
+++ b/packages/jest-jasmine2/src/jestExpect.ts
@@ -8,7 +8,7 @@
 /* eslint-disable local/prefer-spread-eventually */
 
 import type {Global} from '@jest/types';
-import expect = require('expect');
+import expect, {MatcherState} from 'expect';
 import {
   addSerializer,
   toMatchInlineSnapshot,
@@ -42,7 +42,7 @@ export default (config: {expand: boolean}): void => {
     const jestMatchersObject = Object.create(null);
     Object.keys(jasmineMatchersObject).forEach(name => {
       jestMatchersObject[name] = function (
-        this: expect.MatcherState,
+        this: MatcherState,
         ...args: Array<unknown>
       ): RawMatcherFn {
         // use "expect.extend" if you need to use equality testers (via this.equal)

--- a/packages/jest-jasmine2/src/setup_jest_globals.ts
+++ b/packages/jest-jasmine2/src/setup_jest_globals.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Config, Global} from '@jest/types';
-import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
+import expect from 'expect';
 import {
   SnapshotState,
   SnapshotStateType,
@@ -34,8 +34,8 @@ export type SetupOptions = {
 // test execution and add them to the test result, potentially failing
 // a passing test.
 const addSuppressedErrors = (result: SpecResult) => {
-  const {suppressedErrors} = getState();
-  setState({suppressedErrors: []});
+  const {suppressedErrors} = expect.getState();
+  expect.setState({suppressedErrors: []});
   if (suppressedErrors.length) {
     result.status = 'failed';
 
@@ -53,7 +53,7 @@ const addSuppressedErrors = (result: SpecResult) => {
 };
 
 const addAssertionErrors = (result: SpecResult) => {
-  const assertionErrors = extractExpectedAssertionsErrors();
+  const assertionErrors = expect.extractExpectedAssertionsErrors();
   if (assertionErrors.length) {
     const jasmineErrors = assertionErrors.map(({actual, error, expected}) => ({
       actual,
@@ -78,7 +78,7 @@ const patchJasmine = () => {
         };
         const onStart = attr.onStart;
         attr.onStart = (context: JasmineSpec) => {
-          setState({currentTestName: context.getFullName()});
+          expect.setState({currentTestName: context.getFullName()});
           onStart && onStart.call(attr, context);
         };
         super(attr);
@@ -115,7 +115,7 @@ export default async ({
     updateSnapshot,
   });
   // @ts-expect-error: snapshotState is a jest extension of `expect`
-  setState({snapshotState, testPath});
+  expect.setState({snapshotState, testPath});
   // Return it back to the outer scope (test runner outside the VM).
   return snapshotState;
 };

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -7,7 +7,7 @@
 
 import type {AssertionError} from 'assert';
 import type {Config} from '@jest/types';
-import expect = require('expect');
+import type expect from 'expect';
 import type CallTracker from './jasmine/CallTracker';
 import type Env from './jasmine/Env';
 import type JsApiReporter from './jasmine/JsApiReporter';


### PR DESCRIPTION
This allows types to be exported as well.
Fixes https://github.com/facebook/jest/issues/11487
Strictly speaking a breaking change, as expect = require('expect') not longer works, but as this is usually used as a global, this shouldn't be much of an issue.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

To recap https://github.com/facebook/jest/issues/11487 , the "expect" doesn't export the actual `Matchers` interface which the `expect()` function returns, but rather an interface which extends Matchers. This means that you can't extend the returned interface with typescript's declaration merging.

This the cleaner solution, which replaces the `export = ` with `export default ` which allows re-exporting types.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Is it possible to test the types? `packages/expect/src/__tests__/extend.test.ts` has TS errors, but still shows up green.
