### PR TITLE
chore: remove unnecessary `empty.d.ts`

### DIFF
--- a/test-types/empty.d.ts
+++ b/test-types/empty.d.ts
@@ -1,9 +1,0 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * This has to be a empty file
- * @see https://github.com/MLH-Fellowship/jest-runner-tsd/blob/e25720040939fc79ab38d73c1495be90d5b92566/README.md#for-typescript-projects
- */

--- a/test-types/top-level-config.test.ts
+++ b/test-types/top-level-config.test.ts
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @type ./empty.d.ts
  */
 
 import {expectAssignable} from 'mlh-tsd';

--- a/test-types/top-level-expect-namespace.test.ts
+++ b/test-types/top-level-expect-namespace.test.ts
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @type ./empty.d.ts
  */
 
 import {expectError, expectType} from 'mlh-tsd';

--- a/test-types/top-level-globals.test.ts
+++ b/test-types/top-level-globals.test.ts
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @type ./empty.d.ts
  */
 
 import {expectError, expectType} from 'mlh-tsd';

--- a/test-types/top-level-jest-namespace.test.ts
+++ b/test-types/top-level-jest-namespace.test.ts
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @type ./empty.d.ts
  */
 
 import {expectError, expectType} from 'mlh-tsd';


### PR DESCRIPTION
## Summary

It looks like the `empty.d.ts` file in type tests does nothing. I think it can be removed safely just to have less noise around.

Here is why. By design `tsd` is running type checks (or test) on `.d.ts` type definition files. Not on `.ts` source, but on `.d.ts` inside the build artefact. Here in `jest` repo the type tests are set up exactly like this – the build files are tested.

The `empty.d.ts` is unofficial work around to run tests on `.ts` files. The thing is that `tsd` needs to have have some `.d.ts` to work. Install `tsd` in an empty folder and run `yarn tsd`. It will throw: "The type definition `index.d.ts` does not exist. Create one and try again." If an empty `index.d.ts` is added, `tsd` will complain that it can’t find any test.

Now the interesting part – add a test, but keep `index.d.ts` empty. Error: "./index.d.ts is not a module." That’s right! It has no exports, because we kept it empty. Now look at `empty.d.ts` file in this repo. No exports. Seems like this even isn’t valid `.d.ts`. Or?

After playing more with `tsd` I think that `empty.d.ts` is redundant in this repo. Might be I missed something. So let’s check what CI thinks.

In general this PR changes nothing. It is just a clean up with very long explanation. Thanks for reading (;

## Test plan

After removal all works as expected locally. I was running type test before and after the change with Jest’s cache cleaned and the result is the same. Here I included failing test to avoid false positive. On CI nothing should fail.

<img width="769" alt="Screenshot 2021-10-16 at 14 05 23" src="https://user-images.githubusercontent.com/72159681/137584852-5c65e13a-f213-40cd-9f47-27e0f45f16dc.png">

