### PR TITLE
Add toMatchNamedSnapshot matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Performance
 
+## 27.1.0
+
+- `[jest-snapshot]` Add `toMatchNamedSnapshot` to bring snapshot support to concurrent mode ([#11605](https://github.com/facebook/jest/pull/11605)
+
 ## 27.0.5
 
 ### Features

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1238,6 +1238,16 @@ You can provide an optional `propertyMatchers` object argument, which has asymme
 
 You can provide an optional `hint` string argument that is appended to the test name. Although Jest always appends a number at the end of a snapshot name, short descriptive hints might be more useful than numbers to differentiate **multiple** snapshots in a **single** `it` or `test` block. Jest sorts snapshots by name in the corresponding `.snap` file.
 
+### `.toMatchNamedSnapshot(propertyMatchers?, snapshotName?)`
+
+This ensures that a value matches the most recent snapshot. Check out [the Snapshot Testing guide](SnapshotTesting.md) for more information.
+
+You can provide an optional `propertyMatchers` object argument, which has asymmetric matchers as values of a subset of expected properties, **if** the received value will be an **object** instance. It is like `toMatchObject` with flexible criteria for a subset of properties, followed by a snapshot test as exact criteria for the rest of the properties.
+
+You can provide an optional `snapshotName` string argument that functions as the test name. By providing a snapshot name (as opposed to letting Jest infer the name from context) snapshot names can be guaranteed to be consistent across test runs, whatever the context at the time of evaluation. Jest always appends a number at the end of a snapshot name.
+
+Jest sorts snapshots by name in the corresponding `.snap` file.
+
 ### `.toMatchInlineSnapshot(propertyMatchers?, inlineSnapshot)`
 
 Ensures that a value matches the most recent snapshot.

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -143,7 +143,7 @@ it('will fail every time', () => {
   const user = {
     createdAt: new Date(),
     id: Math.floor(Math.random() * 20),
-    name: 'LeBron James',
+    name: 'Ben Simmons',
   };
 
   expect(user).toMatchSnapshot();
@@ -154,7 +154,7 @@ exports[`will fail every time 1`] = `
 Object {
   "createdAt": 2018-05-19T23:36:09.816Z,
   "id": 3,
-  "name": "LeBron James",
+  "name": "Ben Simmons",
 }
 `;
 ```
@@ -166,7 +166,7 @@ it('will check the matchers and pass', () => {
   const user = {
     createdAt: new Date(),
     id: Math.floor(Math.random() * 20),
-    name: 'LeBron James',
+    name: 'Ben Simmons',
   };
 
   expect(user).toMatchSnapshot({
@@ -180,7 +180,7 @@ exports[`will check the matchers and pass 1`] = `
 Object {
   "createdAt": Any<Date>,
   "id": Any<Number>,
-  "name": "LeBron James",
+  "name": "Ben Simmons",
 }
 `;
 ```
@@ -238,6 +238,8 @@ Now, every time the snapshot test case runs, `Date.now()` will return `148236336
 ### 3. Use descriptive snapshot names
 
 Always strive to use descriptive test and/or snapshot names for snapshots. The best names describe the expected snapshot content. This makes it easier for reviewers to verify the snapshots during review, and for anyone to know whether or not an outdated snapshot is the correct behavior before updating.
+
+The default matcher, `toMatchSnapshot`, infers the name based on the test function context when the snapshot is evaluated. This can cause snapshots in tests that are run concurrently to have different names on each test run. If you want to guarantee consistent names, you can use `toMatchNamedSnapshot` as an alternative matcher.
 
 For example, compare:
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -322,6 +322,19 @@ export interface Matchers<R> {
    */
   toMatchSnapshot(snapshotName?: string): R;
   /**
+   * This ensures that a value matches the most recent snapshot.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchNamedSnapshot<T extends {[P in keyof R]: unknown}>(
+    propertyMatchers: Partial<T>,
+    snapshot?: string,
+  ): R;
+  /**
+   * This ensures that a value matches the most recent snapshot.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchNamedSnapshot(snapshotName?: string): R;
+  /**
    * This ensures that a value matches the most recent snapshot with property matchers.
    * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
    * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
@@ -10,6 +10,7 @@ import expect = require('expect');
 import {
   addSerializer,
   toMatchInlineSnapshot,
+  toMatchNamedSnapshot,
   toMatchSnapshot,
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
@@ -21,6 +22,7 @@ export default (config: Pick<Config.GlobalConfig, 'expand'>): Expect => {
   expect.setState({expand: config.expand});
   expect.extend({
     toMatchInlineSnapshot,
+    toMatchNamedSnapshot,
     toMatchSnapshot,
     toThrowErrorMatchingInlineSnapshot,
     toThrowErrorMatchingSnapshot,

--- a/packages/jest-jasmine2/src/jestExpect.ts
+++ b/packages/jest-jasmine2/src/jestExpect.ts
@@ -12,6 +12,7 @@ import expect = require('expect');
 import {
   addSerializer,
   toMatchInlineSnapshot,
+  toMatchNamedSnapshot,
   toMatchSnapshot,
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
@@ -25,6 +26,7 @@ export default (config: {expand: boolean}): void => {
   expect.setState({expand: config.expand});
   expect.extend({
     toMatchInlineSnapshot,
+    toMatchNamedSnapshot,
     toMatchSnapshot,
     toThrowErrorMatchingInlineSnapshot,
     toThrowErrorMatchingSnapshot,

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -43,7 +43,7 @@ import type {
   Context,
   ExpectationResult,
   MatchSnapshotConfig,
-  SnapshotNameConfig
+  SnapshotNameConfig,
 } from './types';
 import * as utils from './utils';
 
@@ -76,16 +76,16 @@ const printSnapshotName = (
 };
 
 const getSnapshotName = (config: SnapshotNameConfig): string => {
-  const { snapshotName, currentTestName, hint } = config
+  const {snapshotName, currentTestName, hint} = config;
   if (snapshotName) {
-    return snapshotName
+    return snapshotName;
   }
   if (currentTestName && hint) {
-    return `${currentTestName}: ${hint}`
+    return `${currentTestName}: ${hint}`;
   }
   // future BREAKING change: || hint
-  return currentTestName || ''
-}
+  return currentTestName || '';
+};
 
 function stripAddedIndentation(inlineSnapshot: string) {
   // Find indentation if exists.
@@ -243,7 +243,10 @@ const toMatchNamedSnapshot = function (
   if (length === 2 && typeof propertiesOrSnapshotName === 'string') {
     snapshotName = propertiesOrSnapshotName;
   } else if (length >= 2) {
-    if (typeof propertiesOrSnapshotName !== 'object' || propertiesOrSnapshotName === null) {
+    if (
+      typeof propertiesOrSnapshotName !== 'object' ||
+      propertiesOrSnapshotName === null
+    ) {
       const options: MatcherHintOptions = {
         isNot: this.isNot,
         promise: this.promise,
@@ -280,11 +283,11 @@ const toMatchNamedSnapshot = function (
 
   return _toMatchSnapshot({
     context: this,
-    snapshotName,
     isInline: false,
     matcherName,
     properties,
     received,
+    snapshotName,
   });
 };
 
@@ -361,7 +364,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     isInline,
     matcherName,
     snapshotName,
-    properties
+    properties,
   } = config;
   let {received} = config;
 
@@ -391,7 +394,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     );
   }
 
-  const fullTestName = getSnapshotName({ snapshotName, hint, currentTestName })
+  const fullTestName = getSnapshotName({currentTestName, hint, snapshotName});
 
   if (typeof properties === 'object') {
     if (typeof received !== 'object' || received === null) {
@@ -620,8 +623,8 @@ const JestSnapshot = {
   getSerializers,
   isSnapshotPath,
   toMatchInlineSnapshot,
-  toMatchSnapshot,
   toMatchNamedSnapshot,
+  toMatchSnapshot,
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
   utils,

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -29,7 +29,7 @@ export type SnapshotNameConfig = {
   hint?: string;
   snapshotName?: string;
   currentTestName?: string;
-}
+};
 
 export type SnapshotData = Record<string, string>;
 

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -20,9 +20,16 @@ export type MatchSnapshotConfig = {
   inlineSnapshot?: string;
   isInline: boolean;
   matcherName: string;
+  snapshotName?: string;
   properties?: object;
   received: any;
 };
+
+export type SnapshotNameConfig = {
+  hint?: string;
+  snapshotName?: string;
+  currentTestName?: string;
+}
 
 export type SnapshotData = Record<string, string>;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds a `toMatchNamedSnapshot` matcher for use:
- in `concurrent` test mode
-  for people who want to name their snapshots for whatever reason.

  I figured that having a separate matcher made the most sense so that I didn't have to change the API for the original matcher, which would be most compatible for existing `toMatchSnapshot` api usage.

Addresses #2180 and #5801. I've got some test written but I was hoping that y'all might have some thoughts about:

- is this the right way forward? Or is there something else you were hoping for?
- should I just add the same unit tests as the `toMatchSnapshot`?

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- [ ] Updating unit tests in the `jest-snapshot` package
- [ ] Updating integration tests

