### PR TITLE
Fix links to type definition in Jest-Circus README.md

### DIFF
--- a/packages/jest-circus/README.md
+++ b/packages/jest-circus/README.md
@@ -1,4 +1,4 @@
-[type-definitions]: https://github.com/facebook/jest/tree/master/packages/jest-types/src/Circus.ts
+[type-definitions]: https://github.com/facebook/jest/blob/master/packages/jest-types/src/Circus.ts
 
 <h1 align="center">
   <img src="https://jestjs.io/img/jest.png" height="150" width="150"/>

--- a/packages/jest-circus/README.md
+++ b/packages/jest-circus/README.md
@@ -1,3 +1,5 @@
+[type-definitions]: https://github.com/facebook/jest/tree/master/packages/jest-types/src/Circus.ts
+
 <h1 align="center">
   <img src="https://jestjs.io/img/jest.png" height="150" width="150"/>
   <img src="https://jestjs.io/img/circus.png" height="150" width="150"/>
@@ -9,7 +11,7 @@
 
 Circus is a flux-based test runner for Jest that is fast, maintainable, and simple to extend.
 
-Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/configuration#testenvironment-string). See the [type definitions](https://github.com/facebook/jest/blob/master/packages/jest-circus/src/types.ts) for more information on the events and state data currently available.
+Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/configuration#testenvironment-string). See the [type definitions][type-definitions] for more information on the events and state data currently available.
 
 ```js
 import {Event, State} from 'jest-circus';
@@ -28,7 +30,7 @@ class MyCustomEnvironment extends NodeEnvironment {
 
 Mutating event or state data is currently unsupported and may cause unexpected behavior or break in a future release without warning. New events, event data, and/or state data will not be considered a breaking change and may be added in any minor release.
 
-Note, that `jest-circus` test runner would pause until a promise returned from `handleTestEvent` gets fulfilled. **However, there are a few events that do not conform to this rule, namely**: `start_describe_definition`, `finish_describe_definition`, `add_hook`, `add_test` or `error` (for the up-to-date list you can look at [SyncEvent type in the types definitions](https://github.com/facebook/jest/tree/master/packages/jest-types/src/Circus.ts)). That is caused by backward compatibility reasons and `process.on('unhandledRejection', callback)` signature, but that usually should not be a problem for most of the use cases.
+Note, that `jest-circus` test runner would pause until a promise returned from `handleTestEvent` gets fulfilled. **However, there are a few events that do not conform to this rule, namely**: `start_describe_definition`, `finish_describe_definition`, `add_hook`, `add_test` or `error` (for the up-to-date list you can look at [SyncEvent type in the types definitions][type-definitions]). That is caused by backward compatibility reasons and `process.on('unhandledRejection', callback)` signature, but that usually should not be a problem for most of the use cases.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Fixing the links in jest-circus readme. Previously, the link on *type definitions* pointed to the local src/types.ts file, when it should have been pointing to the jest-types/Circus.ts file. One of the two links (the one about synchronous events, had already been pointing to the correct place).

## Testing

N/A

## CLA

I've just signed the CLA, even though this is such a minuscule change, I hope to do some actually substantive contributions in the future.