### PR TITLE
fix: usage of `node:` imports for builtin modules

### DIFF
--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -251,6 +251,9 @@ export default class Resolver {
   }
 
   isCoreModule(moduleName: string): boolean {
+    if (moduleName.startsWith('node:')) {
+      return true;
+    }
     return (
       this._options.hasCoreModules &&
       isBuiltinModule(moduleName) &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes #11637 

Currently, when using `node:` for importing something, `jest` fails (see the issue #11637 for more details).
