### PR TITLE
Do not reset global.document before CustomElement:disconnectedCallbac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-core]` Incorrect detection of open ZLIB handles ([#12022](https://github.com/facebook/jest/pull/12022))
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
 - `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
+- `[jest-environment-jsdom]` Do not reset the global.document too early on teardown ([#11871](https://github.com/facebook/jest/pull/11871))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@
 - `[expect]` Allow again `expect.Matchers` generic with single value ([#11986](https://github.com/facebook/jest/pull/11986))
 - `[jest-core]` Incorrect detection of open ZLIB handles ([#12022](https://github.com/facebook/jest/pull/12022))
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
-- `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
 - `[jest-environment-jsdom]` Do not reset the global.document too early on teardown ([#11871](https://github.com/facebook/jest/pull/11871))
+- `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -39,4 +39,28 @@ describe('JSDomEnvironment', () => {
 
     expect(env.dom.window.navigator.userAgent).toEqual('foo');
   });
+
+  /**
+   * When used in conjunction with Custom Elements (part of the WebComponents standard)
+   * setting the global.document to null too early is problematic because:
+   *
+   * CustomElement's disconnectedCallback method is called when a custom element
+   * is removed from the DOM. The disconnectedCallback could need the document
+   * in order to remove some listener for example.
+   *
+   * global.close calls jsdom's Window.js.close which does this._document.body.innerHTML = "".
+   * The custom element will be removed from the DOM at this point, therefore disconnectedCallback
+   * will be called, so please make sure the global.document is still available at this point.
+   */
+  it('should not set the global.document to null too early', () => {
+    const env = new JSDomEnvironment(makeProjectConfig());
+
+    const originalCloseFn = env.global.close.bind(env.global);
+    env.global.close = () => {
+      originalCloseFn();
+      expect(env.global.document).not.toBeNull();
+    };
+
+    return env.teardown();
+  });
 });

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -132,9 +132,14 @@ class JSDOMEnvironment implements JestEnvironment<number> {
       if (this.errorEventListener) {
         this.global.removeEventListener('error', this.errorEventListener);
       }
-      // Dispose "document" to prevent "load" event from triggering.
-      Object.defineProperty(this.global, 'document', {value: null});
       this.global.close();
+
+      // Dispose "document" to prevent "load" event from triggering.
+
+      // Note that this.global.close() will trigger the CustomElement::disconnectedCallback
+      // Do not reset the document before CustomElement disconnectedCallback function has finished running,
+      // document should be accessible within disconnectedCallback.
+      Object.defineProperty(this.global, 'document', {value: null});
     }
     this.errorEventListener = null;
     // @ts-expect-error


### PR DESCRIPTION
## Summary

The order of the statements inside of the teardown function was changed.
This is due to document not being available in the disconnectedCallback function of CustomElements.

The stack trace looks something like this:
this.global.close(); -> window.js::close -> Element.js::innerHTML -> custom-elements.js::ceReactionsPostSteps ->  custom-elements.js::invokeCEReactions -> Function.js::invokeTheCallbackFunction -> my-element::disconnectedCallback

Afaik, **the document should be available inside of disconnectedCallback**, if it's not this results in a: 
"Error: Uncaught [TypeError: Cannot read property 'dispatchEvent' of null]"

## Test plan

I ran yarn build and yarn test. Something weird: during the yarn test, it was written 1 test failed but at the end all succeeded.
