### PR TITLE
fix(expect): allow `expect.Matchers` generic with single value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[expect]` Allow again `expect.Matchers` generic with single value ([#11986](https://github.com/facebook/jest/pull/11986))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -431,7 +431,7 @@ const expectExport = expect as Expect;
 
 declare namespace expectExport {
   export type MatcherState = JestMatcherState;
-  export interface Matchers<R, T> extends MatcherInterface<R, T> {}
+  export interface Matchers<R, T = unknown> extends MatcherInterface<R, T> {}
 }
 
 export = expectExport;

--- a/test-types/expect.test.ts
+++ b/test-types/expect.test.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type * as expect from 'expect';
+
+export type M = expect.Matchers<void, unknown>;
+export type N = expect.Matchers<void>;
+// @ts-expect-error
+export type E = expect.Matchers<>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes https://github.com/facebook/jest/issues/11985

This broke e.g. the Playwright project.

## Test plan

Not sure how to provide tests for this.
