### PR TITLE
perf(jest-resolve): skip error creation on not found stat calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### Chore & Maintenance
 
+- `[*]` Update graceful-fs to ^4.2.9 ([#11749](https://github.com/facebook/jest/pull/11749))
+
 ### Performance
+
+- `[jest-resolve]` perf: skip error creation on not found stat calls ([#11749](https://github.com/facebook/jest/pull/11749))
 
 ## 27.4.7
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "find-process": "^1.4.1",
     "glob": "^7.1.1",
     "globby": "^11.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "isbinaryfile": "^4.0.0",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.0",

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "babel-preset-jest": "^27.4.0",
     "chalk": "^4.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "slash": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -46,7 +46,7 @@
     "@types/graceful-fs": "^4.1.3",
     "@types/stack-utils": "^2.0.0",
     "execa": "^5.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-snapshot-serializer-raw": "^1.1.0"
   },
   "engines": {

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -18,7 +18,7 @@
     "@jest/types": "^27.4.2",
     "chalk": "^4.0.0",
     "exit": "^0.1.2",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "import-local": "^3.0.2",
     "jest-config": "^27.4.7",
     "jest-util": "^27.4.2",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -33,7 +33,7 @@
     "ci-info": "^3.2.0",
     "deepmerge": "^4.2.2",
     "glob": "^7.1.1",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-circus": "^27.4.6",
     "jest-environment-jsdom": "^27.4.6",
     "jest-environment-node": "^27.4.6",

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -22,7 +22,7 @@
     "chalk": "^4.0.0",
     "emittery": "^0.8.1",
     "exit": "^0.1.2",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-changed-files": "^27.4.2",
     "jest-config": "^27.4.7",
     "jest-haste-map": "^27.4.6",

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -22,7 +22,7 @@
     "@types/node": "*",
     "anymatch": "^3.0.3",
     "fb-watchman": "^2.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-regex-util": "^27.4.0",
     "jest-serializer": "^27.4.0",
     "jest-util": "^27.4.2",

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -24,7 +24,7 @@
     "@jest/types": "^27.4.2",
     "@types/stack-utils": "^2.0.0",
     "chalk": "^4.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "micromatch": "^4.0.4",
     "pretty-format": "^27.4.6",
     "slash": "^3.0.0",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -22,7 +22,7 @@
     "collect-v8-coverage": "^1.0.0",
     "exit": "^0.1.2",
     "glob": "^7.1.2",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-instrument": "^5.1.0",
     "istanbul-lib-report": "^3.0.0",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@jest/types": "^27.4.2",
     "chalk": "^4.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-haste-map": "^27.4.6",
     "jest-pnp-resolver": "^1.2.2",
     "jest-util": "^27.4.2",

--- a/packages/jest-resolve/src/fileWalkers.ts
+++ b/packages/jest-resolve/src/fileWalkers.ts
@@ -30,7 +30,8 @@ function statSyncCached(path: string): IPathType {
 
   let stat;
   try {
-    stat = fs.statSync(path);
+    // @ts-expect-error TS2554 - throwIfNoEntry is only available in recent version of node, but inclusion of the option is a backward compatible no-op.
+    stat = fs.statSync(path, {throwIfNoEntry: false});
   } catch (e: any) {
     if (!(e && (e.code === 'ENOENT' || e.code === 'ENOTDIR'))) {
       throw e;

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -26,7 +26,7 @@
     "chalk": "^4.0.0",
     "emittery": "^0.8.1",
     "exit": "^0.1.2",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-docblock": "^27.4.0",
     "jest-environment-jsdom": "^27.4.6",
     "jest-environment-node": "^27.4.6",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -29,7 +29,7 @@
     "collect-v8-coverage": "^1.0.0",
     "execa": "^5.0.0",
     "glob": "^7.1.3",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-haste-map": "^27.4.6",
     "jest-message-util": "^27.4.6",
     "jest-mock": "^27.4.6",

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@types/node": "*",
-    "graceful-fs": "^4.2.4"
+    "graceful-fs": "^4.2.9"
   },
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -29,7 +29,7 @@
     "babel-preset-current-node-syntax": "^1.0.0",
     "chalk": "^4.0.0",
     "expect": "^27.4.6",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-diff": "^27.4.6",
     "jest-get-type": "^27.4.0",
     "jest-haste-map": "^27.4.6",

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "callsites": "^3.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "source-map": "^0.6.0"
   },
   "devDependencies": {

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@jest/test-result": "^27.4.6",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-haste-map": "^27.4.6",
     "jest-runtime": "^27.4.6"
   },

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -23,7 +23,7 @@
     "chalk": "^4.0.0",
     "convert-source-map": "^1.4.0",
     "fast-json-stable-stringify": "^2.0.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "jest-haste-map": "^27.4.6",
     "jest-regex-util": "^27.4.0",
     "jest-util": "^27.4.2",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -21,7 +21,7 @@
     "@types/node": "*",
     "chalk": "^4.0.0",
     "ci-info": "^3.2.0",
-    "graceful-fs": "^4.2.4",
+    "graceful-fs": "^4.2.9",
     "picomatch": "^2.2.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10957,14 +10957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
-  version: 4.2.8
-  resolution: "graceful-fs@npm:4.2.8"
-  checksum: b07e032c0a17e928d3e8ab0f0fea1492efd4568b55a3d2675aaaccf1619eca91156edfa0cb05e99b923e24edf5e26fdce22ffa58ec14d5b13a3b1392460f37f0
-  languageName: node
-  linkType: hard
-
-"graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.1.9, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.9
   resolution: "graceful-fs@npm:4.2.9"
   checksum: e0382eb1aab9d04d8dbf0faed61987145cf876548138ff660553168b1ff04e6c65ee407aca102a0047bb2144845261c4a8a5f65934842f64acf12d3a8fd711ba

--- a/yarn.lock
+++ b/yarn.lock
@@ -2504,7 +2504,7 @@ __metadata:
     chalk: ^4.0.0
     emittery: ^0.8.1
     exit: ^0.1.2
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-changed-files: ^27.4.2
     jest-config: ^27.4.7
     jest-haste-map: ^27.4.6
@@ -2624,7 +2624,7 @@ __metadata:
     find-process: ^1.4.1
     glob: ^7.1.1
     globby: ^11.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     isbinaryfile: ^4.0.0
     istanbul-lib-coverage: ^3.0.0
     istanbul-lib-report: ^3.0.0
@@ -2688,7 +2688,7 @@ __metadata:
     collect-v8-coverage: ^1.0.0
     exit: ^0.1.2
     glob: ^7.1.2
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     istanbul-lib-coverage: ^3.0.0
     istanbul-lib-instrument: ^5.1.0
     istanbul-lib-report: ^3.0.0
@@ -2719,7 +2719,7 @@ __metadata:
   dependencies:
     "@types/graceful-fs": ^4.1.2
     callsites: ^3.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     source-map: ^0.6.0
   languageName: unknown
   linkType: soft
@@ -2741,7 +2741,7 @@ __metadata:
   dependencies:
     "@jest/test-result": ^27.4.6
     "@types/graceful-fs": ^4.1.3
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-haste-map: ^27.4.6
     jest-runtime: ^27.4.6
   languageName: unknown
@@ -2779,7 +2779,7 @@ __metadata:
     convert-source-map: ^1.4.0
     dedent: ^0.7.0
     fast-json-stable-stringify: ^2.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-haste-map: ^27.4.6
     jest-regex-util: ^27.4.0
     jest-snapshot-serializer-raw: ^1.1.0
@@ -6308,7 +6308,7 @@ __metadata:
     babel-plugin-istanbul: ^6.1.1
     babel-preset-jest: ^27.4.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     slash: ^3.0.0
   peerDependencies:
     "@babel/core": ^7.8.0
@@ -10964,6 +10964,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graceful-fs@npm:^4.2.9":
+  version: 4.2.9
+  resolution: "graceful-fs@npm:4.2.9"
+  checksum: e0382eb1aab9d04d8dbf0faed61987145cf876548138ff660553168b1ff04e6c65ee407aca102a0047bb2144845261c4a8a5f65934842f64acf12d3a8fd711ba
+  languageName: node
+  linkType: hard
+
 "graphql-request@npm:^3.1.0":
   version: 3.7.0
   resolution: "graphql-request@npm:3.7.0"
@@ -12612,7 +12619,7 @@ __metadata:
     dedent: ^0.7.0
     execa: ^5.0.0
     expect: ^27.4.6
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     is-generator-fn: ^2.0.0
     jest-each: ^27.4.6
     jest-matcher-utils: ^27.4.6
@@ -12641,7 +12648,7 @@ __metadata:
     "@types/yargs": ^16.0.0
     chalk: ^4.0.0
     exit: ^0.1.2
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     import-local: ^3.0.2
     jest-config: ^27.4.7
     jest-util: ^27.4.2
@@ -12673,7 +12680,7 @@ __metadata:
     ci-info: ^3.2.0
     deepmerge: ^4.2.2
     glob: ^7.1.1
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-circus: ^27.4.6
     jest-environment-jsdom: ^27.4.6
     jest-environment-node: ^27.4.6
@@ -12818,7 +12825,7 @@ __metadata:
     anymatch: ^3.0.3
     fb-watchman: ^2.0.0
     fsevents: ^2.3.2
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-regex-util: ^27.4.0
     jest-serializer: ^27.4.0
     jest-snapshot-serializer-raw: ^1.1.0
@@ -12930,7 +12937,7 @@ __metadata:
     "@types/micromatch": ^4.0.1
     "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     micromatch: ^4.0.4
     pretty-format: ^27.4.6
     slash: ^3.0.0
@@ -13027,7 +13034,7 @@ __metadata:
     "@types/graceful-fs": ^4.1.3
     "@types/resolve": ^1.20.0
     chalk: ^4.0.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-haste-map: ^27.4.6
     jest-pnp-resolver: ^1.2.2
     jest-util: ^27.4.2
@@ -13065,7 +13072,7 @@ __metadata:
     chalk: ^4.0.0
     emittery: ^0.8.1
     exit: ^0.1.2
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-docblock: ^27.4.0
     jest-environment-jsdom: ^27.4.6
     jest-environment-node: ^27.4.6
@@ -13102,7 +13109,7 @@ __metadata:
     collect-v8-coverage: ^1.0.0
     execa: ^5.0.0
     glob: ^7.1.3
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-environment-node: ^27.4.6
     jest-haste-map: ^27.4.6
     jest-message-util: ^27.4.6
@@ -13123,7 +13130,7 @@ __metadata:
   dependencies:
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
   languageName: unknown
   linkType: soft
 
@@ -13178,7 +13185,7 @@ __metadata:
     babel-preset-current-node-syntax: ^1.0.0
     chalk: ^4.0.0
     expect: ^27.4.6
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     jest-diff: ^27.4.6
     jest-get-type: ^27.4.0
     jest-haste-map: ^27.4.6
@@ -13203,7 +13210,7 @@ __metadata:
     "@types/picomatch": ^2.2.2
     chalk: ^4.0.0
     ci-info: ^3.2.0
-    graceful-fs: ^4.2.4
+    graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
Implements perf improvement for resolving discussed in #11738

## Test plan
No user-facing changes requireing e2e testing. Added UT to ensure stacktrace is properly set back to pre-change value
