### PR TITLE
fix: transform code for code coverage async if possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/reporters]` Use async transform if available to transform files with no coverage ([#11852](https://github.com/facebook/jest/pull/11852))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-reporters/src/generateEmptyCoverage.ts
+++ b/packages/jest-reporters/src/generateEmptyCoverage.ts
@@ -69,13 +69,17 @@ export default async function (
     const scriptTransformer = await createScriptTransformer(config);
 
     // Transform file with instrumentation to make sure initial coverage data is well mapped to original code.
-    const {code} = scriptTransformer.transformSource(filename, source, {
-      instrument: true,
-      supportsDynamicImport: true,
-      supportsExportNamespaceFrom: true,
-      supportsStaticESM: true,
-      supportsTopLevelAwait: true,
-    });
+    const {code} = await scriptTransformer.transformSourceAsync(
+      filename,
+      source,
+      {
+        instrument: true,
+        supportsDynamicImport: true,
+        supportsExportNamespaceFrom: true,
+        supportsStaticESM: true,
+        supportsTopLevelAwait: true,
+      },
+    );
     // TODO: consider passing AST
     const extracted = readInitialCoverage(code);
     // Check extracted initial coverage is not null, this can happen when using /* istanbul ignore file */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

In case the transform people use is async. `transformSourceAsync` works with both sync and async transforms, so this shouldn't affect anything except fixing bugs for people with async only transforms

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
