### PR TITLE
Allow to pass arguments via environment variables

### DIFF
--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -53,8 +53,13 @@ export const buildArgv = (maybeArgv?: Array<string>): Config.Argv => {
     getVersion() +
     (__dirname.includes(`packages${path.sep}jest-cli`) ? '-dev' : '');
 
-  const rawArgv: Config.Argv | Array<string> =
-    maybeArgv || process.argv.slice(2);
+  const rawArgv: Array<string> = maybeArgv || process.argv.slice(2);
+  const envArgv = (process.env.JEST_OPTIONS || '').split(' ');
+
+  if (envArgv.length > 0) {
+    rawArgv.push(...envArgv);
+  }
+
   const argv: Config.Argv = yargs(rawArgv)
     .usage(args.usage)
     .version(version)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I found it very useful to pass arguments or part of arguments via environment variables. Nodejs allow to do it by passing [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#cli_node_options_options). It would be also useful for jest, because jest often running from package.json scripts or IDEs. Users could set JEST_OPTIONS environment variable once for all project (i.e. ~/.bashrc) and for current project (in CI, for example).
