### PR TITLE
fix(expect): improve typings of `toThrow()` and `toThrowError()` matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[expect]` Pass matcher context to asymmetric matchers ([#11926](https://github.com/facebook/jest/pull/11926) & [#11930](https://github.com/facebook/jest/pull/11930))
 - `[expect]` Improve TypeScript types ([#11931](https://github.com/facebook/jest/pull/11931))
+- `[expect]` Improve typings of `toThrow()` and `toThrowError()` matchers ([#11929](https://github.com/facebook/jest/pull/11929))
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
 - `[jest-cli]` Improve `--help` printout by removing defunct `--browser` option ([#11914](https://github.com/facebook/jest/pull/11914))
 - `[jest-haste-map]` Use distinct cache paths for different values of `computeDependencies` ([#11916](https://github.com/facebook/jest/pull/11916))

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -106,10 +106,6 @@ export type Expect<State extends MatcherState = MatcherState> = {
     not: InverseAsymmetricMatchers & ExtraAsymmetricMatchers;
   };
 
-interface Constructable {
-  new (...args: Array<unknown>): unknown;
-}
-
 // This is a copy from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de6730f4463cba69904698035fafd906a72b9664/types/jest/index.d.ts#L570-L817
 export interface Matchers<R> {
   /**
@@ -322,11 +318,11 @@ export interface Matchers<R> {
   /**
    * Used to test that a function throws when it is called.
    */
-  toThrow(error?: string | Constructable | RegExp | Error): R;
+  toThrow(error?: unknown): R;
   /**
    * If you want to test that a specific error is thrown inside a function.
    */
-  toThrowError(error?: string | Constructable | RegExp | Error): R;
+  toThrowError(error?: unknown): R;
 
   /* TODO: START snapshot matchers are not from `expect`, the types should not be here */
   /**

--- a/test-types/top-level-globals.test.ts
+++ b/test-types/top-level-globals.test.ts
@@ -115,6 +115,12 @@ expectType<void>(describe.skip.each(testTable)(testName, fn, timeout));
 expectType<void>(expect(2).toBe(2));
 expectType<Promise<void>>(expect(2).resolves.toBe(2));
 
+expectType<void>(expect(() => {}).toThrow());
+expectType<void>(expect(() => {}).toThrow(/error/));
+expectType<void>(expect(() => {}).toThrow('error'));
+expectType<void>(expect(() => {}).toThrow(Error));
+expectType<void>(expect(() => {}).toThrow(new Error('error')));
+
 expectType<void>(expect('Hello').toEqual(expect.any(String)));
 
 // this currently does not error due to `[id: string]` in ExtraAsymmetricMatchers - we should have nothing there and force people to use interface merging


### PR DESCRIPTION
Resolves #10087

## Summary

It looks like the typings issue described in #10087 is caused by definition of `Constructable` in `expect` package – https://github.com/facebook/jest/blob/f13abff8df9a0e1148baf3584bcde6d1b479edc7/packages/expect/src/types.ts#L93-L95

In `@types/jest` it is defined differently:

```ts
interface Constructable {
  new (...args: any[]): any;
}
```

Changing `unknown`s back into `any`s solves the issue.

It is possible to revert back or to move forward and to use [`ErrorConstructor`](https://github.com/microsoft/TypeScript/blob/cec2fda9a53620dc545a2c4d7b0156446ab145b4/lib/lib.es5.d.ts#L978) instead of `Constructable`. This solves the problem as well and is more explicit, right?

## Test plan

Added tests. As usual.
