### PR TITLE
--runInBand addition to 'Using with MongoDB' documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Added explaination for using `--runInBand` in the 'Using with MongoDB' documentation
+
 ### Performance
 
 ## 27.0.7

--- a/website/versioned_docs/version-27.0/MongoDB.md
+++ b/website/versioned_docs/version-27.0/MongoDB.md
@@ -56,6 +56,12 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+```
+jest --runInBand
+```
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).


### PR DESCRIPTION
## Summary

I've had a problem with my tests being flaky while using MongoDB following the documentation that was provided, I later found out that the approach I was using (different test files for different parts of my application) was causing problems with data being deleted from my database while other tests were expecting this data to be there.
After searching for a while I found out that the different test files in jest are being ran parallel to each other, and this caused my issue... So after looking for a solution for running my tests in a serial way I came across the `--runInBand` option for jest and I thought this might be a nice addition to the documentation for other people who also run into this problem.

## Test plan

![tests succeeded](https://user-images.githubusercontent.com/12232680/130093180-d1f824b3-cf82-448b-b366-dfe1ffe0dfa2.png)
![flaky fail](https://user-images.githubusercontent.com/12232680/130093182-f1bdfdb4-9498-4c7c-9d7f-23268c5d2130.png)

