### PR TITLE
fix(jest-environment-node): Add Event and EventTarget to node global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-environment-node]` Add `Event` and `EventTarget` to node global environment. ([#11705](https://github.com/facebook/jest/issues/11705))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -66,6 +66,14 @@ class NodeEnvironment implements JestEnvironment {
     if (typeof AbortController !== 'undefined') {
       global.AbortController = AbortController;
     }
+    // Event is global in Node >= 15.4
+    if (typeof Event !== 'undefined') {
+      global.Event = Event;
+    }
+    // EventTarget is global in Node >= 15.4
+    if (typeof EventTarget !== 'undefined') {
+      global.EventTarget = EventTarget;
+    }
     installCommonGlobals(global, config.globals);
 
     this.moduleMocker = new ModuleMocker(global);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds Event and EventTarget to node global, if available (starting in Node 15.4+). Fixes #11705.

## Test plan

No existing pattern of testing of exposing environment globals could be found, but one can can test it by trying to see if Event and EventTarget are available to node test environments: https://github.com/jayphelps/jest-event-demo
