### PR TITLE
fix(types): mark deprecated configuration options as `@deprecated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
 
-
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixes
 
+- `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
+
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -196,6 +196,9 @@ export type InitialOptions = Partial<{
   onlyFailures: boolean;
   outputFile: Path;
   passWithNoTests: boolean;
+  /**
+   * @deprecated Use `transformIgnorePatterns` options instead.
+   */
   preprocessorIgnorePatterns: Array<Glob>;
   preset: string | null | undefined;
   prettierPath: string | null | undefined;
@@ -209,6 +212,9 @@ export type InitialOptions = Partial<{
   roots: Array<Path>;
   runner: string;
   runTestsByPath: boolean;
+  /**
+   * @deprecated Use `transform` options instead.
+   */
   scriptPreprocessor: string;
   setupFiles: Array<Path>;
   /**
@@ -230,6 +236,9 @@ export type InitialOptions = Partial<{
   testLocationInResults: boolean;
   testMatch: Array<Glob>;
   testNamePattern: string;
+  /**
+   * @deprecated Use `roots` options instead.
+   */
   testPathDirs: Array<Path>;
   testPathIgnorePatterns: Array<string>;
   testRegex: string | Array<string>;


### PR DESCRIPTION
## Summary

Simply marked deprecated configuration options as `@deprecated` to improve DX. I was following [deprecation massages](https://github.com/facebook/jest/blob/main/packages/jest-config/src/Deprecated.ts) to add these marks.

## Test plan

Code did not change.