### PR TITLE
docs: fix wrong MockFunctions.md log result

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -106,7 +106,7 @@ const result = [11, 12].filter(num => filterTestFn(num));
 console.log(result);
 // > [11]
 console.log(filterTestFn.mock.calls[0][0]); // 11
-console.log(filterTestFn.mock.calls[0][1]); // 12
+console.log(filterTestFn.mock.calls[0][1]); // undefined
 ```
 
 Most real-world examples actually involve getting ahold of a mock function on a dependent component and configuring that, but the technique is the same. In these cases, try to avoid the temptation to implement logic inside of any function that's not directly being tested.

--- a/website/versioned_docs/version-27.0/MockFunctions.md
+++ b/website/versioned_docs/version-27.0/MockFunctions.md
@@ -106,7 +106,7 @@ const result = [11, 12].filter(num => filterTestFn(num));
 console.log(result);
 // > [11]
 console.log(filterTestFn.mock.calls[0][0]); // 11
-console.log(filterTestFn.mock.calls[0][1]); // 12
+console.log(filterTestFn.mock.calls[0][1]); // undefined
 ```
 
 Most real-world examples actually involve getting ahold of a mock function on a dependent component and configuring that, but the technique is the same. In these cases, try to avoid the temptation to implement logic inside of any function that's not directly being tested.


### PR DESCRIPTION
It seems a little strange to me. Why are we showing the first and second arguments of the first function call (lines 108-109 of the MockFunctions.md). It would be more correct to write .calls[0][0] and .calls[1][0] to show the first argument of function
![Screenshot_1](https://user-images.githubusercontent.com/55926537/122571338-4b5b3c00-d055-11eb-8c95-063b98eff4f0.jpg)
 calls.

MockFunctions.md typo fixed

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

It fixes documentation typo. Therefore, the reader will correctly understand the text if we fix this typo.

## Test plan

http://prntscr.com/15t2xmb
