### PR TITLE
test: fix project `jest.config.js` so that example tests do not run

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
     'website/.*',
     'e2e/runtime-internal-module-registry/__mocks__',
   ],
-  projects: ['<rootDir>', '<rootDir>/examples/*/'],
+  projects: ['<rootDir>'],
   setupFilesAfterEnv: ['<rootDir>/testSetupFile.js'],
   snapshotSerializers: [
     '<rootDir>/packages/pretty-format/build/plugins/ConvertAnsi.js',


### PR DESCRIPTION
## Summary

Removes the [`examples`](https://github.com/facebook/jest/tree/master/examples) directory from the [`projects`](https://jestjs.io/docs/configuration#projects-arraystring--projectconfig) option in the Jest project's root `jest.config.js`.

Otherwise config files within `examples` are loaded and all tests ran when running the projects tests.

![Screenshot 2021-08-27 at 17 05](https://user-images.githubusercontent.com/6737410/131150468-371024ce-7af9-467c-8f9d-a2d3962cd49b.png)

This has a particularly unfortunate effect if you are using an `arm64` based system (e.g. Apple M1) because `examples/mongodb` includes an example `jest.config.js` with a `globalSetup` setting which attempts to download and install a non-existing `mongodb-osx-ssl-arm64-4.0.14.tgz` from mongodb.org's mirror.

This crashes Jest before a single test can run:

```bash
Error: Jest: Got error running globalSetup - /path/to/jest/examples/mongodb/setup.js, reason: Status Code is 403 (MongoDB's 404)
This means that the requested version-platform combination doesn't exist
  Used Url: "https://fastdl.mongodb.org/osx/mongodb-osx-ssl-arm64-4.0.14.tgz"
Try to use different version 'new MongoMemoryServer({ binary: { version: 'X.Y.Z' } })'
List of available versions can be found here:
  https://www.mongodb.org/dl/linux for Linux
  https://www.mongodb.org/dl/osx for OSX
  https://www.mongodb.org/dl/win32 for Windows
    at ClientRequest.<anonymous> (/path/to/jest/node_modules/mongodb-memory-server-core/lib/util/MongoBinaryDownload.js:386:44)
(...)
```

(I wonder if this has caused some weird stuff in ci-runs over the years? :sweat_smile: )

~~Looks like snapshots needs to be updated; I will leave that up to you @SimenB~~