### PR TITLE
feat(jest-resolve): detect `node:`-prefixed built-in modules

### DIFF
--- a/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
+++ b/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
@@ -23,4 +23,8 @@ describe('isBuiltinModule', () => {
   it('should return false for any internal node builtins', () => {
     expect(isBuiltinModule('internal/http')).toBe(false);
   });
+
+  it('should return true for the `node:http` module', () => {
+    expect(isBuiltinModule('node:http')).toBe(true);
+  });
 });

--- a/packages/jest-resolve/src/isBuiltinModule.ts
+++ b/packages/jest-resolve/src/isBuiltinModule.ts
@@ -23,5 +23,10 @@ const BUILTIN_MODULES = new Set(
 );
 
 export default function isBuiltinModule(module: string): boolean {
-  return BUILTIN_MODULES.has(module);
+  // https://nodejs.org/api/modules.html#modules_core_modules
+  // Core modules can also be identified using the node: prefix, for instance, require('node:http')
+
+  return BUILTIN_MODULES.has(
+    module.startsWith('node:') ? module.slice(5) : module,
+  );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->
## Problem
```
 ● Test suite failed to run

    ENOENT: no such file or directory, open 'node:util'

      at Runtime.readFile (node_modules/jest/node_modules/jest-runtime/build/index.js:2117:21)
      at Object.<anonymous> (node_modules/globby/gitignore.js:8:17)
```

## Summary
https://nodejs.org/api/modules.html#modules_core_modules
> Core modules can also be identified using the node: prefix, for instance, require('node:http').  

## Fix
```ts
export default function isBuiltinModule(module: string): boolean {
  // https://nodejs.org/api/modules.html#modules_core_modules
  // Core modules can also be identified using the node: prefix, for instance, require('node:http')
  return BUILTIN_MODULES.has(
    module.startsWith('node:') ? module.slice(5) : module,
  );
}
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`jest /Users/a.golub/projects/gh/jest/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts`

```ts
  it('should return true for the `node:http` module', () => {
    expect(isBuiltinModule('node:http')).toBe(true);
  });
```
