### PR TITLE
feat(expect): Add equality support for Array Buffers to ToStrictEqual method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[expect]` Add equality checks for Array Buffers in `expect.ToStrictEqual()`
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[expect]` Add equality checks for Array Buffers in `expect.ToStrictEqual()`
+- `[expect]` Add equality checks for Array Buffers in `expect.ToStrictEqual()` ([#11805](https://github.com/facebook/jest/pull/11805))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -429,6 +429,14 @@ describe('.toStrictEqual()', () => {
 
   it('does not pass when ArrayBuffers are not equal', () => {
     expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(Uint8Array.from([0, 0]).buffer);
+    expect(Uint8Array.from([2,1]).buffer).not.toStrictEqual(Uint8Array.from([2,2]).buffer);
+    expect(Uint8Array.from([]).buffer).not.toStrictEqual(Uint8Array.from([1]).buffer);
+  });
+
+  it('passes for matching buffers', () => {
+    expect(Uint8Array.from([1]).buffer).toStrictEqual(Uint8Array.from([1]).buffer);
+    expect(Uint8Array.from([]).buffer).toStrictEqual(Uint8Array.from([]).buffer);
+    expect(Uint8Array.from([9,3]).buffer).toStrictEqual(Uint8Array.from([9,3]).buffer);
   })
   /* eslint-enable */
 });

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -426,6 +426,10 @@ describe('.toStrictEqual()', () => {
   it('does not pass when equally sparse arrays have different values', () => {
     expect([, 1]).not.toStrictEqual([, 2]);
   });
+
+  it('does not pass when ArrayBuffers are not equal', () => {
+    expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(Uint8Array.from([0, 0]).buffer);
+  })
   /* eslint-enable */
 });
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -437,7 +437,7 @@ describe('.toStrictEqual()', () => {
     expect(Uint8Array.from([1]).buffer).toStrictEqual(Uint8Array.from([1]).buffer);
     expect(Uint8Array.from([]).buffer).toStrictEqual(Uint8Array.from([]).buffer);
     expect(Uint8Array.from([9,3]).buffer).toStrictEqual(Uint8Array.from([9,3]).buffer);
-  })
+  });
   /* eslint-enable */
 });
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -428,15 +428,27 @@ describe('.toStrictEqual()', () => {
   });
 
   it('does not pass when ArrayBuffers are not equal', () => {
-    expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(Uint8Array.from([0, 0]).buffer);
-    expect(Uint8Array.from([2,1]).buffer).not.toStrictEqual(Uint8Array.from([2,2]).buffer);
-    expect(Uint8Array.from([]).buffer).not.toStrictEqual(Uint8Array.from([1]).buffer);
+    expect(Uint8Array.from([1, 2]).buffer).not.toStrictEqual(
+      Uint8Array.from([0, 0]).buffer,
+    );
+    expect(Uint8Array.from([2, 1]).buffer).not.toStrictEqual(
+      Uint8Array.from([2, 2]).buffer,
+    );
+    expect(Uint8Array.from([]).buffer).not.toStrictEqual(
+      Uint8Array.from([1]).buffer,
+    );
   });
 
   it('passes for matching buffers', () => {
-    expect(Uint8Array.from([1]).buffer).toStrictEqual(Uint8Array.from([1]).buffer);
-    expect(Uint8Array.from([]).buffer).toStrictEqual(Uint8Array.from([]).buffer);
-    expect(Uint8Array.from([9,3]).buffer).toStrictEqual(Uint8Array.from([9,3]).buffer);
+    expect(Uint8Array.from([1]).buffer).toStrictEqual(
+      Uint8Array.from([1]).buffer,
+    );
+    expect(Uint8Array.from([]).buffer).toStrictEqual(
+      Uint8Array.from([]).buffer,
+    );
+    expect(Uint8Array.from([9, 3]).buffer).toStrictEqual(
+      Uint8Array.from([9, 3]).buffer,
+    );
   });
   /* eslint-enable */
 });

--- a/packages/expect/src/__tests__/utils.test.ts
+++ b/packages/expect/src/__tests__/utils.test.ts
@@ -8,6 +8,7 @@
 
 import {stringify} from 'jest-matcher-utils';
 import {
+  arrayBufferEquality,
   emptyObject,
   getObjectSubset,
   getPath,
@@ -465,4 +466,24 @@ describe('iterableEquality', () => {
 
     expect(iterableEquality(a, b)).toBe(true);
   });
+});
+
+describe('arrayBufferEquality', () => {
+  test('returns undefined if given a non instance of ArrayBuffer', () => {
+    expect(arrayBufferEquality(2, "s")).toBeUndefined();
+    expect(arrayBufferEquality(undefined, 2)).toBeUndefined();
+    expect(arrayBufferEquality(new Date(), new ArrayBuffer(2))).toBeUndefined();
+  });
+
+  test('returns false when given non-matching buffers', () => {
+    const a = Uint8Array.from([2,4]).buffer;
+    const b = Uint8Array.from([1,7]).buffer;
+    expect(arrayBufferEquality(a, b)).not.toBeTruthy();
+  });
+
+  test('returns true when given matching buffers', () => {
+    const a = Uint8Array.from([1,2]).buffer;
+    const b = Uint8Array.from([1,2]).buffer;
+    expect(arrayBufferEquality(a, b)).toBeTruthy();
+  })
 });

--- a/packages/expect/src/__tests__/utils.test.ts
+++ b/packages/expect/src/__tests__/utils.test.ts
@@ -470,14 +470,14 @@ describe('iterableEquality', () => {
 
 describe('arrayBufferEquality', () => {
   test('returns undefined if given a non instance of ArrayBuffer', () => {
-    expect(arrayBufferEquality(2, "s")).toBeUndefined();
+    expect(arrayBufferEquality(2, 's')).toBeUndefined();
     expect(arrayBufferEquality(undefined, 2)).toBeUndefined();
     expect(arrayBufferEquality(new Date(), new ArrayBuffer(2))).toBeUndefined();
   });
 
   test('returns false when given non-matching buffers', () => {
     const a = Uint8Array.from([2,4]).buffer;
-    const b = Uint8Array.from([1,7]).buffer;
+    const b = Uint16Array.from([1,7]).buffer;
     expect(arrayBufferEquality(a, b)).not.toBeTruthy();
   });
 

--- a/packages/expect/src/__tests__/utils.test.ts
+++ b/packages/expect/src/__tests__/utils.test.ts
@@ -476,14 +476,14 @@ describe('arrayBufferEquality', () => {
   });
 
   test('returns false when given non-matching buffers', () => {
-    const a = Uint8Array.from([2,4]).buffer;
-    const b = Uint16Array.from([1,7]).buffer;
+    const a = Uint8Array.from([2, 4]).buffer;
+    const b = Uint16Array.from([1, 7]).buffer;
     expect(arrayBufferEquality(a, b)).not.toBeTruthy();
   });
 
   test('returns true when given matching buffers', () => {
-    const a = Uint8Array.from([1,2]).buffer;
-    const b = Uint8Array.from([1,2]).buffer;
+    const a = Uint8Array.from([1, 2]).buffer;
+    const b = Uint8Array.from([1, 2]).buffer;
     expect(arrayBufferEquality(a, b)).toBeTruthy();
-  })
+  });
 });

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -40,6 +40,7 @@ import {
 } from './print';
 import type {MatcherState, MatchersObject} from './types';
 import {
+  arrayBufferEquality,
   getObjectSubset,
   getPath,
   iterableEquality,
@@ -61,6 +62,7 @@ const toStrictEqualTesters = [
   iterableEquality,
   typeEquality,
   sparseArrayEquality,
+  arrayBufferEquality,
 ];
 
 type ContainIterable =

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -329,7 +329,7 @@ export const arrayBufferEquality = (a: any, b: any): boolean | undefined => {
   const dataViewB = new DataView(b);
 
   // Buffers are not equal when they do not have the same byte length
-  if (dataViewA.byteLength != dataViewB.byteLength) {
+  if (dataViewA.byteLength !== dataViewB.byteLength) {
     return false;
   }
 

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -325,17 +325,17 @@ export const arrayBufferEquality = (a: any, b: any): boolean | undefined => {
     return undefined;
   }
 
-  const d1 = new DataView(a);
-  const d2 = new DataView(b);
+  const dataViewA = new DataView(a);
+  const dataViewB = new DataView(b);
 
   // Buffers are not equal when they do not have the same byte length
-  if (d1.byteLength != d2.byteLength) {
+  if (dataViewA.byteLength != dataViewB.byteLength) {
     return false;
   }
 
   // Compare each arraryBuffer byte's buffers
-  for (let i = 0;i < d1.byteLength; i++) {
-    if (d1.getUint8(i) != d2.getUint8(i)) {
+  for (let i = 0;i < dataViewA.byteLength; i++) {
+    if (dataViewA.getUint8(i) != dataViewB.getUint8(i)) {
       return false;
     }
   }

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -334,7 +334,7 @@ export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined
 
   // Check if every byte value is equal to each other
   for (let i = 0;i < dataViewA.byteLength; i++) {
-    if (dataViewA.getUint8(i) != dataViewB.getUint8(i)) {
+    if (dataViewA.getUint8(i) !== dataViewB.getUint8(i)) {
       return false;
     }
   }

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -320,7 +320,7 @@ export const typeEquality = (a: any, b: any): boolean | undefined => {
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const arrayBufferEquality = (a: any, b: any): boolean | undefined => {
+export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined => {
   if (!(a instanceof ArrayBuffer) || !(b instanceof ArrayBuffer)) {
     return undefined;
   }

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -340,7 +340,7 @@ export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined
   }
 
   return true;
-}
+};
 
 export const sparseArrayEquality = (
   a: unknown,

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -319,6 +319,30 @@ export const typeEquality = (a: any, b: any): boolean | undefined => {
   return false;
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const arrayBufferEquality = (a: any, b: any): boolean | undefined => {
+  if (!(a instanceof ArrayBuffer) || !(b instanceof ArrayBuffer)) {
+    return undefined;
+  }
+
+  const d1 = new DataView(a);
+  const d2 = new DataView(b);
+
+  // Buffers are not equal when they do not have the same byte length
+  if (d1.byteLength != d2.byteLength) {
+    return false;
+  }
+
+  // Compare each arraryBuffer byte's buffers
+  for (let i = 0;i < d1.byteLength; i++) {
+    if (d1.getUint8(i) != d2.getUint8(i)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export const sparseArrayEquality = (
   a: unknown,
   b: unknown,

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -319,7 +319,10 @@ export const typeEquality = (a: any, b: any): boolean | undefined => {
   return false;
 };
 
-export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined => {
+export const arrayBufferEquality = (
+  a: unknown,
+  b: unknown,
+): boolean | undefined => {
   if (!(a instanceof ArrayBuffer) || !(b instanceof ArrayBuffer)) {
     return undefined;
   }
@@ -333,7 +336,7 @@ export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined
   }
 
   // Check if every byte value is equal to each other
-  for (let i = 0;i < dataViewA.byteLength; i++) {
+  for (let i = 0; i < dataViewA.byteLength; i++) {
     if (dataViewA.getUint8(i) !== dataViewB.getUint8(i)) {
       return false;
     }

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -333,7 +333,7 @@ export const arrayBufferEquality = (a: any, b: any): boolean | undefined => {
     return false;
   }
 
-  // Compare each arraryBuffer byte's buffers
+  // Check if every byte value is equal to each other
   for (let i = 0;i < dataViewA.byteLength; i++) {
     if (dataViewA.getUint8(i) != dataViewB.getUint8(i)) {
       return false;

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -319,7 +319,6 @@ export const typeEquality = (a: any, b: any): boolean | undefined => {
   return false;
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const arrayBufferEquality = (a: unknown, b: unknown): boolean | undefined => {
   if (!(a instanceof ArrayBuffer) || !(b instanceof ArrayBuffer)) {
     return undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Adds equality checks for Array Buffers in `ToStrictEqual` method, Fixes #11770.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The changes add a new entry to the array `toStrictEqualTesters` in expect package's `matchers.ts` and a new util function `arrayBufferEquality`. I've added tests in `matchers.test.js` to test the actual method and tests in `utils.test.ts` to test the util function.
