### PR TITLE
[docs] Fix syntax to inject test case index in `test.each()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Fix the example syntax for injecting the test case index into the test title for `test.each()`
+
 ### Performance
 
 ## 27.0.4

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -681,7 +681,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - `%%` - single percent sign ('%'). This does not consume an argument.
   - Or generate unique test titles by injecting properties of test case object with `$variable`
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-    - You can use `$#` to inject the index of the test case
+    - You can use `%#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
 - `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The [documentation](https://jestjs.io/docs/api#testeachtablename-fn-timeout) says `$#` can be used to inject the index of the test case into the test title; this is incorrect. `%#` is the correct syntax, which I found [here](https://github.com/facebook/jest/pull/6414#issuecomment-396217419).

Here's a screenshot of the incorrect documentation:

<img src="https://user-images.githubusercontent.com/3293811/122121718-d1228180-cde0-11eb-813b-ae9c0fa067ee.png" width="700">

## Test plan

Code from the documentation (incorrect):

```javascript
test.each([1, 1, 1])('Test case index: $#', (n) => {
  expect(n).toEqual(n);
});
```

Output from the documentation:
<img src="https://user-images.githubusercontent.com/3293811/122122300-7ccbd180-cde1-11eb-94dd-a0044e0f7b0d.png" width="300">

Correct syntax:

```javascript
test.each([1, 1, 1])('Test case index: %#', (n) => {
  expect(n).toEqual(n);
});
```

Output from the correct syntax:
<img src="https://user-images.githubusercontent.com/3293811/122122406-9c62fa00-cde1-11eb-860e-d1e972361814.png" width="300">