### PR TITLE
Throw when there are multiple configs. package.json and jest.config.js

### DIFF
--- a/packages/jest-config/src/__tests__/resolveConfigPath.test.ts
+++ b/packages/jest-config/src/__tests__/resolveConfigPath.test.ts
@@ -14,6 +14,7 @@ import resolveConfigPath from '../resolveConfigPath';
 const DIR = path.resolve(tmpdir(), 'resolve_config_path_test');
 const ERROR_PATTERN = /Could not find a config file based on provided values/;
 const NO_ROOT_DIR_ERROR_PATTERN = /Can't find a root directory/;
+const MULTIPLE_CONFIGS_ERROR_PATTERN = /Multiple configurations found/;
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
@@ -66,7 +67,7 @@ describe.each(JEST_CONFIG_EXT_ORDER.slice(0))(
         resolveConfigPath(path.dirname(relativeJestConfigPath), DIR),
       ).toThrowError(ERROR_PATTERN);
 
-      writeFiles(DIR, {[relativePackageJsonPath]: ''});
+      writeFiles(DIR, {[relativePackageJsonPath]: JSON.stringify({jest: {}})});
 
       // absolute
       expect(
@@ -80,17 +81,17 @@ describe.each(JEST_CONFIG_EXT_ORDER.slice(0))(
 
       writeFiles(DIR, {[relativeJestConfigPath]: ''});
 
-      // jest.config.js takes precedence
+      // jest.config.js and package.json are not allowed together
 
       // absolute
-      expect(
+      expect(() =>
         resolveConfigPath(path.dirname(absolutePackageJsonPath), DIR),
-      ).toBe(absoluteJestConfigPath);
+      ).toThrowError(MULTIPLE_CONFIGS_ERROR_PATTERN);
 
       // relative
-      expect(
+      expect(() =>
         resolveConfigPath(path.dirname(relativePackageJsonPath), DIR),
-      ).toBe(absoluteJestConfigPath);
+      ).toThrowError(MULTIPLE_CONFIGS_ERROR_PATTERN);
 
       expect(() => {
         resolveConfigPath(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix https://github.com/facebook/jest/issues/10124

There are 2 stale PRs that I took inspiration from.

It is a breaking change (error, not a warning) as proposed by @SimenB here: https://github.com/facebook/jest/pull/10798#pullrequestreview-593655004

## Test plan

I wrote/updated unit tests that check the behavior.
