### PR TITLE
fix(cli): improve `--help` printout by removing defunct `--browser` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
+- `[jest-cli]` Improve `--help` printout by removing defunct `--browser` option ([#11914](https://github.com/facebook/jest/pull/11914))
 
 ### Chore & Maintenance
 

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -107,13 +107,6 @@ export const options = {
       'Exit the test suite immediately after `n` number of failing tests.',
     type: 'boolean',
   },
-  browser: {
-    description:
-      'Respect the "browser" field in package.json ' +
-      'when resolving modules. Some packages export different versions ' +
-      'based on whether they are operating in node.js or a browser.',
-    type: 'boolean',
-  },
   cache: {
     description:
       'Whether to use the transform cache. Disable the cache ' +


### PR DESCRIPTION
## Summary

It seems like `--browser` flag was left by mistake in the CLI API. @SimenB Wasn’t it supposed to be remove in #9943? Or is this intentional?

The flag does nothing and is not documented. But `yargs` is including it in the printout of `--help` option. That’s misleading. This PR is an attempt to improve the printout. If the removal looks like a breaking change, it might be better to use `yargs`’s deprecation mechanism as an alternative.

## Test plan

`yarn jest --help` to see that `--browser` is included without deprecation note.