### PR TITLE
Add options object with ignore property to modern useFakeTimers function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 ### Features
+- `[@jest/fake-timers]` Add options object with ignore property to modern useFakeTimers function. ([#11661](https://github.com/facebook/jest/pull/11661))
 
 ### Fixes
 

--- a/examples/async/__tests__/user.test.js
+++ b/examples/async/__tests__/user.test.js
@@ -68,3 +68,9 @@ it('tests error with async/await and rejects', async () => {
     error: 'User with 3 not found.',
   });
 });
+
+it('works with fakeTimers', async () => {
+  jest.useFakeTimers('modern', {ignore: ['nextTick']});
+  expect.assertions(1);
+  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+});

--- a/examples/async/__tests__/user.test.js
+++ b/examples/async/__tests__/user.test.js
@@ -68,9 +68,3 @@ it('tests error with async/await and rejects', async () => {
     error: 'User with 3 not found.',
   });
 });
-
-it('works with fakeTimers', async () => {
-  jest.useFakeTimers('modern', {ignore: ['nextTick']});
-  expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
-});

--- a/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts
+++ b/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts
@@ -798,6 +798,30 @@ describe('FakeTimers', () => {
       expect(global.setImmediate).not.toBe(nativeSetImmediate);
       expect(global.clearImmediate).not.toBe(nativeClearImmediate);
     });
+
+    it('ignores timer functions from the ignore option', () => {
+      const nativeSetTimeout = jest.fn();
+      const nativeClearTimeout = jest.fn();
+      const nativeNextTick = jest.fn();
+      process.nextTick = nativeNextTick;
+      const global = {
+        Date,
+        clearTimeout: nativeClearTimeout,
+        process,
+        setTimeout: nativeSetTimeout,
+      };
+
+      const timers = new FakeTimers({global});
+      timers.useFakeTimers({
+        ignore: ['nextTick', 'clearTimeout'],
+      });
+
+      // Ignored functions don't get mocked
+      expect(global.process.nextTick).toBe(nativeNextTick);
+      expect(global.clearTimeout).toBe(nativeClearTimeout);
+      // check if other functions are still being mocked
+      expect(global.setTimeout).not.toBe(nativeSetTimeout);
+    });
   });
 
   describe('getTimerCount', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Since version 27, the "modern" useFakeTimers implementation became the default implementation. Unfortunately, this way doesn't support the async/await pattern. This is caused because the process.nextTick function is mocked which causes the async tests to timeout.
Issue can be found here: https://github.com/facebook/jest/issues/10221
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
