### PR TITLE
chore: bump version of CircleCI orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ aliases:
     app-dir: ~/jest
 
 orbs:
-  node: circleci/node@4.0.0
+  node: circleci/node@4.7.0
 
 jobs:
   test-node:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,5 +70,6 @@ workflows:
           partial: true
           matrix:
             parameters:
-              node-version: ['10', '12', '15', '16']
+              # https://github.com/nodejs/node/issues/40030
+              node-version: ['10', '12', '15', '16.8']
       - test-jest-jasmine

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -69,7 +69,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x, 16.x]
+        # https://github.com/nodejs/node/issues/40030
+        node-version: [10.x, 12.x, 14.x, 15.x, 16.8]
         os: [ubuntu-latest, macOS-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     needs: prepare-yarn-cache

--- a/examples/mongodb/setup.js
+++ b/examples/mongodb/setup.js
@@ -18,7 +18,7 @@ module.exports = async () => {
 
   const mongoConfig = {
     mongoDBName: 'jest',
-    mongoUri: await mongod.getConnectionString(),
+    mongoUri: await mongod.getUri(),
   };
 
   // Write global config to disk because all tests run in different contexts.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

From investigation in #11817, it seems when using `execa` and spawning `node` it doesn't spawn the correct version. Bumping the version of the orb seemingly fixes that issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
