### PR TITLE
Updating to include known issue with CI pipelines

### DIFF
--- a/website/versioned_docs/version-27.0/CLI.md
+++ b/website/versioned_docs/version-27.0/CLI.md
@@ -166,7 +166,7 @@ Print debugging info about your Jest config.
 
 ### `--detectOpenHandles`
 
-Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use `--forceExit` in order for Jest to exit to potentially track down the reason. This implies `--runInBand`, making tests run serially. Implemented using [`async_hooks`](https://nodejs.org/api/async_hooks.html). This option has a significant performance penalty and should only be used for debugging.
+Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use `--forceExit` in order for Jest to exit to potentially track down the reason. This implies `--runInBand`, making tests run serially. Implemented using [`async_hooks`](https://nodejs.org/api/async_hooks.html). This option has a significant performance penalty and should only be used for debugging. Do not use this in a CI pipelines as it can cause the error: `Segmentation fault (core dumped)`. 
 
 ### `--env=<environment>`
 


### PR DESCRIPTION
The issue of detecting open handles on a filesystem where you do not have the correct access to view it causes a `Segmentation fault (core dumped)` error and unless this is documented, it is extremely hard to diagnose and fix. 
It's a small line, but would have saved us days in bug fixing without a correct way to solve it. 
We only came across that this was the issue by chance, as it works in every other environment set up

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is a random issue that occurs when jest doesn't have access to detect handles on a filesystem that is private, such as a gitlab or github CI pipeline. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
There are no tests to go alone with this.   
Here is a stack overflow issue created for the issue:   
[https://stackoverflow.com/questions/68012814/gitlab-jest-test-segmentation-fault-core-dumped](https://stackoverflow.com/questions/68012814/gitlab-jest-test-segmentation-fault-core-dumped)
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
