### PR TITLE
fix:  call `destroy` on `v8-to-istanbul` converters to free memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory
+- `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory ([#11896](https://github.com/facebook/jest/pull/11896))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -32,7 +32,7 @@
     "source-map": "^0.6.0",
     "string-length": "^4.0.1",
     "terminal-link": "^2.0.0",
-    "v8-to-istanbul": "^8.0.0"
+    "v8-to-istanbul": "^8.1.0"
   },
   "devDependencies": {
     "@jest/test-utils": "^27.2.2",

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -473,7 +473,7 @@ export default class CoverageReporter extends BaseReporter {
 
           const istanbulData = converter.toIstanbul();
 
-          converter.destory();
+          converter.destroy();
 
           return istanbulData;
         }),

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -471,7 +471,11 @@ export default class CoverageReporter extends BaseReporter {
 
           converter.applyCoverage(res.functions);
 
-          return converter.toIstanbul();
+          const istanbulData = converter.toIstanbul();
+
+          converter.destory();
+
+          return istanbulData;
         }),
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2676,7 +2676,7 @@ __metadata:
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
     terminal-link: ^2.0.0
-    v8-to-istanbul: ^8.0.0
+    v8-to-istanbul: ^8.1.0
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -21815,14 +21815,14 @@ react-native@0.64.0:
   languageName: node
   linkType: hard
 
-"v8-to-istanbul@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "v8-to-istanbul@npm:8.0.0"
+"v8-to-istanbul@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "v8-to-istanbul@npm:8.1.0"
   dependencies:
     "@types/istanbul-lib-coverage": ^2.0.1
     convert-source-map: ^1.6.0
     source-map: ^0.7.3
-  checksum: ada29177f2944438eecb6a2fafb2144553c9dc9e623a253083149f4bbb193d862f93bda3cfde93178f3ca799df67da8f0b87222bde8d415a06550476893de0fc
+  checksum: a43c4feab9014ed55a0ba62513a96f4a68a156ddccede380934f934bc7c63a992e506033ef133a06013540cc7fcbbce1ec8c2b0352c376033854a94b93cbde44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

See https://github.com/istanbuljs/v8-to-istanbul/pull/161

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
