### PR TITLE
fix: support userAgent option for jsdom environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-environment-jsdom]` Add support for `userAgent` option ([#11773](https://github.com/facebook/jest/pull/11773))
+
 ### Fixes
 
 - `[jest-environment-node]` Add `Event` and `EventTarget` to node global environment. ([#11705](https://github.com/facebook/jest/issues/11705))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ### Features
 
-- `[jest-environment-jsdom]` Add support for `userAgent` option ([#11773](https://github.com/facebook/jest/pull/11773))
-
 ### Fixes
 
+- `[jest-environment-jsdom]` Add support for `userAgent` option ([#11773](https://github.com/facebook/jest/pull/11773))
 - `[jest-environment-node]` Add `Event` and `EventTarget` to node global environment. ([#11705](https://github.com/facebook/jest/issues/11705))
 - `[jest-mock]` Fix `spyOn` to use `Object.prototype.hasOwnProperty` [#11721](https://github.com/facebook/jest/pull/11721)
 - `[jest-resolver]` Add dependency on `jest-haste-map` [#11759](https://github.com/facebook/jest/pull/11759)

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -29,11 +29,13 @@ describe('JSDomEnvironment', () => {
   });
 
   it('should respect userAgent option', () => {
-    const env = new JSDomEnvironment(makeProjectConfig({
-      testEnvironmentOptions: {
-        userAgent: 'foo',
-      },
-    }));
+    const env = new JSDomEnvironment(
+      makeProjectConfig({
+        testEnvironmentOptions: {
+          userAgent: 'foo',
+        },
+      }),
+    );
 
     expect(env.dom.window.navigator.userAgent).toEqual('foo');
   });

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -27,4 +27,14 @@ describe('JSDomEnvironment', () => {
 
     expect(env.fakeTimersModern).toBeDefined();
   });
+
+  it('should respect userAgent option', () => {
+    const env = new JSDomEnvironment(makeProjectConfig({
+      testEnvironmentOptions: {
+        userAgent: 'foo',
+      },
+    }));
+
+    expect(env.dom.window.navigator.userAgent).toEqual('foo');
+  });
 });

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Context} from 'vm';
-import {JSDOM, VirtualConsole, ResourceLoader} from 'jsdom';
+import {JSDOM, ResourceLoader, VirtualConsole} from 'jsdom';
 import type {EnvironmentContext, JestEnvironment} from '@jest/environment';
 import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
 import type {Config, Global} from '@jest/types';
@@ -33,12 +33,15 @@ class JSDOMEnvironment implements JestEnvironment {
   constructor(config: Config.ProjectConfig, options?: EnvironmentContext) {
     this.dom = new JSDOM('<!DOCTYPE html>', {
       pretendToBeVisual: true,
+      resources:
+        typeof config.testEnvironmentOptions.userAgent === 'string'
+          ? new ResourceLoader({
+              userAgent: config.testEnvironmentOptions.userAgent,
+            })
+          : undefined,
       runScripts: 'dangerously',
       url: config.testURL,
       virtualConsole: new VirtualConsole().sendTo(options?.console || console),
-      resources: config.testEnvironmentOptions.userAgent ? new ResourceLoader({
-        userAgent: config.testEnvironmentOptions.userAgent as string,
-      }) : undefined,
       ...config.testEnvironmentOptions,
     });
     const global = (this.global = this.dom.window.document

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Context} from 'vm';
-import {JSDOM, VirtualConsole} from 'jsdom';
+import {JSDOM, VirtualConsole, ResourceLoader} from 'jsdom';
 import type {EnvironmentContext, JestEnvironment} from '@jest/environment';
 import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
 import type {Config, Global} from '@jest/types';
@@ -36,6 +36,9 @@ class JSDOMEnvironment implements JestEnvironment {
       runScripts: 'dangerously',
       url: config.testURL,
       virtualConsole: new VirtualConsole().sendTo(options?.console || console),
+      resources: config.testEnvironmentOptions.userAgent ? new ResourceLoader({
+        userAgent: config.testEnvironmentOptions.userAgent as string,
+      }) : undefined,
       ...config.testEnvironmentOptions,
     });
     const global = (this.global = this.dom.window.document


### PR DESCRIPTION
## Summary

In older versions of `jsdom`, it was possible to specify a custom `userAgent` in the JSDOM constructor options. In Jest, that could be set with `testEnvironmentOptions`, which would be passed as options to the Jest constructor. The Jest docs even specifically call out this example: https://github.com/facebook/jest/blame/6df4ad4a8eb4f63fa4580d6f5664f43762940379/docs/Configuration.md#L1132.

However, `jsdom` removed this option at some point in a minor release of v12 in [this commit](https://github.com/jsdom/jsdom/pull/2362). When we went to upgrade Jest to a newer version, many of our tests started failing because jsdom's default user agent was being used instead of the one we had specified.

As called out in [this comment](https://github.com/facebook/jest/issues/8701#issuecomment-512130059), it's possible to work around this by setting up a custom testing environment, but I'd hate to have to copy that boilerplate around to all of the repos where we need to customize the user agent. So, I'm proposing this change.

This change should be safe; for the past several major versions of `jsdom`, the `userAgent` option to the constructor has been a no-op, so this should be considered a feature addition as opposed to a breaking change. If someone had previously set `userAgent` in `testEnvironmentOptions`, it would start taking effect with this change where it hadn't previously; that's the only risk to this I can think of.

## Test plan

I edited the code in `node_modules` in my project to reflect these changes, and it worked as expected! I also added a test case, which passes.
