### PR TITLE
fix(jest-transform): improve runtime errors and warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[expect]` Allow again `expect.Matchers` generic with single value ([#11986](https://github.com/facebook/jest/pull/11986))
+- `[jest-transform]` Improve the invalid transformer module error message ([#11998](https://github.com/facebook/jest/pull/11998))
 
 ### Chore & Maintenance
 

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -486,14 +486,14 @@ describe('ScriptTransformer', () => {
     await Promise.all([...promisesToReject, ...promisesToResolve]);
   });
 
-  it('throws an error if neither `process` nor `processAsync is defined', async () => {
+  it('throws an error if neither `process` nor `processAsync` is defined', async () => {
     config = {
       ...config,
       transform: [['\\.js$', 'skipped-required-props-preprocessor', {}]],
     };
-    await expect(() => createScriptTransformer(config)).rejects.toThrow(
-      'Jest: a transform must export a `process` or `processAsync` function.',
-    );
+    await expect(() =>
+      createScriptTransformer(config),
+    ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it("(in sync mode) throws an error if `process` isn't defined", async () => {
@@ -537,9 +537,9 @@ describe('ScriptTransformer', () => {
         ],
       ],
     };
-    await expect(() => createScriptTransformer(config)).rejects.toThrow(
-      'Jest: a transform must export a `process` or `processAsync` function.',
-    );
+    await expect(() =>
+      createScriptTransformer(config),
+    ).rejects.toThrowErrorMatchingSnapshot();
   });
 
   it("shouldn't throw error without process method. But with correct createTransformer method", async () => {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -506,9 +506,7 @@ describe('ScriptTransformer', () => {
     const scriptTransformer = await createScriptTransformer(config);
     expect(() =>
       scriptTransformer.transformSource('sample.js', '', {instrument: false}),
-    ).toThrow(
-      'Jest: synchronous transformer skipped-required-props-preprocessor-only-async must export a "process" function.',
-    );
+    ).toThrowErrorMatchingSnapshot();
   });
 
   it('(in async mode) handles only sync `process`', async () => {

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -340,6 +340,26 @@ exports[`ScriptTransformer passes expected transform options to getCacheKeyAsync
 }
 `;
 
+exports[`ScriptTransformer throws an error if createTransformer returns object without \`process\` method 1`] = `
+"<red><bold>● Invalid transformer module:</></>
+<red>  \\"skipped-required-create-transformer-props-preprocessor\\" specified in the \\"transform\\" object of Jest configuration</>
+<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
+<red></>
+<red>  Code Transformation Documentation:</>
+<red>  https://jestjs.io/docs/code-transformation</>
+<red></>"
+`;
+
+exports[`ScriptTransformer throws an error if neither \`process\` nor \`processAsync\` is defined 1`] = `
+"<red><bold>● Invalid transformer module:</></>
+<red>  \\"skipped-required-props-preprocessor\\" specified in the \\"transform\\" object of Jest configuration</>
+<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
+<red></>
+<red>  Code Transformation Documentation:</>
+<red>  https://jestjs.io/docs/code-transformation</>
+<red></>"
+`;
+
 exports[`ScriptTransformer transforms a file async properly 1`] = `
 /* istanbul ignore next */
 function cov_25u22311x4() {

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScriptTransformer (in sync mode) throws an error if \`process\` isn't defined 1`] = `
+"<red><bold>● Invalid synchronous transformer module:</></>
+<red>  \\"skipped-required-props-preprocessor-only-async\\" specified in the \\"transform\\" object of Jest configuration</>
+<red>  must export a \`process\` function.</>
+<red>  <bold>Code Transformation Documentation:</></>
+<red>  https://jestjs.io/docs/code-transformation</>
+<red></>"
+`;
+
 exports[`ScriptTransformer in async mode, passes expected transform options to getCacheKey 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -126,7 +135,11 @@ const TRANSFORMED = {
 
 exports[`ScriptTransformer in async mode, uses the supplied preprocessor 2`] = `module.exports = "react";`;
 
-exports[`ScriptTransformer in async mode, warns of unparseable inlined source maps from the preprocessor 1`] = `jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file.`;
+exports[`ScriptTransformer in async mode, warns of unparseable inlined source maps from the preprocessor 1`] = `
+[33m[1m● Invalid source map:[22m[39m
+[33m  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.[39m
+[33m  Proceeding without source mapping for that file.[39m
+`;
 
 exports[`ScriptTransformer passes expected transform options to getCacheKey 1`] = `
 [MockFunction] {
@@ -344,8 +357,7 @@ exports[`ScriptTransformer throws an error if createTransformer returns object w
 "<red><bold>● Invalid transformer module:</></>
 <red>  \\"skipped-required-create-transformer-props-preprocessor\\" specified in the \\"transform\\" object of Jest configuration</>
 <red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
-<red></>
-<red>  Code Transformation Documentation:</>
+<red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
 `;
@@ -354,8 +366,7 @@ exports[`ScriptTransformer throws an error if neither \`process\` nor \`processA
 "<red><bold>● Invalid transformer module:</></>
 <red>  \\"skipped-required-props-preprocessor\\" specified in the \\"transform\\" object of Jest configuration</>
 <red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
-<red></>
-<red>  Code Transformation Documentation:</>
+<red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
 `;
@@ -708,6 +719,14 @@ const TRANSFORMED = {
 
 exports[`ScriptTransformer uses the supplied preprocessor 2`] = `module.exports = "react";`;
 
-exports[`ScriptTransformer warns of unparseable inlined source maps from the async preprocessor 1`] = `jest-transform: The source map produced for the file /fruits/banana.js by async-preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file.`;
+exports[`ScriptTransformer warns of unparseable inlined source maps from the async preprocessor 1`] = `
+[33m[1m● Invalid source map:[22m[39m
+[33m  The source map for "/fruits/banana.js" returned by "async-preprocessor-with-sourcemaps" is invalid.[39m
+[33m  Proceeding without source mapping for that file.[39m
+`;
 
-exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file.`;
+exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `
+[33m[1m● Invalid source map:[22m[39m
+[33m  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.[39m
+[33m  Proceeding without source mapping for that file.[39m
+`;

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -1,0 +1,60 @@
+import chalk = require('chalk');
+import slash = require('slash');
+
+const BULLET = '\u25cf ';
+const DOCUMENTATION_NOTE = `  ${chalk.bold(
+  'Code Transformation Documentation:',
+)}
+  https://jestjs.io/docs/code-transformation
+`;
+
+export const makeInvalidReturnValueError = (): string =>
+  chalk.red(
+    [
+      chalk.bold(BULLET + 'Invalid return value:'),
+      `  Code transformer's \`process\` function must return a string or an object`,
+      '  with `code` key containing a string. If `processAsync` function is implemented,',
+      '  it must return a Promise resolving to one of these values.',
+      '',
+    ].join('\n') + DOCUMENTATION_NOTE,
+  );
+
+export const makeInvalidSourceMapWarning = (
+  filename: string,
+  transformPath: string,
+): string =>
+  chalk.yellow(
+    [
+      chalk.bold(BULLET + 'Invalid source map:'),
+      `  The source map for "${slash(filename)}" returned by "${slash(
+        transformPath,
+      )}" is invalid.`,
+      '  Proceeding without source mapping for that file.',
+    ].join('\n'),
+  );
+
+export const makeInvalidSyncTransformerError = (
+  transformPath: string,
+): string =>
+  chalk.red(
+    [
+      chalk.bold(BULLET + 'Invalid synchronous transformer module:'),
+      `  "${slash(
+        transformPath,
+      )}" specified in the "transform" object of Jest configuration`,
+      '  must export a `process` function.',
+      '',
+    ].join('\n') + DOCUMENTATION_NOTE,
+  );
+
+export const makeInvalidTransformerError = (transformPath: string): string =>
+  chalk.red(
+    [
+      chalk.bold(BULLET + 'Invalid transformer module:'),
+      `  "${slash(
+        transformPath,
+      )}" specified in the "transform" object of Jest configuration`,
+      '  must export a `process` or `processAsync` or `createTransformer` function.',
+      '',
+    ].join('\n') + DOCUMENTATION_NOTE,
+  );

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import chalk = require('chalk');
 import slash = require('slash');
 


### PR DESCRIPTION
## Summary

Resolves #11955

It would be useful to provide more information if a user is attempting to import an invalid transformer module. Current message does not specify modules name. Hence, it may be hard to identify the problem.

This PR is an attempt to improve the error message.

## Test plan

Updated the existing tests.