### PR TITLE
fix(jest-config): parse `testEnvironmentOptions` if received from CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory ([#11896](https://github.com/facebook/jest/pull/11896))
-- `[jest-config]` Parse JSON string `testEnvironmentOptions` received from CLI ([#11902](https://github.com/facebook/jest/pull/11902))
+- `[jest-config]` Parse `testEnvironmentOptions` if received from CLI ([#11902](https://github.com/facebook/jest/pull/11902))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory ([#11896](https://github.com/facebook/jest/pull/11896))
-- `[jest-cli]` Improve description of `testEnvironmentOptions` option ([#11902](https://github.com/facebook/jest/pull/11902))
+- `[jest-config]` Parse JSON string `testEnvironmentOptions` received from CLI ([#11902](https://github.com/facebook/jest/pull/11902))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-reporters]` Call `destroy` on `v8-to-istanbul` converters to free memory ([#11896](https://github.com/facebook/jest/pull/11896))
+- `[jest-cli]` Improve description of `testEnvironmentOptions` option ([#11902](https://github.com/facebook/jest/pull/11902))
 
 ### Chore & Maintenance
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -302,7 +302,7 @@ Print your Jest config and then exits.
 
 Prevent tests from printing messages through the console.
 
-### `--testEnvironmentOptions`
+### `--testEnvironmentOptions=<json string>`
 
 A JSON string with options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -302,6 +302,10 @@ Print your Jest config and then exits.
 
 Prevent tests from printing messages through the console.
 
+### `--testEnvironmentOptions`
+
+A JSON string with options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
+
 ### `--testNamePattern=<regex>`
 
 Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like `"GET /api/posts with auth"`, then you can use `jest -t=auth`.

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -549,9 +549,9 @@ export const options = {
   },
   testEnvironmentOptions: {
     description:
-      'Test environment options that will be passed to the testEnvironment. ' +
+      'A JSON string with options that will be passed to the `testEnvironment`. ' +
       'The relevant options depend on the environment.',
-    type: 'string', // Object
+    type: 'string',
   },
   testFailureExitCode: {
     description: 'Exit code of `jest` command if the test run failed',

--- a/packages/jest-config/src/__tests__/setFromArgv.test.ts
+++ b/packages/jest-config/src/__tests__/setFromArgv.test.ts
@@ -47,12 +47,16 @@ test('works with string objects', () => {
   const argv = {
     moduleNameMapper:
       '{"types/(.*)": "<rootDir>/src/types/$1", "types2/(.*)": ["<rootDir>/src/types2/$1", "<rootDir>/src/types3/$1"]}',
+    testEnvironmentOptions: '{"userAgent": "Agent/007"}',
     transform: '{"*.js": "<rootDir>/transformer"}',
   } as Config.Argv;
   expect(setFromArgv(options, argv)).toMatchObject({
     moduleNameMapper: {
       'types/(.*)': '<rootDir>/src/types/$1',
       'types2/(.*)': ['<rootDir>/src/types2/$1', '<rootDir>/src/types3/$1'],
+    },
+    testEnvironmentOptions: {
+      userAgent: 'Agent/007',
     },
     transform: {
       '*.js': '<rootDir>/transformer',

--- a/packages/jest-config/src/setFromArgv.ts
+++ b/packages/jest-config/src/setFromArgv.ts
@@ -35,9 +35,10 @@ export default function setFromArgv(
           break;
         case 'coverageThreshold':
         case 'globals':
-        case 'moduleNameMapper':
-        case 'transform':
         case 'haste':
+        case 'moduleNameMapper':
+        case 'testEnvironmentOptions':
+        case 'transform':
           const str = argv[key];
           if (isJSONString(str)) {
             options[key] = JSON.parse(str);

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -462,6 +462,7 @@ export type Argv = Arguments<
     silent: boolean;
     snapshotSerializers: Array<string>;
     testEnvironment: string;
+    testEnvironmentOptions: string;
     testFailureExitCode: string | null | undefined;
     testMatch: Array<string>;
     testNamePattern: string;

--- a/website/versioned_docs/version-27.2/CLI.md
+++ b/website/versioned_docs/version-27.2/CLI.md
@@ -302,7 +302,7 @@ Print your Jest config and then exits.
 
 Prevent tests from printing messages through the console.
 
-### `--testEnvironmentOptions`
+### `--testEnvironmentOptions=<json string>`
 
 A JSON string with options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 

--- a/website/versioned_docs/version-27.2/CLI.md
+++ b/website/versioned_docs/version-27.2/CLI.md
@@ -302,6 +302,10 @@ Print your Jest config and then exits.
 
 Prevent tests from printing messages through the console.
 
+### `--testEnvironmentOptions`
+
+A JSON string with options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
+
 ### `--testNamePattern=<regex>`
 
 Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like `"GET /api/posts with auth"`, then you can use `jest -t=auth`.


### PR DESCRIPTION
Resolves #11900

## Summary

See https://github.com/facebook/jest/issues/11900#issuecomment-928960018.

## Test plan

I have added a unit test.