### PR TITLE
updgrading resolve version, so as to resolve the security issues in a dependency package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## master
+The older versions of path-parse have security audit issues. The upgraded version of the resolve package uses the latest version of path-parse package in which the issues have been resolved
+
+https://github.com/facebook/jest/pull/11712
+## master
 
 ### Features
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "progress": "^2.0.0",
     "promise": "^8.0.2",
     "read-pkg": "^5.2.0",
-    "resolve": "^1.15.0",
+    "resolve": "^1.20.0",
     "rimraf": "^3.0.0",
     "semver": "^7.3.2",
     "slash": "^3.0.0",


### PR DESCRIPTION

## Summary

The older versions of path-parse have security audit issues. The upgraded version of the resolve package uses the latest version of path-parse package in which the issues have been resolved