### PR TITLE
[jest-haste-map] Use more optimal suffix-set format

### DIFF
--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -67,7 +67,8 @@ export = async function watchmanCrawl(options: CrawlerOptions): Promise<{
   const defaultWatchExpression = [
     'allof',
     ['type', 'f'],
-    ['anyof', ...extensions.map(extension => ['suffix', extension])],
+    // suffix-set https://facebook.github.io/watchman/docs/expr/suffix.html#suffix-set
+    ['suffix', extensions]
   ];
   const clocks = data.clocks;
   const client = new watchman.Client();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

While looking through the code (expo-cli-(react-native)->metro->jest), I noticed that the syntax used here is specifically advised against in the [watchman docs](https://facebook.github.io/watchman/docs/expr/suffix.html#suffix-set). I don't know enough about watchman to determine if these docs are incorrect, but @cpojer recommended opening a PR.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Running the command locally works:
```
$ watchman -j <<-EOT                                                                        
["query", "./", {           
  "expression": ["allof",                
    ["type", "f"],      
    ["suffix", ["js", "json", "ts"]]
  ],                
  "fields": ["name", "exists", "mtime_ms", "size"]
}] 
EOT
```
