### PR TITLE
docs: fix regression introduced in #11904

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -220,7 +220,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -232,9 +232,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -202,7 +202,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 1. Tests needs to run in Node test environment (support for `jsdom` requires [`jest-environment-jsdom-sixteen`](https://www.npmjs.com/package/jest-environment-jsdom-sixteen))
 1. V8 has way better data in the later versions, so using the latest versions of node (v13 at the time of this writing) will yield better results
 
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -214,9 +214,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -220,7 +220,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -232,9 +232,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 

--- a/website/versioned_docs/version-27.0/Configuration.md
+++ b/website/versioned_docs/version-27.0/Configuration.md
@@ -220,7 +220,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -232,9 +232,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 

--- a/website/versioned_docs/version-27.1/Configuration.md
+++ b/website/versioned_docs/version-27.1/Configuration.md
@@ -220,8 +220,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -233,9 +232,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 

--- a/website/versioned_docs/version-27.2/Configuration.md
+++ b/website/versioned_docs/version-27.2/Configuration.md
@@ -220,7 +220,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-### `coverageReporters` \[array&lt;string | [string, options]&gt;]
+### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`
 
@@ -232,9 +232,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 
 ```json
 {
-  "coverageReporters": [
-    "clover", "json", "lcov", ["text", {"skipFull": true}]
-  ]
+  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
 }
 ```
 


### PR DESCRIPTION
## Summary

This PR is fixing regression introduced by #11904.

Escaping was necessary, only italic was redundant. I removed too much. TOC was rendering incorrectly. All good now. Apologies.

## Test plan

Prettier will be happy now.