### PR TITLE
docs: remove deprecated `setupTestFrameworkScriptFile` option and `setupFilesAfterEnv` instead

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -290,9 +290,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -276,7 +276,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -211,6 +211,9 @@ export type InitialOptions = Partial<{
   runTestsByPath: boolean;
   scriptPreprocessor: string;
   setupFiles: Array<Path>;
+  /**
+   * @deprecated Use `setupFilesAfterEnv` options instead.
+   */
   setupTestFrameworkScriptFile: Path;
   setupFilesAfterEnv: Array<Path>;
   silent: boolean;

--- a/website/versioned_docs/version-25.x/CLI.md
+++ b/website/versioned_docs/version-25.x/CLI.md
@@ -274,9 +274,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -272,7 +272,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 

--- a/website/versioned_docs/version-26.x/CLI.md
+++ b/website/versioned_docs/version-26.x/CLI.md
@@ -290,9 +290,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -900,8 +900,6 @@ If you want a path to be [relative to the root directory of your project](#rootd
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in these modules.
 
-_Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
-
 Example `setupFilesAfterEnv` array in a jest.config.js:
 
 ```js

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -276,7 +276,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 

--- a/website/versioned_docs/version-27.0/CLI.md
+++ b/website/versioned_docs/version-27.0/CLI.md
@@ -290,9 +290,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/website/versioned_docs/version-27.0/Configuration.md
+++ b/website/versioned_docs/version-27.0/Configuration.md
@@ -927,8 +927,6 @@ If you want a path to be [relative to the root directory of your project](#rootd
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in these modules.
 
-_Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
-
 Example `setupFilesAfterEnv` array in a jest.config.js:
 
 ```js

--- a/website/versioned_docs/version-27.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.0/JestObjectAPI.md
@@ -276,7 +276,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 

--- a/website/versioned_docs/version-27.1/CLI.md
+++ b/website/versioned_docs/version-27.1/CLI.md
@@ -290,9 +290,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/website/versioned_docs/version-27.1/Configuration.md
+++ b/website/versioned_docs/version-27.1/Configuration.md
@@ -928,8 +928,6 @@ If you want a path to be [relative to the root directory of your project](#rootd
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in these modules.
 
-_Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
-
 Example `setupFilesAfterEnv` array in a jest.config.js:
 
 ```js

--- a/website/versioned_docs/version-27.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.1/JestObjectAPI.md
@@ -276,7 +276,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 

--- a/website/versioned_docs/version-27.2/CLI.md
+++ b/website/versioned_docs/version-27.2/CLI.md
@@ -290,9 +290,9 @@ Run only the tests that were specified with their exact paths.
 
 _Note: The default regex matching works fine on small runs, but becomes slow if provided with multiple patterns and/or against a lot of tests. This option replaces the regex matching logic and by that optimizes the time it takes Jest to filter specific test files_
 
-### `--setupTestFrameworkScriptFile=<file>`
+### `--setupFilesAfterEnv <path1> ... <pathN>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
+A list of paths to modules that run some code to configure or to set up the testing framework before each test. Beware that files imported by the setup scripts will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/website/versioned_docs/version-27.2/Configuration.md
+++ b/website/versioned_docs/version-27.2/Configuration.md
@@ -931,8 +931,6 @@ If you want a path to be [relative to the root directory of your project](#rootd
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in these modules.
 
-_Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
-
 Example `setupFilesAfterEnv` array in a jest.config.js:
 
 ```js

--- a/website/versioned_docs/version-27.2/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.2/JestObjectAPI.md
@@ -276,7 +276,7 @@ jest.mock(
 );
 ```
 
-> **Warning:** Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.
+> **Warning:** Importing a module in a setup file (as specified by `setupFilesAfterEnv`) will prevent mocking for the module in question, as well as all the modules that it imports.
 
 Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if it runs after the test file that mocks the module.
 


### PR DESCRIPTION
## Summary

`setupTestFrameworkScriptFile` option is deprecated in favor of `setupFilesAfterEnv` since `v24`: https://github.com/facebook/jest/releases/tag/v24.0.0

It was still present in the CLI API docs. Time to say good bye?

In the CLI API docs I simply replaced it with `setupFilesAfterEnv` which was not documented before.

Also:
- removed a note on deprecation of `setupTestFrameworkScriptFile` in Configuration docs. Only `v26` and `v27`. Did not touch earlier ones on purpose. The note is good to have in `v24` docs (and perhaps `25`?).
- replaced `setupTestFrameworkScriptFile` -> `setupFilesAfterEnv` elsewhere.
- and added `@deprecated` in typings.

## Test plan

The code was not touched. Just in case, I tryout out if the CLI option works as documented. It does.