### PR TITLE
fix(jest-haste-map): Add computeDependencies to cache path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
 - `[jest-cli]` Improve `--help` printout by removing defunct `--browser` option ([#11914](https://github.com/facebook/jest/pull/11914))
+- `[jest-haste-map]` Use distinct cache paths for different values of `computeDependencies` ([#11916](https://github.com/facebook/jest/pull/11916))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -265,6 +265,20 @@ describe('HasteMap', () => {
     expect(hasteMap1.getCacheFilePath()).not.toBe(hasteMap2.getCacheFilePath());
   });
 
+  it('creates different cache file paths for different values of computeDependencies', () => {
+    jest.resetModules();
+    const HasteMap = require('../').default;
+    const hasteMap1 = new HasteMap({
+      ...defaultConfig,
+      computeDependencies: true,
+    });
+    const hasteMap2 = new HasteMap({
+      ...defaultConfig,
+      computeDependencies: false,
+    });
+    expect(hasteMap1.getCacheFilePath()).not.toBe(hasteMap2.getCacheFilePath());
+  });
+
   it('creates different cache file paths for different hasteImplModulePath cache keys', () => {
     jest.resetModules();
     const HasteMap = require('../').default;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -325,6 +325,7 @@ export default class HasteMap extends EventEmitter {
       (options.ignorePattern || '').toString(),
       hasteImplHash,
       dependencyExtractorHash,
+      this._options.computeDependencies.toString(),
     );
     this._buildPromise = null;
     this._watchers = [];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

#6667 added the `computeDependencies` option, which affects the contents of the Haste map, but doesn't change the cache path. If two `jest-haste-map` instances are created with identical options except for `computeDependencies`, the one with `computeDependencies: true` could end up attempting to reuse cached data where the dependencies are missing.

Here we add the value of `computeDependencies` to the cache path.

## Test plan

Added a unit test.
