### PR TITLE
chore(jest-runtime): `runtime.unstable_importModule` should not return `Promise<void>`

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -622,7 +622,7 @@ export default class Runtime {
   async unstable_importModule(
     from: Config.Path,
     moduleName?: string,
-  ): Promise<void> {
+  ): Promise<VMModule | void> {
     invariant(
       runtimeSupportsVmModules,
       'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/ecmascript-modules',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The `linkAndEvaluateModule(...)` method returns `Promise<VMModule | void>` , so `unstable_importModule(...)` should returns the same type.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

No. Just a simple type modification.
