### PR TITLE
fix: construct mather context for asymmetric matchers on demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[expect]` Pass matcher context to asymmetric matchers ([#11926](https://github.com/facebook/jest/pull/11926))
+- `[expect]` Pass matcher context to asymmetric matchers ([#11926](https://github.com/facebook/jest/pull/11926) & [#11930](https://github.com/facebook/jest/pull/11930))
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
 - `[jest-cli]` Improve `--help` printout by removing defunct `--browser` option ([#11914](https://github.com/facebook/jest/pull/11914))
 - `[jest-haste-map]` Use distinct cache paths for different values of `computeDependencies` ([#11916](https://github.com/facebook/jest/pull/11916))

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -68,16 +68,16 @@ export const setMatchers = (
 
         asymmetricMatch(other: unknown) {
           const {pass} = matcher.call(
-            this.matcherState,
+            this.getMatcherContext(),
             other,
             ...this.sample,
           ) as SyncExpectationResult;
 
-          return this.matcherState.isNot ? !pass : pass;
+          return this.inverse ? !pass : pass;
         }
 
         toString() {
-          return `${this.matcherState.isNot ? 'not.' : ''}${key}`;
+          return `${this.inverse ? 'not.' : ''}${key}`;
         }
 
         getExpectedType() {
@@ -92,7 +92,9 @@ export const setMatchers = (
       expect[key] = (...sample: [unknown, unknown]) =>
         new CustomMatcher(false, ...sample);
       if (!expect.not) {
-        expect.not = {};
+        throw new Error(
+          '`expect.not` is not defined - please report this bug to https://github.com/facebook/jest',
+        );
       }
       expect.not[key] = (...sample: [unknown, unknown]) =>
         new CustomMatcher(true, ...sample);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Following up #11926. That constructs the context when the matcher is _created_ rather than when it's _called_, which is wrong (i.e. number of assertions would be wrong).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
