### PR TITLE
docs: enable syntax highlighting to a code block

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -147,7 +147,7 @@ Creates a new property with the same primitive value as the original property.
 
 Example:
 
-```
+```js
 // example.js
 module.exports = {
   function: function square(a, b) {

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -143,7 +143,7 @@ Creates a new property with the same primitive value as the original property.
 
 Example:
 
-```
+```js
 // example.js
 module.exports = {
   function: function square(a, b) {

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -147,7 +147,7 @@ Creates a new property with the same primitive value as the original property.
 
 Example:
 
-```
+```js
 // example.js
 module.exports = {
   function: function square(a, b) {

--- a/website/versioned_docs/version-27.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.0/JestObjectAPI.md
@@ -147,7 +147,7 @@ Creates a new property with the same primitive value as the original property.
 
 Example:
 
-```
+```js
 // example.js
 module.exports = {
   function: function square(a, b) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

A code block under the [jest.createMockFromModule](https://jestjs.io/docs/jest-object#jestcreatemockfrommodulemodulename) section is not having syntax highlighting.

<img width="1022" alt="Screen Shot 2021-06-21 at 13 20 59" src="https://user-images.githubusercontent.com/25715018/122715862-babe6f00-d293-11eb-9b1d-5e470e084b0c.png">


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Screenshot of the change

<img width="1068" alt="Screen Shot 2021-06-21 at 13 24 37" src="https://user-images.githubusercontent.com/25715018/122716120-125cda80-d294-11eb-8420-4e9ee53e4079.png">
