### PR TITLE
fix: resolve bundled modules from correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Performance
 
+## 27.0.4
+
+### Fixes
+
+- `[jest-config, jest-resolve]` Pass in `require.resolve` to resolvers to resolve from correct base ([#11493](https://github.com/facebook/jest/pull/11493))
+
 ## 27.0.3
 
 ### Fixes

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -607,6 +607,7 @@ export default async function normalize(
   }
 
   options.testEnvironment = resolveTestEnvironment({
+    requireResolveFunction: require.resolve,
     rootDir: options.rootDir,
     testEnvironment:
       options.testEnvironment ||
@@ -745,6 +746,7 @@ export default async function normalize(
             option &&
             resolveRunner(newOptions.resolver, {
               filePath: option,
+              requireResolveFunction: require.resolve,
               rootDir: options.rootDir,
             });
         }
@@ -1016,6 +1018,7 @@ export default async function normalize(
               config: {},
               path: resolveWatchPlugin(newOptions.resolver, {
                 filePath: watchPlugin,
+                requireResolveFunction: require.resolve,
                 rootDir: options.rootDir,
               }),
             };
@@ -1024,6 +1027,7 @@ export default async function normalize(
               config: watchPlugin[1] || {},
               path: resolveWatchPlugin(newOptions.resolver, {
                 filePath: watchPlugin[0],
+                requireResolveFunction: require.resolve,
                 rootDir: options.rootDir,
               }),
             };
@@ -1058,6 +1062,7 @@ export default async function normalize(
   newOptions.testSequencer = resolveSequencer(newOptions.resolver, {
     filePath:
       options.testSequencer || require.resolve(DEFAULT_CONFIG.testSequencer),
+    requireResolveFunction: require.resolve,
     rootDir: options.rootDir,
   });
 

--- a/packages/jest-resolve/src/utils.ts
+++ b/packages/jest-resolve/src/utils.ts
@@ -40,12 +40,14 @@ const resolveWithPrefix = (
     humanOptionName,
     optionName,
     prefix,
+    requireResolveFunction,
     rootDir,
   }: {
     filePath: string;
     humanOptionName: string;
     optionName: string;
     prefix: string;
+    requireResolveFunction: (moduleName: string) => string;
     rootDir: Config.Path;
   },
 ): string => {
@@ -59,7 +61,7 @@ const resolveWithPrefix = (
   }
 
   try {
-    return require.resolve(`${prefix}${fileName}`);
+    return requireResolveFunction(`${prefix}${fileName}`);
   } catch {}
 
   module = Resolver.findNodeModule(fileName, {
@@ -71,7 +73,7 @@ const resolveWithPrefix = (
   }
 
   try {
-    return require.resolve(fileName);
+    return requireResolveFunction(fileName);
   } catch {}
 
   throw createValidationError(
@@ -94,15 +96,19 @@ const resolveWithPrefix = (
 export const resolveTestEnvironment = ({
   rootDir,
   testEnvironment: filePath,
+  // TODO: remove default in Jest 28
+  requireResolveFunction = require.resolve,
 }: {
   rootDir: Config.Path;
   testEnvironment: string;
+  requireResolveFunction?: (moduleName: string) => string;
 }): string =>
   resolveWithPrefix(undefined, {
     filePath,
     humanOptionName: 'Test environment',
     optionName: 'testEnvironment',
     prefix: 'jest-environment-',
+    requireResolveFunction,
     rootDir,
   });
 
@@ -116,13 +122,23 @@ export const resolveTestEnvironment = ({
  */
 export const resolveWatchPlugin = (
   resolver: string | undefined | null,
-  {filePath, rootDir}: {filePath: string; rootDir: Config.Path},
+  {
+    filePath,
+    rootDir,
+    // TODO: remove default in Jest 28
+    requireResolveFunction = require.resolve,
+  }: {
+    filePath: string;
+    rootDir: Config.Path;
+    requireResolveFunction?: (moduleName: string) => string;
+  },
 ): string =>
   resolveWithPrefix(resolver, {
     filePath,
     humanOptionName: 'Watch plugin',
     optionName: 'watchPlugins',
     prefix: 'jest-watch-',
+    requireResolveFunction,
     rootDir,
   });
 
@@ -136,24 +152,44 @@ export const resolveWatchPlugin = (
  */
 export const resolveRunner = (
   resolver: string | undefined | null,
-  {filePath, rootDir}: {filePath: string; rootDir: Config.Path},
+  {
+    filePath,
+    rootDir,
+    // TODO: remove default in Jest 28
+    requireResolveFunction = require.resolve,
+  }: {
+    filePath: string;
+    rootDir: Config.Path;
+    requireResolveFunction?: (moduleName: string) => string;
+  },
 ): string =>
   resolveWithPrefix(resolver, {
     filePath,
     humanOptionName: 'Jest Runner',
     optionName: 'runner',
     prefix: 'jest-runner-',
+    requireResolveFunction,
     rootDir,
   });
 
 export const resolveSequencer = (
   resolver: string | undefined | null,
-  {filePath, rootDir}: {filePath: string; rootDir: Config.Path},
+  {
+    filePath,
+    rootDir,
+    // TODO: remove default in Jest 28
+    requireResolveFunction = require.resolve,
+  }: {
+    filePath: string;
+    rootDir: Config.Path;
+    requireResolveFunction?: (moduleName: string) => string;
+  },
 ): string =>
   resolveWithPrefix(resolver, {
     filePath,
     humanOptionName: 'Jest Sequencer',
     optionName: 'testSequencer',
     prefix: 'jest-sequencer-',
+    requireResolveFunction,
     rootDir,
   });

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -25,6 +25,8 @@
     "exit": "^0.1.2",
     "graceful-fs": "^4.2.4",
     "jest-docblock": "^27.0.1",
+    "jest-environment-jsdom": "^27.0.3",
+    "jest-environment-node": "^27.0.3",
     "jest-haste-map": "^27.0.2",
     "jest-leak-detector": "^27.0.2",
     "jest-message-util": "^27.0.2",

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -98,6 +98,7 @@ async function runTestInternal(
     }
     testEnvironment = resolveTestEnvironment({
       ...config,
+      requireResolveFunction: require.resolve,
       testEnvironment: customEnvironment,
     });
   }

--- a/packages/jest-runner/tsconfig.json
+++ b/packages/jest-runner/tsconfig.json
@@ -8,6 +8,8 @@
     {"path": "../jest-console"},
     {"path": "../jest-docblock"},
     {"path": "../jest-environment"},
+    {"path": "../jest-environment-jsdom"},
+    {"path": "../jest-environment-node"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-leak-detector"},
     {"path": "../jest-message-util"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -13733,6 +13733,8 @@ fsevents@^1.2.7:
     exit: ^0.1.2
     graceful-fs: ^4.2.4
     jest-docblock: ^27.0.1
+    jest-environment-jsdom: ^27.0.3
+    jest-environment-node: ^27.0.3
     jest-haste-map: ^27.0.2
     jest-jasmine2: ^27.0.3
     jest-leak-detector: ^27.0.2


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Take 2 at fixing #11452. This time by passing in `require.resolve` from the modules that do the `require` so that it looks like it's e.g. `jest-config` doing the `require.resolve` rather than `jest-resolve`, thus satisfying the dependency

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
