### PR TITLE
docs: fix broken links to jest documentation

### DIFF
--- a/packages/jest-changed-files/README.md
+++ b/packages/jest-changed-files/README.md
@@ -16,7 +16,7 @@ Get the list of files and repos that have changed since the last commit.
 
 #### Parameters
 
-roots: Array of string paths gathered from [jest roots](https://jestjs.io/docs/configuration#roots-array-string).
+roots: Array of string paths gathered from [jest roots](https://jestjs.io/docs/configuration#roots-arraystring).
 
 options: Object literal with keys
 
@@ -29,7 +29,7 @@ Get a set of git and hg repositories.
 
 #### Parameters
 
-roots: Array of string paths gathered from [jest roots](https://jestjs.io/docs/configuration#roots-array-string).
+roots: Array of string paths gathered from [jest roots](https://jestjs.io/docs/configuration#roots-arraystring).
 
 ## Usage
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR fixes the broken links to jest documentation in `jest-changed-files` [readme](https://github.com/facebook/jest/blob/master/packages/jest-changed-files/README.md). They do not jump to the anchors of the corresponding sections. This is due to an extra hyphen in the link, for example:
```
Original: https://jestjs.io/docs/configuration#roots-array-string
Fixed:    https://jestjs.io/docs/configuration#roots-arraystring
```

## Test plan

Links in `jest-changed-files` readme should jump to corresponding sections of the documentation.
