### PR TITLE
Update expect.assertions documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Performance
 
+## 27.0.7
+
+### Chore & Maintenance
+
+- `[docs]` Correct expects.assertions documentation by adding async/await for asynchronous function.
+
 ## 27.0.6
 
 ### Fixes

--- a/website/versioned_docs/version-27.0/ExpectAPI.md
+++ b/website/versioned_docs/version-27.0/ExpectAPI.md
@@ -406,7 +406,7 @@ describe('Beware of a misunderstanding! A sequence of dice rolls', () => {
 For example, let's say that we have a function `doAsync` that receives two callbacks `callback1` and `callback2`, it will asynchronously call both of them in an unknown order. We can test this with:
 
 ```js
-test('doAsync calls both callbacks', () => {
+test('doAsync calls both callbacks', async () => {
   expect.assertions(2);
   function callback1(data) {
     expect(data).toBeTruthy();
@@ -415,7 +415,7 @@ test('doAsync calls both callbacks', () => {
     expect(data).toBeTruthy();
   }
 
-  doAsync(callback1, callback2);
+  await doAsync(callback1, callback2);
 });
 ```
 


### PR DESCRIPTION
## Summary

The expects.assertions documentation is misleading because the example will fail every time if the asynchronous function doesn't block. I've added async/await statements to the example so it will run as is.

## Test plan

No testing needed, this is just a documentation update.
