### PR TITLE
docs: add partials mocking guide

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -151,6 +151,44 @@ test('should fetch users', () => {
 });
 ```
 
+## Mocking Partials
+
+Subsets of a module can be mocked and the rest of the module can keep their actual implementation:
+
+```js
+// foo-bar-baz.js
+export const foo = 'foo';
+export const bar = () => 'bar';
+export default () => 'baz';
+```
+
+```js
+//test.js
+import defaultExport, {bar, foo} from '../foo-bar-baz';
+
+jest.mock('../foo-bar-baz', () => {
+  const originalModule = jest.requireActual('../foo-bar-baz');
+  const mockedModule = jest.createMockFromModule('../foo-bar-baz');
+
+  //Mock the default export and named export 'foo'
+  return {
+    ...mockedModule,
+    ...originalModule,
+    foo: 'mocked foo',
+    default: jest.fn(() => 'mocked baz'),
+  };
+});
+
+test('should do a partial mock', () => {
+  const defaultExportResult = defaultExport();
+  expect(defaultExportResult).toBe('mocked baz');
+  expect(defaultExport).toHaveBeenCalled();
+
+  expect(foo).toBe('mocked foo');
+  expect(bar()).toBe('bar');
+});
+```
+
 ## Mock Implementations
 
 Still, there are cases where it's useful to go beyond the ability to specify return values and full-on replace the implementation of a mock function. This can be done with `jest.fn` or the `mockImplementationOnce` method on mock functions.

--- a/website/versioned_docs/version-25.x/MockFunctions.md
+++ b/website/versioned_docs/version-25.x/MockFunctions.md
@@ -151,6 +151,44 @@ test('should fetch users', () => {
 });
 ```
 
+## Mocking Partials
+
+Subsets of a module can be mocked and the rest of the module can keep their actual implementation:
+
+```js
+// foo-bar-baz.js
+export const foo = 'foo';
+export const bar = () => 'bar';
+export default () => 'baz';
+```
+
+```js
+//test.js
+import defaultExport, {bar, foo} from '../foo-bar-baz';
+
+jest.mock('../foo-bar-baz', () => {
+  const originalModule = jest.requireActual('../foo-bar-baz');
+  const mockedModule = jest.createMockFromModule('../foo-bar-baz');
+
+  //Mock the default export and named export 'foo'
+  return {
+    ...mockedModule,
+    ...originalModule,
+    foo: 'mocked foo',
+    default: jest.fn(() => 'mocked baz'),
+  };
+});
+
+test('should do a partial mock', () => {
+  const defaultExportResult = defaultExport();
+  expect(defaultExportResult).toBe('mocked baz');
+  expect(defaultExport).toHaveBeenCalled();
+
+  expect(foo).toBe('mocked foo');
+  expect(bar()).toBe('bar');
+});
+```
+
 ## Mock Implementations
 
 Still, there are cases where it's useful to go beyond the ability to specify return values and full-on replace the implementation of a mock function. This can be done with `jest.fn` or the `mockImplementationOnce` method on mock functions.

--- a/website/versioned_docs/version-26.x/MockFunctions.md
+++ b/website/versioned_docs/version-26.x/MockFunctions.md
@@ -151,6 +151,44 @@ test('should fetch users', () => {
 });
 ```
 
+## Mocking Partials
+
+Subsets of a module can be mocked and the rest of the module can keep their actual implementation:
+
+```js
+// foo-bar-baz.js
+export const foo = 'foo';
+export const bar = () => 'bar';
+export default () => 'baz';
+```
+
+```js
+//test.js
+import defaultExport, {bar, foo} from '../foo-bar-baz';
+
+jest.mock('../foo-bar-baz', () => {
+  const originalModule = jest.requireActual('../foo-bar-baz');
+  const mockedModule = jest.createMockFromModule('../foo-bar-baz');
+
+  //Mock the default export and named export 'foo'
+  return {
+    ...mockedModule,
+    ...originalModule,
+    foo: 'mocked foo',
+    default: jest.fn(() => 'mocked baz'),
+  };
+});
+
+test('should do a partial mock', () => {
+  const defaultExportResult = defaultExport();
+  expect(defaultExportResult).toBe('mocked baz');
+  expect(defaultExport).toHaveBeenCalled();
+
+  expect(foo).toBe('mocked foo');
+  expect(bar()).toBe('bar');
+});
+```
+
 ## Mock Implementations
 
 Still, there are cases where it's useful to go beyond the ability to specify return values and full-on replace the implementation of a mock function. This can be done with `jest.fn` or the `mockImplementationOnce` method on mock functions.

--- a/website/versioned_docs/version-27.0/MockFunctions.md
+++ b/website/versioned_docs/version-27.0/MockFunctions.md
@@ -151,6 +151,44 @@ test('should fetch users', () => {
 });
 ```
 
+## Mocking Partials
+
+Subsets of a module can be mocked and the rest of the module can keep their actual implementation:
+
+```js
+// foo-bar-baz.js
+export const foo = 'foo';
+export const bar = () => 'bar';
+export default () => 'baz';
+```
+
+```js
+//test.js
+import defaultExport, {bar, foo} from '../foo-bar-baz';
+
+jest.mock('../foo-bar-baz', () => {
+  const originalModule = jest.requireActual('../foo-bar-baz');
+  const mockedModule = jest.createMockFromModule('../foo-bar-baz');
+
+  //Mock the default export and named export 'foo'
+  return {
+    ...mockedModule,
+    ...originalModule,
+    foo: 'mocked foo',
+    default: jest.fn(() => 'mocked baz'),
+  };
+});
+
+test('should do a partial mock', () => {
+  const defaultExportResult = defaultExport();
+  expect(defaultExportResult).toBe('mocked baz');
+  expect(defaultExport).toHaveBeenCalled();
+
+  expect(foo).toBe('mocked foo');
+  expect(bar()).toBe('bar');
+});
+```
+
 ## Mock Implementations
 
 Still, there are cases where it's useful to go beyond the ability to specify return values and full-on replace the implementation of a mock function. This can be done with `jest.fn` or the `mockImplementationOnce` method on mock functions.


### PR DESCRIPTION
"Mock Functions" guide was lack of describing the partial mocking, add "Mocking Partials" part to the documentation.

resolves https://github.com/facebook/jest/issues/10021