### PR TITLE
fix(findRelatedTests): edge cases with --findRelatedTests on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-reporter]` Allow `node-notifier@10` as peer dependency ([#11523](https://github.com/facebook/jest/pull/11523))
 - `[jest-reporter]` Update `v8-to-istanbul` ([#11523](https://github.com/facebook/jest/pull/11523))
+- `[jest-core]` Support special characters on windows with `--findRelatedTests` ([#11548](https://github.com/facebook/jest/pull/11548))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `[jest-reporter]` Allow `node-notifier@10` as peer dependency ([#11523](https://github.com/facebook/jest/pull/11523))
 - `[jest-reporter]` Update `v8-to-istanbul` ([#11523](https://github.com/facebook/jest/pull/11523))
-- `[jest-core]` Support special characters on windows with `--findRelatedTests` ([#11548](https://github.com/facebook/jest/pull/11548))
+- `[jest-core]` Support special characters like `@`, `+` and `()` on windows with `--findRelatedTests` ([#11548](https://github.com/facebook/jest/pull/11548))
 
 ### Chore & Maintenance
 

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -309,18 +309,22 @@ export default class SearchSource {
     const allFiles = this._context.hasteFS.getAllFiles();
     const options = {nocase: true, windows: false};
 
+    function normalizePosix(filePath: string) {
+      return filePath.replace(/\\/g, '/');
+    }
+
     paths = paths
       .map(p => {
-        const relativePath = path
-          .resolve(this._context.config.cwd, p)
-          .replace(/\\/g, '\\\\')
-          // Escape extended globs without a pattern: https://github.com/micromatch/micromatch#extended-globbing
-          // (* and ? are forbidden in file names)
-          .replace(/(@|\+|!)([^\(])/g, '\\$1$2')
-          // Allow search in hidden directories
-          .replace(/\\\./g, '\\\\.');
-        const match = micromatch(allFiles, relativePath, options);
-        return match[0];
+        // micromatch works with forward slashes: https://github.com/micromatch/micromatch#backslashes
+        const normalizedPath = normalizePosix(
+          path.resolve(this._context.config.cwd, p),
+        );
+        const match = micromatch(
+          allFiles.map(normalizePosix),
+          normalizedPath,
+          options,
+        );
+        return path.resolve(match[0]);
       })
       .filter(Boolean);
     return paths;

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -324,9 +324,10 @@ export default class SearchSource {
           normalizedPath,
           options,
         );
-        return match.length && path.resolve(match[0]);
+        return match[0];
       })
-      .filter(Boolean);
+      .filter(Boolean)
+      .map(p => path.resolve(p));
     return paths;
   }
 

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -324,7 +324,7 @@ export default class SearchSource {
           normalizedPath,
           options,
         );
-        return path.resolve(match[0]);
+        return match.length && path.resolve(match[0]);
       })
       .filter(Boolean);
     return paths;

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -406,6 +406,77 @@ describe('SearchSource', () => {
     });
   });
 
+  describe('filterPathsWin32', () => {
+    beforeEach(async () => {
+      const config = (
+        await normalize(
+          {
+            name,
+            rootDir: '.',
+            roots: [],
+          },
+          {} as Config.Argv,
+        )
+      ).options;
+      const context = await Runtime.createContext(config, {
+        maxWorkers,
+        watchman: false,
+      });
+
+      searchSource = new SearchSource(context);
+      context.hasteFS.getAllFiles = () => [
+        path.resolve('packages/lib/my-lib.ts'),
+        path.resolve('packages/@core/my-app.ts'),
+        path.resolve('packages/+cli/my-cli.ts'),
+        path.resolve('packages/.hidden/my-app-hidden.ts'),
+        path.resolve('packages/programs (x86)/my-program.ts'),
+      ];
+    });
+
+    it('should allow a simple match', async () => {
+      const result = searchSource.filterPathsWin32(['packages/lib/my-lib.ts']);
+      expect(result).toEqual([path.resolve('packages/lib/my-lib.ts')]);
+    });
+    it('should allow to match a file inside a hidden directory', async () => {
+      const result = searchSource.filterPathsWin32([
+        'packages/.hidden/my-app-hidden.ts',
+      ]);
+      expect(result).toEqual([
+        path.resolve('packages/.hidden/my-app-hidden.ts'),
+      ]);
+    });
+    it('should allow to match a file inside a directory prefixed with a "@"', async () => {
+      const result = searchSource.filterPathsWin32([
+        'packages/@core/my-app.ts',
+      ]);
+      expect(result).toEqual([path.resolve('packages/@core/my-app.ts')]);
+    });
+    it('should allow to match a file inside a directory prefixed with a "+"', async () => {
+      const result = searchSource.filterPathsWin32(['packages/+cli/my-cli.ts']);
+      expect(result).toEqual([path.resolve('packages/+cli/my-cli.ts')]);
+    });
+    it('should allow an @(pattern)', () => {
+      const result = searchSource.filterPathsWin32([
+        'packages/@(@core)/my-app.ts',
+      ]);
+      expect(result).toEqual([path.resolve('packages/@core/my-app.ts')]);
+    });
+    it('should allow a +(pattern)', () => {
+      const result = searchSource.filterPathsWin32([
+        'packages/+(@core)/my-app.ts',
+      ]);
+      expect(result).toEqual([path.resolve('packages/@core/my-app.ts')]);
+    });
+    it('should allow for (pattern) in file path', () => {
+      const result = searchSource.filterPathsWin32([
+        'packages/programs (x86)/my-program.ts',
+      ]);
+      expect(result).toEqual([
+        path.resolve('packages/programs (x86)/my-program.ts'),
+      ]);
+    });
+  });
+
   describe('findRelatedTests', () => {
     const rootDir = path.join(
       __dirname,

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -475,6 +475,10 @@ describe('SearchSource', () => {
         path.resolve('packages/programs (x86)/my-program.ts'),
       ]);
     });
+    it('should allow no results found', () => {
+      const result = searchSource.filterPathsWin32(['not/exists']);
+      expect(result).toHaveLength(0);
+    });
   });
 
   describe('findRelatedTests', () => {


### PR DESCRIPTION

## Summary

Allow hidden directories and special characters with `--findRelatedTests` on windows.
* `jest --findRelatedTests packages/@core/my-app.ts`
* `jest --findRelatedTests packages/.hidden/my-hidden-app.ts`
* `jest --findRelatedTests 'packages/programs (x86)/my-hidden-app.ts'`

Fixes #11534
Fixes #9728

## Test plan

I've tested this against the reproduction repo provided by @blephy in https://github.com/facebook/jest/issues/11534#issuecomment-855434826
I also added unit tests for this, which run on both linux and windows in CI