### PR TITLE
Update Circus docs

### DIFF
--- a/packages/jest-circus/README.md
+++ b/packages/jest-circus/README.md
@@ -9,7 +9,7 @@
 
 Circus is a flux-based test runner for Jest that is fast, maintainable, and simple to extend.
 
-Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/configuration#testenvironment-string). See the [type definitions](https://github.com/facebook/jest/blob/master/packages/jest-circus/src/types.ts) for more information on the events and state data currently available.
+Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/configuration#testenvironment-string). See the [type definitions](https://github.com/facebook/jest/blob/master/packages/jest-types/src/Circus.ts) for more information on the events and state data currently available.
 
 ```js
 import {Event, State} from 'jest-circus';


### PR DESCRIPTION
This commit updates the link to the types file in the circus docs.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I noticed the docs were wrong for jest-circus. There was a link to the package's types file... but it seems the actual information devs will be looking for was moved to the Types package.

## Test plan

Only docs update performed in the github webapp.
