### PR TITLE
chore(expect): expose default matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Chore & Maintenance
 
+- `[expect]` Expose default matchers ([#11932](https://github.com/facebook/jest/pull/11932))
+
 ### Performance
 
 ## 27.2.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Chore & Maintenance
 
-- `[expect]` Expose default matchers ([#11932](https://github.com/facebook/jest/pull/11932))
+- `[expect]` Export default matchers ([#11932](https://github.com/facebook/jest/pull/11932))
 
 ### Performance
 

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -12,7 +12,8 @@
   "exports": {
     ".": "./build/index.js",
     "./package.json": "./package.json",
-    "./build/utils": "./build/utils.js"
+    "./build/utils": "./build/utils.js",
+    "./build/matchers": "./build/matchers.js"
   },
   "dependencies": {
     "@jest/types": "^27.2.4",

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -52,7 +52,10 @@ module.exports.getPackages = function getPackages() {
           {},
         ),
         ...(pkg.name === 'jest-circus' ? {'./runner': './runner.js'} : {}),
-        ...(pkg.name === 'expect' ? {'./build/utils': './build/utils.js'} : {}),
+        ...(pkg.name === 'expect' ? {
+          './build/utils': './build/utils.js',
+          './build/matchers': './build/matchers.js',
+        } : {}),
       },
       `Package ${pkg.name} does not export correct files`,
     );

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -52,10 +52,12 @@ module.exports.getPackages = function getPackages() {
           {},
         ),
         ...(pkg.name === 'jest-circus' ? {'./runner': './runner.js'} : {}),
-        ...(pkg.name === 'expect' ? {
-          './build/utils': './build/utils.js',
-          './build/matchers': './build/matchers.js',
-        } : {}),
+        ...(pkg.name === 'expect'
+          ? {
+              './build/matchers': './build/matchers.js',
+              './build/utils': './build/utils.js',
+            }
+          : {}),
       },
       `Package ${pkg.name} does not export correct files`,
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Projects which use expect sometimes want to have access to the default matchers before they get overridden. This was not possible before and lead to `ERR_PACKAGE_PATH_NOT_EXPORTED`. After this change it's possible to require it via `expect/build/matchers`.

Context:

- https://github.com/facebook/jest/pull/11816
- https://github.com/microsoft/playwright/pull/8718