### PR TITLE
Typo fixed in examples 

### DIFF
--- a/examples/snapshot/Clock.react.js
+++ b/examples/snapshot/Clock.react.js
@@ -15,7 +15,7 @@ const Clock = () => {
     return () => clearInterval(timerID);
   }, []);
 
-  return <p>{seconds} seconds have ellapsed since the UNIX epoch.</p>;
+  return <p>{seconds} seconds have elapsed since the UNIX epoch.</p>;
 };
 
 export default Clock;


### PR DESCRIPTION
Fixed a typo in the file **Clock.react.js** which is under **snapshot** folder under **examples** folder


 
