### PR TITLE
fix(legacy-timers): Do not add `setImmediate` and `clearImmediate` if they do not exist in the global environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 
 ### Fixes
 
+- `[jest-fake-timers]` Do not add `setImmediate` and `clearImmediate` if they do not exist in the global environment ([#11599](https://github.com/facebook/jest/pull/11599))
+- `[jest-core]` Support special characters like `@`, `+` and `()` on Windows with `--findRelatedTests` ([#11548](https://github.com/facebook/jest/pull/11548))
 - `[jest-reporter]` Allow `node-notifier@10` as peer dependency ([#11523](https://github.com/facebook/jest/pull/11523))
 - `[jest-reporter]` Update `v8-to-istanbul` ([#11523](https://github.com/facebook/jest/pull/11523))
-- `[jest-core]` Support special characters like `@`, `+` and `()` on windows with `--findRelatedTests` ([#11548](https://github.com/facebook/jest/pull/11548))
 
 ### Chore & Maintenance
 

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -334,7 +334,9 @@ export default class FakeTimers<TimerRef> {
         this._timerAPIs.cancelAnimationFrame,
       );
     }
-    setGlobal(global, 'clearImmediate', this._timerAPIs.clearImmediate);
+    if (typeof global.clearImmediate === 'function') {
+      setGlobal(global, 'clearImmediate', this._timerAPIs.clearImmediate);
+    }
     setGlobal(global, 'clearInterval', this._timerAPIs.clearInterval);
     setGlobal(global, 'clearTimeout', this._timerAPIs.clearTimeout);
     if (typeof global.requestAnimationFrame === 'function') {
@@ -344,7 +346,9 @@ export default class FakeTimers<TimerRef> {
         this._timerAPIs.requestAnimationFrame,
       );
     }
-    setGlobal(global, 'setImmediate', this._timerAPIs.setImmediate);
+    if (typeof global.setImmediate === 'function') {
+      setGlobal(global, 'setImmediate', this._timerAPIs.setImmediate);
+    }
     setGlobal(global, 'setInterval', this._timerAPIs.setInterval);
     setGlobal(global, 'setTimeout', this._timerAPIs.setTimeout);
 
@@ -362,7 +366,9 @@ export default class FakeTimers<TimerRef> {
         this._fakeTimerAPIs.cancelAnimationFrame,
       );
     }
-    setGlobal(global, 'clearImmediate', this._fakeTimerAPIs.clearImmediate);
+    if (typeof global.clearImmediate === 'function') {
+      setGlobal(global, 'clearImmediate', this._fakeTimerAPIs.clearImmediate);
+    }
     setGlobal(global, 'clearInterval', this._fakeTimerAPIs.clearInterval);
     setGlobal(global, 'clearTimeout', this._fakeTimerAPIs.clearTimeout);
     if (typeof global.requestAnimationFrame === 'function') {
@@ -372,7 +378,9 @@ export default class FakeTimers<TimerRef> {
         this._fakeTimerAPIs.requestAnimationFrame,
       );
     }
-    setGlobal(global, 'setImmediate', this._fakeTimerAPIs.setImmediate);
+    if (typeof global.setImmediate === 'function') {
+      setGlobal(global, 'setImmediate', this._fakeTimerAPIs.setImmediate);
+    }
     setGlobal(global, 'setInterval', this._fakeTimerAPIs.setInterval);
     setGlobal(global, 'setTimeout', this._fakeTimerAPIs.setTimeout);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #11539

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
