### PR TITLE
Export PrettyFormatOptions type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-types]` Export the `PrettyFormatOptions` interface ([#11801](https://github.com/facebook/jest/pull/11801))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -61,7 +61,7 @@ export interface ConfigGlobals {
 }
 
 // This interface gets filled out when pretty-format is included
-interface PrettyFormatOptions {}
+export interface PrettyFormatOptions {}
 
 export type DefaultOptions = {
   automock: boolean;


### PR DESCRIPTION
## Summary

Without `PrettyFormatOptions` exported, `Config` from `@jest/types` cannot be used in another TS project since `tsc` gives the following error: 

```bash
index.ts:16:7 - error TS4023: Exported variable 'X' has or is using name 'PrettyFormatOptions' from external module "/Users/.../node_modules/@jest/types/build/Config" but cannot be named.
```

## Test plan

None