### PR TITLE
chore: reject `waitUntil` if process exits

### DIFF
--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -13,6 +13,7 @@ import * as fs from 'graceful-fs';
 import stripAnsi = require('strip-ansi');
 import type {FormattedTestResults} from '@jest/test-result';
 import type {Config} from '@jest/types';
+import {ErrorWithStack} from 'jest-util';
 import {normalizeIcons} from './Utils';
 
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
@@ -212,7 +213,7 @@ export const runContinuous = function (
     }),
   );
 
-  return {
+  const continuousRun = {
     async end() {
       jestPromise.kill();
 
@@ -242,12 +243,17 @@ export const runContinuous = function (
             resolve();
           }
         };
-        const error = new Error('Process exited');
+        const error = new ErrorWithStack(
+          'Process exited',
+          continuousRun.waitUntil,
+        );
         pendingRejection.set(check, () => reject(error));
         pending.add(check);
       });
     },
   };
+
+  return continuousRun;
 };
 
 // return type matches output of logDebugMessages


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

From investigating #11467, while the process times out, the `waitUntil` call never resolves. So this change rejects any waiting calls.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

![image](https://user-images.githubusercontent.com/1404810/135268097-cb104de3-28be-4244-a2ca-0789e4af4d06.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
