### PR TITLE
fix(jest-runtime): fix node:-prefixed modules loading

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1361,10 +1361,9 @@ export default class Runtime {
   }
 
   private _requireCoreModule(moduleName: string, supportPrefix: boolean) {
-    const moduleWithoutNodePrefix =
-      supportPrefix && moduleName.startsWith('node:')
-        ? moduleName.slice('node:'.length)
-        : moduleName;
+    const moduleWithoutNodePrefix = moduleName.startsWith('node:')
+      ? moduleName.slice('node:'.length)
+      : moduleName;
 
     if (moduleWithoutNodePrefix === 'process') {
       return this._environment.global.process;
@@ -1374,7 +1373,7 @@ export default class Runtime {
       return this._getMockedNativeModule();
     }
 
-    return require(moduleWithoutNodePrefix);
+    return require(supportPrefix ? moduleName : moduleWithoutNodePrefix);
   }
 
   private _importCoreModule(moduleName: string, context: VMContext) {


### PR DESCRIPTION
relates #11331

Hey, @simenb

Got trouble on loading `node:`-prefixed modules with Node.js 14 and jest v27.1.0:

https://github.com/antongolub/tsc-esm-fix/runs/3472541312?check_suite_focus=true  
```
 $ /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/.bin/jest -v
27.1.0

 FAIL src/test/ts/index.ts

  ● Test suite failed to run

    Cannot find module 'node:fs'
    Require stack:
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/jest-runtime/build/index.js
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/@jest/core/build/cli/index.js
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/@jest/core/build/jest.js
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/jest/node_modules/jest-cli/build/cli/index.js
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/jest/node_modules/jest-cli/bin/jest.js
    - /home/runner/work/tsc-esm-fix/tsc-esm-fix/node_modules/jest/bin/jest.js

    Require stack:
      node_modules/jest-runtime/build/index.js
      node_modules/@jest/core/build/cli/index.js
      node_modules/@jest/core/build/jest.js
      node_modules/jest/node_modules/jest-cli/build/cli/index.js
      node_modules/jest/node_modules/jest-cli/bin/jest.js
      node_modules/jest/bin/jest.js
      
at Runtime._requireCoreModule (node_modules/jest-runtime/build/index.js:1561:12)
 at Object.<anonymous> (node_modules/globby/index.js:20:38)
```

The current impl trims `node:` if the runtime already supports it.

```ts
   private _requireCoreModule(moduleName: string, supportPrefix: boolean) {
  const moduleWithoutNodePrefix =
    supportPrefix && moduleName.startsWith('node:')
      ? moduleName.slice('node:'.length)
      : moduleName;

  if (moduleWithoutNodePrefix === 'process') {
    return this._environment.global.process;
  }

  if (moduleWithoutNodePrefix === 'module') {
    return this._getMockedNativeModule();
  }

  return require(moduleWithoutNodePrefix);
}
```

I suggest to invert this logic:

```ts
  private _requireCoreModule(moduleName: string, supportPrefix: boolean) {
    const moduleWithoutNodePrefix = moduleName.startsWith('node:')
      ? moduleName.slice('node:'.length)
      : moduleName;

    if (moduleWithoutNodePrefix === 'process') {
      return this._environment.global.process;
    }

    if (moduleWithoutNodePrefix === 'module') {
      return this._getMockedNativeModule();
    }

    return require(supportPrefix ? moduleName : moduleWithoutNodePrefix);
  }
```
