### PR TITLE
Update `watchModePatterns.test` snapshot

### DIFF
--- a/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
@@ -1,18 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`can press "p" to filter by file name 1`] = `
-
+"
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a filenames regex pattern.
 
- pattern › 
- pattern › b
- pattern › ba
- pattern › bar
+ pattern ›  pattern › bar
 
-
-
+"
 `;
 
 exports[`can press "p" to filter by file name: test results 1`] = `
@@ -43,16 +39,14 @@ Ran all test suites matching /bar/i.
 `;
 
 exports[`can press "t" to filter by test name 1`] = `
-
+"
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a tests regex pattern.
 
- pattern › 
- pattern › 2
+ pattern ›  pattern › 2
 
-
-
+"
 `;
 
 exports[`can press "t" to filter by test name: test results 1`] = `

--- a/e2e/__tests__/watchModePatterns.test.ts
+++ b/e2e/__tests__/watchModePatterns.test.ts
@@ -42,7 +42,7 @@ const setupFiles = (input: Array<{keys: Array<string>}>) => {
 };
 
 test('can press "p" to filter by file name', () => {
-  const input = [{keys: ['p', 'b', 'a', 'r', '\r']}, {keys: ['q']}];
+  const input = [{keys: ['p', 'bar', '\r']}, {keys: ['q']}];
   setupFiles(input);
 
   const {exitCode, stdout, stderr} = runJest(DIR, [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`$ yarn test e2e/__tests__/watchModePatterns.test.ts` was faild so update snapshot.

<details>
<summary>Result (was faild)</summary>

```zsh
$ yarn test e2e/__tests__/watchModePatterns.test.ts
 FAIL  e2e/__tests__/watchModePatterns.test.ts
  ✕ can press "p" to filter by file name (2053 ms)
  ✕ can press "t" to filter by test name (2132 ms)

  ● can press "p" to filter by file name

    expect(received).toMatchSnapshot()

    Snapshot name: `can press "p" to filter by file name 1`

    - Snapshot  - 7
    + Received  + 3

    -
    + "
      Pattern Mode Usage
       › Press Esc to exit pattern mode.
       › Press Enter to filter by a filenames regex pattern.

    -  pattern ›
    -  pattern › b
    -  pattern › ba
    -  pattern › bar
    -
    +  pattern ›  pattern › b pattern › ba pattern › bar

    -
    + "

      53 |
      54 |   // contains ansi characters, should not use `wrap`
    > 55 |   expect(stdout).toMatchSnapshot();
         |                  ^
      56 |   expect(results).toHaveLength(2);
      57 |   results.forEach(({rest, summary}) => {
      58 |     expect(wrap(rest)).toMatchSnapshot('test results');
      at Object.toMatchSnapshot (e2e/__tests__/watchModePatterns.test.ts:55:18)

  ● can press "t" to filter by test name

    expect(received).toMatchSnapshot()

    Snapshot name: `can press "t" to filter by test name 1`

    - Snapshot  - 5
    + Received  + 3

    -
    + "
      Pattern Mode Usage
       › Press Esc to exit pattern mode.
       › Press Enter to filter by a tests regex pattern.

    -  pattern ›
    -  pattern › 2
    +  pattern ›  pattern › 2

    -
    -
    + "

      73 |
      74 |   // contains ansi characters, should not use `wrap`
    > 75 |   expect(stdout).toMatchSnapshot();
         |                  ^
      76 |   expect(results).toHaveLength(2);
      77 |   results.forEach(({rest, summary}) => {
      78 |     expect(wrap(rest)).toMatchSnapshot('test results');

      at Object.toMatchSnapshot (e2e/__tests__/watchModePatterns.test.ts:75:18)

 › 2 snapshots failed.
```

<img width="778" alt="スクリーンショット 2021-06-01 20 12 54" src="https://user-images.githubusercontent.com/50798936/120314079-d0d0b380-c315-11eb-86de-06f2384f982c.png">
<img width="838" alt="スクリーンショット 2021-06-01 20 13 07" src="https://user-images.githubusercontent.com/50798936/120314102-d62dfe00-c315-11eb-926a-d0899e597ac7.png">
</details>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
