### PR TITLE
fix: include path to test file in "after teardown" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - `[jest-runtime]` Fix regression when using `jest.isolateModules` and mocks ([#11882](https://github.com/facebook/jest/pull/11882))
+- `[jest-runtime]` Include test name when importing modules after test has completed ([#11885](https://github.com/facebook/jest/pull/11885))
+- `[jest-runtime]` Error when ESM import is used after test is torn down ([#11885](https://github.com/facebook/jest/pull/11885))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints useful error for environment methods after test is done 1`] = `
-ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down.
+ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From test __tests__/afterTeardown.test.js.
 
        9 | test('access environment methods after done', () => {
       10 |   setTimeout(() => {

--- a/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints useful error for environment methods after test is done 1`] = `
-ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From test __tests__/afterTeardown.test.js.
+ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From __tests__/afterTeardown.test.js.
 
        9 | test('access environment methods after done', () => {
       10 |   setTimeout(() => {

--- a/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`prints useful error for requires after test is done 1`] = `
-ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down.
+ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
        9 | test('require after done', () => {
       10 |   setTimeout(() => {

--- a/e2e/__tests__/environmentAfterTeardown.test.ts
+++ b/e2e/__tests__/environmentAfterTeardown.test.ts
@@ -14,6 +14,6 @@ test('prints useful error for environment methods after test is done', () => {
 
   expect(wrap(interestingLines)).toMatchSnapshot();
   expect(stderr.split('\n')[9]).toBe(
-    'ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down.',
+    'ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From test __tests__/afterTeardown.test.js.',
   );
 });

--- a/e2e/__tests__/environmentAfterTeardown.test.ts
+++ b/e2e/__tests__/environmentAfterTeardown.test.ts
@@ -14,6 +14,6 @@ test('prints useful error for environment methods after test is done', () => {
 
   expect(wrap(interestingLines)).toMatchSnapshot();
   expect(stderr.split('\n')[9]).toBe(
-    'ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From test __tests__/afterTeardown.test.js.',
+    'ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From __tests__/afterTeardown.test.js.',
   );
 });

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -329,9 +329,8 @@ async function runTestInternal(
       setImmediate(() => resolve({leakDetector, result}));
     });
   } finally {
+    runtime.teardown();
     await environment.teardown();
-    // TODO: this function might be missing, remove ? in Jest 26
-    runtime.teardown?.();
 
     sourcemapSupport.resetRetrieveHandlers();
   }

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1975,7 +1975,10 @@ export default class Runtime {
   }
 
   private _logFormattedReferenceError(errorMessage: string) {
-    const originalStack = new ReferenceError(errorMessage)
+    const testPath = this._testPath
+      ? ` From test ${path.relative(this._config.rootDir, this._testPath)}.`
+      : '';
+    const originalStack = new ReferenceError(`${errorMessage}${testPath}`)
       .stack!.split('\n')
       // Remove this file from the stack (jest-message-utils will keep one line)
       .filter(line => line.indexOf(__filename) === -1)

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -2004,7 +2004,7 @@ export default class Runtime {
 
   private _logFormattedReferenceError(errorMessage: string) {
     const testPath = this._testPath
-      ? ` From test ${path.relative(this._config.rootDir, this._testPath)}.`
+      ? ` From ${path.relative(this._config.rootDir, this._testPath)}.`
       : '';
     const originalStack = new ReferenceError(`${errorMessage}${testPath}`)
       .stack!.split('\n')

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -532,6 +532,14 @@ export default class Runtime {
     referencingIdentifier: string,
     context: VMContext,
   ) {
+    if (this.isTornDown) {
+      this._logFormattedReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
     if (specifier === '@jest/globals') {
       const fromCache = this._esmoduleRegistry.get('@jest/globals');
 
@@ -576,6 +584,14 @@ export default class Runtime {
   }
 
   private async linkAndEvaluateModule(module: VMModule) {
+    if (this.isTornDown) {
+      this._logFormattedReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
     if (module.status === 'unlinked') {
       // since we might attempt to link the same module in parallel, stick the promise in a weak map so every call to
       // this method can await it

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -22,6 +22,7 @@ import {parse as parseCjs} from 'cjs-module-lexer';
 import {CoverageInstrumenter, V8Coverage} from 'collect-v8-coverage';
 import execa = require('execa');
 import * as fs from 'graceful-fs';
+import slash = require('slash');
 import stripBOM = require('strip-bom');
 import type {
   Jest,
@@ -2004,7 +2005,7 @@ export default class Runtime {
 
   private _logFormattedReferenceError(errorMessage: string) {
     const testPath = this._testPath
-      ? ` From ${path.relative(this._config.rootDir, this._testPath)}.`
+      ? ` From ${slash(path.relative(this._config.rootDir, this._testPath))}.`
       : '';
     const originalStack = new ReferenceError(`${errorMessage}${testPath}`)
       .stack!.split('\n')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The logging can happen long after the test has been printed as `PASS` to the user, so let's include the test file in the message to make it easier to track down (not super useful in sync situations as the stack trace should include it, but that doesn't happen in async contexts)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
