### PR TITLE
Use `globalThis` (with fallback if needed) instead of `global` to enable esbuild support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-fake-timers]` Flush callbacks scheduled with `requestAnimationFrame` every 16ms when using legacy timers. ([#11523](https://github.com/facebook/jest/pull/11567))
+- `[pretty-format]` Use `globalThis` (with polyfill if required) to bring support for esbuild's browser bundling mode ([#11569](https://github.com/facebook/jest/pull/11569)
 
 ### Fixes
 

--- a/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
@@ -16,7 +16,7 @@ FAIL __tests__/asyncDefinition.test.js
       14 |   });
       15 | });
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:146:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:190:11)
       at test (__tests__/asyncDefinition.test.js:12:5)
 
   ● Test suite failed to run
@@ -31,7 +31,7 @@ FAIL __tests__/asyncDefinition.test.js
       15 | });
       16 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:114:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:158:11)
       at afterAll (__tests__/asyncDefinition.test.js:13:5)
 
   ● Test suite failed to run
@@ -46,7 +46,7 @@ FAIL __tests__/asyncDefinition.test.js
       20 | });
       21 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:146:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:190:11)
       at test (__tests__/asyncDefinition.test.js:18:3)
 
   ● Test suite failed to run
@@ -60,6 +60,6 @@ FAIL __tests__/asyncDefinition.test.js
       20 | });
       21 |
 
-      at eventHandler (../../packages/jest-circus/build/eventHandler.js:114:11)
+      at eventHandler (../../packages/jest-circus/build/eventHandler.js:158:11)
       at afterAll (__tests__/asyncDefinition.test.js:19:3)
 `;

--- a/scripts/babel-plugin-jest-native-globals.js
+++ b/scripts/babel-plugin-jest-native-globals.js
@@ -12,21 +12,99 @@
 
 module.exports = ({template}) => {
   const promiseDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
   `);
   const symbolDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var Symbol = global['jest-symbol-do-not-touch'] || global.Symbol;
   `);
   const nowDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var jestNow = global[Symbol.for('jest-native-now')] || global.Date.now;
   `);
   const fsReadFileDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var jestReadFile = global[Symbol.for('jest-native-read-file')] || fs.readFileSync;
   `);
   const fsWriteFileDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var jestWriteFile = global[Symbol.for('jest-native-write-file')] || fs.writeFileSync;
   `);
   const fsExistsFileDeclaration = template(`
+    var global = (function() {
+      if (typeof globalThis !== 'undefined') {
+        return globalThis;
+      } else if (typeof global !== 'undefined') {
+        return global;
+      } else if (typeof self !== 'undefined') {
+        return self;
+      } else if (typeof window !== 'undefined') {
+        return window;
+      } else {
+        return Function('return this')();
+      }
+    }())
     var jestExistsFile = global[Symbol.for('jest-native-exists-file')] || fs.existsSync;
   `);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The motivation for this pull-request is to get the jest packages such as `pretty-format` to work with esbuild when targeting the browser platform. This is because [@testing-library/dom](https://testing-library.com/) uses pretty-format and I am trying to use that package as part of my testing setup.

By using `global`, the package `pretty-format` can not be bundled for the browser by `esbuild` because `global` is not defined in a browser environment.

Switching to `globalThis`, with a polyfill for older environments, allows `pretty-format` (and hopefully other packages) to be bundled by `esbuild --platform browser`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The change does not modify any logic of Jest's packages, it only adds a polyfill for `globalThis`.

A way to test this change will solve my original problem would be to build the project and then attempt to bundle `pretty-format` with `esbuild --bundle --target=es2020 --platform=browser` and run the bundle in a browser environment.


### Before

Building from master branch:
```
~/Code/jest
❯ yarn build
❯ yarn build
 Building packages 
 Building TypeScript definition files 
 Successfully built TypeScript definition files 
 Validating TypeScript definition files 
 Successfully validated TypeScript definition files 
❯ esbuild packages/pretty-format/build/index.js --bundle --target=es2020 --platform=browser | pbcopy
```

Running the bundle in the browser gives an Error `Uncaught ReferenceError: global is not defined`
<img width="660" alt="image" src="https://user-images.githubusercontent.com/1569131/121963583-3aaf7b00-cd62-11eb-95fb-ce39fdf44de2.png">


### After

Building from globalthis branch:
```
❯ git switch -
Switched to branch 'globalthis'
❯ yarn build
 Building packages
 Building TypeScript definition files
 Successfully built TypeScript definition files
 Validating TypeScript definition files
 Successfully validated TypeScript definition files
❯ esbuild packages/pretty-format/build/index.js --bundle --target=es2020 --platform=browser | pbcopy
```

Running the bundle in the browser gives no error:
<img width="662" alt="image" src="https://user-images.githubusercontent.com/1569131/121963497-16ec3500-cd62-11eb-9fbe-8b807ba9f1b9.png">
