### PR TITLE
fix: Incorrect detection of open ZLIB handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 - `[expect]` Allow again `expect.Matchers` generic with single value ([#11986](https://github.com/facebook/jest/pull/11986))
+- `[jest-core]` Incorrect detection of open ZLIB handles ([#12022](https://github.com/facebook/jest/pull/12022))
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
 - `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
 

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -9,6 +9,7 @@
 import {promises as dns} from 'dns';
 import http from 'http';
 import {PerformanceObserver} from 'perf_hooks';
+import zlib from 'zlib';
 import collectHandles from '../collectHandles';
 
 describe('collectHandles', () => {
@@ -49,6 +50,20 @@ describe('collectHandles', () => {
 
     expect(openHandles).not.toContainEqual(
       expect.objectContaining({message: 'DNSCHANNEL'}),
+    );
+  });
+
+  it('should not collect the ZLIB open handle', async () => {
+    const handleCollector = collectHandles();
+
+    const decompressed = zlib.inflateRawSync(
+      Buffer.from('cb2a2d2e5128492d2ec9cc4b0700', 'hex'),
+    );
+
+    const openHandles = await handleCollector();
+
+    expect(openHandles).not.toContainEqual(
+      expect.objectContaining({message: 'ZLIB'}),
     );
   });
 

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -71,7 +71,8 @@ export default function collectHandles(): HandleCollectionResult {
         type === 'ELDHISTOGRAM' ||
         type === 'PerformanceObserver' ||
         type === 'RANDOMBYTESREQUEST' ||
-        type === 'DNSCHANNEL'
+        type === 'DNSCHANNEL' ||
+        type === 'ZLIB'
       ) {
         return;
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

It appears that some calls into `zlib` are detected as incorrectly being open. This change ignores open handles in the ZLIB context.

Fixes #11542

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I added a test for this specific scenario. Before this change is applied, the test fails as expected. With this change applied, the test passes.

![image](https://user-images.githubusercontent.com/1658949/139860509-de85cb67-b828-476c-aabf-7d34142a0ac9.png)
