### PR TITLE
fix(eslint): use eslint-import-resolver-typescript to fix import/no-unresolved

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -485,5 +485,8 @@ module.exports = {
     'import/internal-regex': new RegExp(
       internalPackages.map(pkg => `^${pkg}$`).join('|'),
     ).source,
+    'import/resolver': {
+      typescript: {},
+    },
   },
 };

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -18,9 +18,11 @@ import staticImportedStatefulFromCjs from '../fromCjs.mjs';
 import {double} from '../index';
 import defaultFromCjs, {half, namedFunction} from '../namedExport.cjs';
 import {bag} from '../namespaceExport.js';
+/* eslint-disable import/no-duplicates */
 import staticImportedStateful from '../stateful.mjs';
 import staticImportedStatefulWithQuery from '../stateful.mjs?query=1';
 import staticImportedStatefulWithAnotherQuery from '../stateful.mjs?query=2';
+/* eslint-enable import/no-duplicates */
 
 test('should have correct import.meta', () => {
   expect(typeof require).toBe('undefined');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "dedent": "^0.7.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.6.0",
     "eslint-plugin-jest": "^24.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,7 @@ __metadata:
     dedent: ^0.7.0
     eslint: ^7.7.0
     eslint-config-prettier: ^8.1.0
+    eslint-import-resolver-typescript: ^2.5.0
     eslint-plugin-eslint-comments: ^3.1.2
     eslint-plugin-import: ^2.6.0
     eslint-plugin-jest: ^24.0.0
@@ -9211,6 +9212,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-import-resolver-typescript@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "eslint-import-resolver-typescript@npm:2.5.0"
+  dependencies:
+    debug: ^4.3.1
+    glob: ^7.1.7
+    is-glob: ^4.0.1
+    resolve: ^1.20.0
+    tsconfig-paths: ^3.9.0
+  peerDependencies:
+    eslint: "*"
+    eslint-plugin-import: "*"
+  checksum: c13542b1f6283ac354c151f11f5e6e6fb69471ed66c6b6491a72a1ead3504404bf3dca830c9b093e26d419c89ee48433ba45cab1e3a1c3fb968fc7ffa9454cad
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.6.2":
   version: 2.6.2
   resolution: "eslint-module-utils@npm:2.6.2"
@@ -10743,7 +10760,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.1.7":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -21002,7 +21019,7 @@ react-native@0.64.0:
   languageName: node
   linkType: hard
 
-"tsconfig-paths@npm:^3.11.0":
+"tsconfig-paths@npm:^3.11.0, tsconfig-paths@npm:^3.9.0":
   version: 3.11.0
   resolution: "tsconfig-paths@npm:3.11.0"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

#12011

In [the TypeScript section](https://github.com/import-js/eslint-plugin-import#typescript) of `eslint-plugin-import`'s README, they say "You will also need to install and configure the TypeScript resolver: eslint-import-resolver-typescript."
It uses `paths` defined in `tsconfig.json` to help resolving the packages.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`yarn lint` on my machine returns no errors.