### PR TITLE
Replaced module with namespace

### DIFF
--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -21,7 +21,7 @@ export const TEST_TIMEOUT_SYMBOL = Symbol.for(
 ) as unknown as 'TEST_TIMEOUT_SYMBOL';
 
 declare global {
-  module NodeJS {
+  namespace NodeJS {
     interface Global {
       STATE_SYM_SYMBOL: Circus.State;
       RETRY_TIMES_SYMBOL: string;

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -93,7 +93,7 @@ export type Jasmine = {
   typeof globalThis;
 
 declare global {
-  module NodeJS {
+  namespace NodeJS {
     interface Global {
       expect: typeof expect;
     }


### PR DESCRIPTION
In an effort to prevent further confusion between custom TypeScript modules and the new ES2015 modules, starting with TypeScript v1.5 the keyword namespace is now the preferred way to declare custom TypeScript modules.


therefore `module`  can be replaced with `namespace`