### PR TITLE
feat: add `--platform` flag to override `haste.defaultPlatform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-config]` Add `--platform` flag to override `haste.defaultPlatform` option ([#11764](https://github.com/facebook/jest/pull/11764))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -262,6 +262,10 @@ Alias: `-o`. Attempts to identify which tests to run based on which files have c
 
 Allows the test suite to pass when no files are found.
 
+### `--platform`
+
+Specifies which platform to target. Overrides `haste.defaultPlatform` option.
+
 ### `--projects <path1> ... <pathN>`
 
 Run tests from one or more projects, found in the specified paths; also takes path globs. This option is the CLI equivalent of the [`projects`](configuration#projects-arraystring--projectconfig) configuration option. Note that if configuration files are found in the specified paths, _all_ projects specified within those configuration files will be run.

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -426,7 +426,7 @@ export const options = {
     type: 'boolean',
   },
   platform: {
-    description: 'Specifies which platform to target.',
+    description: 'Specifies which platform to target. Overrides `haste.defaultPlatform` option.',
     type: 'string',
   },
   preset: {

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -425,6 +425,10 @@ export const options = {
       'Will not fail if no tests are found (for example while using `--testPathPattern`.)',
     type: 'boolean',
   },
+  platform: {
+    description: 'Specifies which platform to target.',
+    type: 'string',
+  },
   preset: {
     description: "A preset that is used as a base for Jest's configuration.",
     type: 'string',

--- a/packages/jest-config/src/setFromArgv.ts
+++ b/packages/jest-config/src/setFromArgv.ts
@@ -24,6 +24,14 @@ export default function setFromArgv(
         case 'json':
           options.useStderr = argv[key];
           break;
+        case 'platform':
+          options.haste = {
+            ...(options.haste && typeof options.haste === 'object'
+              ? options.haste
+              : undefined),
+            defaultPlatform: argv[key],
+          };
+          break;
         case 'watchAll':
           options.watch = false;
           options.watchAll = argv[key];

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -445,6 +445,7 @@ export type Argv = Arguments<
     onlyChanged: boolean;
     onlyFailures: boolean;
     outputFile: string;
+    platform: string | null | undefined;
     preset: string | null | undefined;
     projects: Array<string>;
     prettierPath: string | null | undefined;

--- a/website/versioned_docs/version-27.0/CLI.md
+++ b/website/versioned_docs/version-27.0/CLI.md
@@ -262,6 +262,10 @@ Alias: `-o`. Attempts to identify which tests to run based on which files have c
 
 Allows the test suite to pass when no files are found.
 
+### `--platform`
+
+Specifies which platform to target. Overrides `haste.defaultPlatform` option.
+
 ### `--projects <path1> ... <pathN>`
 
 Run tests from one or more projects, found in the specified paths; also takes path globs. This option is the CLI equivalent of the [`projects`](configuration#projects-arraystring--projectconfig) configuration option. Note that if configuration files are found in the specified paths, _all_ projects specified within those configuration files will be run.


### PR DESCRIPTION
## Summary

Adds a new flag, `--platform`, to override `haste.defaultPlatform` option. This is useful for tests that need to be run against multiple platform targets. Previously, you would need separate Jest configs for each platform and set `haste.defaultPlatform` accordingly. With this flag, you can have one config and instead specify `--platform ios` instead.

## Test plan

Normally, running `react-native` tests without a haste configuration will fail:

```
test-app % yarn jest
 FAIL  test/App.test.tsx
  ● Test suite failed to run

    Cannot find module '../Libraries/Image/Image' from '../../node_modules/react-native/jest/setup.js'

      at Resolver.resolveModule (../../node_modules/jest-resolve/build/resolver.js:311:11)
      at Object.<anonymous> (../../node_modules/react-native/jest/setup.js:58:4)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        1.028 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With this change, you can now specify the platform from the command line:

```
% yarn jest --platform ios
 PASS  test/App.test.tsx
  ✓ renders correctly (239 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        0.747 s
Ran all test suites.
✨  Done in 2.33s.
```