### PR TITLE
remove db.close()

### DIFF
--- a/website/versioned_docs/version-27.0/MongoDB.md
+++ b/website/versioned_docs/version-27.0/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {


### PR DESCRIPTION
remove db.close() because it's is not defined. "close()" is not a function of an instance of Db class from the official MongoDB driver API.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
