### PR TITLE
fix: avoid unhandled promise rejections when concurrent tests fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-circus, jest-jasmine2]` Avoid false concurrent test failures due to unhandled promise rejections
+- `[jest-circus, jest-jasmine2]` Avoid false concurrent test failures due to unhandled promise rejections ([#11987](https://github.com/facebook/jest/pull/11987))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-circus, jest-jasmine2]` Avoid false concurrent test failures due to unhandled promise rejections
+
 ### Chore & Maintenance
 
 ### Performance

--- a/e2e/__tests__/jasmineAsync.test.ts
+++ b/e2e/__tests__/jasmineAsync.test.ts
@@ -168,4 +168,13 @@ describe('async jasmine', () => {
 
     expect(result.exitCode).toBe(0);
   });
+
+  it('works when another test fails while one is running', () => {
+    const {json} = runWithJson('jasmine-async', [
+      'concurrent-parallel-failure.test.js',
+    ]);
+    expect(json.numTotalTests).toBe(2);
+    expect(json.numPassedTests).toBe(1);
+    expect(json.numFailedTests).toBe(1);
+  });
 });

--- a/e2e/jasmine-async/__tests__/concurrent-parallel-failure.test.js
+++ b/e2e/jasmine-async/__tests__/concurrent-parallel-failure.test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it.concurrent('Good Test', async () => {
+  await new Promise(r => setTimeout(r, 100));
+});
+
+it.concurrent('Bad Test', async () => {
+  expect('a').toBe('b');
+});

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -93,6 +93,9 @@ export const initialize = async ({
       // that will result in this test to be skipped, so we'll be executing the promise function anyway,
       // even if it ends up being skipped.
       const promise = mutex(() => testFn());
+      // Avoid triggering the uncaught promise rejection handler in case the test errors before
+      // being awaited on.
+      promise.catch(() => {});
       globalsObject.test(testName, () => promise, timeout);
     };
 

--- a/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
+++ b/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
@@ -215,6 +215,9 @@ function makeConcurrent(
     } catch (error: unknown) {
       promise = Promise.reject(error);
     }
+    // Avoid triggering the uncaught promise rejection handler in case the test errors before
+    // being awaited on.
+    promise.catch(() => {});
 
     return spec;
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This change fixes an issue where a failing `concurrent` test could trigger the global unhandled promise rejection handler, which would then attribute this failure to a different test (the one that was currently "running" i.e. the one that Jest was currently awaiting on). The issue is present in both jest-jasmine2 and jest-circus.

You can also check existing bug reports (#11691, #11231) for examples.

Fixes #11691
Fixes #11231

## Test plan

There is a new integration test that demonstrates the issue.
