### PR TITLE
chore: remove node 13 as condition in some tests

### DIFF
--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`on node >=12.16.0 runs test with native ESM 1`] = `
+Test Suites: 1 passed, 1 total
+Tests:       21 passed, 21 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /native-esm.test.js/i.
+`;
+
 exports[`on node >=14.3.0 supports top-level await 1`] = `
 Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /native-esm.tla.test.js/i.
-`;
-
-exports[`on node ^12.16.0 || >=13.7.0 runs test with native ESM 1`] = `
-Test Suites: 1 passed, 1 total
-Tests:       21 passed, 21 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching /native-esm.test.js/i.
 `;

--- a/e2e/__tests__/customEsmTestSequencers.test.ts
+++ b/e2e/__tests__/customEsmTestSequencers.test.ts
@@ -11,7 +11,7 @@ import {extractSummary} from '../Utils';
 import runJest from '../runJest';
 const dir = path.resolve(__dirname, '../custom-esm-test-sequencer');
 
-onNodeVersions('^12.16.0 || >=13.7.0', () => {
+onNodeVersions('>=12.16.0', () => {
   test('run prioritySequence', () => {
     const result = runJest(dir, ['-i'], {
       nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -161,7 +161,7 @@ describe('Custom Reporters Integration', () => {
     expect(exitCode).toBe(1);
   });
 
-  onNodeVersions('^12.17.0 || >=13.2.0', () => {
+  onNodeVersions('>=12.17.0', () => {
     test('supports reporter written in ESM', () => {
       writeFiles(DIR, {
         '__tests__/test.test.js': `test('test', () => {});`,

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -82,7 +82,7 @@ it('does not report crypto random data', () => {
   expect(textAfterTest).toBe('');
 });
 
-onNodeVersions('>=12.0.0', () => {
+onNodeVersions('>=12', () => {
   it('does not report ELD histograms', () => {
     const {stderr} = runJest('detect-open-handles', [
       'histogram',

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -82,7 +82,7 @@ it('does not report crypto random data', () => {
   expect(textAfterTest).toBe('');
 });
 
-onNodeVersions('>=11.10.0', () => {
+onNodeVersions('>=12.0.0', () => {
   it('does not report ELD histograms', () => {
     const {stderr} = runJest('detect-open-handles', [
       'histogram',
@@ -110,7 +110,7 @@ describe('notify', () => {
   });
 });
 
-onNodeVersions('>=11', () => {
+onNodeVersions('>=12', () => {
   it('does not report timeouts using unref', () => {
     // The test here is basically that it exits cleanly without reporting anything (does not need `until`)
     const {stderr} = runJest('detect-open-handles', [

--- a/e2e/__tests__/esmConfigFile.test.ts
+++ b/e2e/__tests__/esmConfigFile.test.ts
@@ -20,7 +20,7 @@ test('reads config from cjs file', () => {
   });
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   test('reads config from mjs file', () => {
     const {configs} = getConfig('esm-config/mjs', [], {
       skipPkgJsonCheck: true,

--- a/e2e/__tests__/globalSetup.test.ts
+++ b/e2e/__tests__/globalSetup.test.ts
@@ -197,7 +197,7 @@ test('properly handle rejections', () => {
   expect(stderr).toContain('reason: undefined');
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   test('globalSetup works with ESM modules', () => {
     const {exitCode} = runJest('global-setup-esm', [`--no-cache`], {
       nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/globalTeardown.test.ts
+++ b/e2e/__tests__/globalTeardown.test.ts
@@ -136,7 +136,7 @@ test('globalTeardown throws with named export', () => {
   );
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   test('globalTeardown works with ESM modules', () => {
     const {exitCode} = runJest('global-teardown-esm', [`--no-cache`], {
       nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/nativeAsyncMock.test.ts
+++ b/e2e/__tests__/nativeAsyncMock.test.ts
@@ -12,10 +12,6 @@ import runJest from '../runJest';
 const dir = path.resolve(__dirname, '..', 'native-async-mock');
 
 test('mocks async functions', () => {
-  if (process.versions.node < '7.6.0') {
-    return;
-  }
-
   runYarnInstall(dir);
 
   // --no-cache because babel can cache stuff and result in false green

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -21,7 +21,7 @@ test('test config is without transform', () => {
 });
 
 // The versions where vm.Module exists and commonjs with "exports" is not broken
-onNodeVersions('^12.16.0 || >=13.7.0', () => {
+onNodeVersions('>=12.16.0', () => {
   test('runs test with native ESM', () => {
     const {exitCode, stderr, stdout} = runJest(DIR, ['native-esm.test.js'], {
       nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/nativeEsmTypescript.test.ts
+++ b/e2e/__tests__/nativeEsmTypescript.test.ts
@@ -12,7 +12,7 @@ import {json as runJest} from '../runJest';
 const DIR = resolve(__dirname, '../native-esm-typescript');
 
 // The versions where vm.Module exists and commonjs with "exports" is not broken
-onNodeVersions('^12.16.0 || >=13.7.0', () => {
+onNodeVersions('>=12.16.0', () => {
   test('runs TS test with native ESM', () => {
     const {exitCode, json} = runJest(DIR, [], {
       nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/presets.test.ts
+++ b/e2e/__tests__/presets.test.ts
@@ -19,7 +19,7 @@ test.each(['js', 'cjs'])('supports %s preset', presetDir => {
   expect(result.exitCode).toBe(0);
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   // eslint-disable-next-line jest/no-identical-title
   test.each(['mjs', 'js-type-module'])('supports %s preset', presetDir => {
     const result = runJest(`presets/${presetDir}`);

--- a/e2e/__tests__/resolveConditions.test.ts
+++ b/e2e/__tests__/resolveConditions.test.ts
@@ -17,7 +17,7 @@ beforeAll(() => {
 });
 
 // The versions where vm.Module exists and commonjs with "exports" is not broken
-onNodeVersions('^12.16.0 || >=13.7.0', () => {
+onNodeVersions('>=12.16.0', () => {
   test('resolves package exports correctly with custom resolver', () => {
     // run multiple times to ensure there are no caching errors
     for (let i = 0; i < 5; i++) {

--- a/e2e/__tests__/testEnvironmentEsm.ts
+++ b/e2e/__tests__/testEnvironmentEsm.ts
@@ -10,7 +10,7 @@ import {onNodeVersions} from '@jest/test-utils';
 import runJest from '../runJest';
 
 // The versions where vm.Module exists and commonjs with "exports" is not broken
-onNodeVersions('^12.16.0 || >=13.7.0', () => {
+onNodeVersions('>=12.16.0', () => {
   it('support test environment written in ESM', () => {
     const DIR = resolve(__dirname, '../test-environment-esm');
     const {exitCode} = runJest(DIR);

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -277,7 +277,7 @@ describe('transform-testrunner', () => {
   });
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   describe('esm-transformer', () => {
     const dir = path.resolve(__dirname, '../transform/esm-transformer');
 

--- a/e2e/__tests__/watch-plugins.test.ts
+++ b/e2e/__tests__/watch-plugins.test.ts
@@ -26,7 +26,7 @@ test.each(['js', 'cjs'])('supports %s watch plugins', async watchPluginDir => {
   await testRun.end();
 });
 
-onNodeVersions('^12.17.0 || >=13.2.0', () => {
+onNodeVersions('>=12.17.0', () => {
   test.each(['mjs', 'js-type-module'])(
     // eslint-disable-next-line jest/no-identical-title
     'supports %s watch plugins',

--- a/packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts
+++ b/packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts
@@ -8,7 +8,6 @@
 
 import assert from 'assert';
 import fc from 'fast-check';
-import {onNodeVersions} from '@jest/test-utils';
 import expect from '..';
 import {
   anythingSettings,
@@ -58,20 +57,18 @@ describe('toStrictEqual', () => {
     );
   });
 
-  onNodeVersions('>=9', () => {
-    it('should be equivalent to Node deepStrictEqual', () => {
-      fc.assert(
-        fc.property(
-          fc.anything(anythingSettings),
-          fc.anything(anythingSettings),
-          (a, b) => {
-            expect(safeExpectStrictEqual(a, b)).toBe(
-              safeAssertDeepStrictEqual(a, b),
-            );
-          },
-        ),
-        assertSettings,
-      );
-    });
+  it('should be equivalent to Node deepStrictEqual', () => {
+    fc.assert(
+      fc.property(
+        fc.anything(anythingSettings),
+        fc.anything(anythingSettings),
+        (a, b) => {
+          expect(safeExpectStrictEqual(a, b)).toBe(
+            safeAssertDeepStrictEqual(a, b),
+          );
+        },
+      ),
+      assertSettings,
+    );
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We don't support (or test on) Node 13 since the release of Jest 27, so we can remove it and simplify some conditions in tests that depend on the node version

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
