### PR TITLE
Removed db.close()

### DIFF
--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {

--- a/website/versioned_docs/version-25.x/MongoDB.md
+++ b/website/versioned_docs/version-25.x/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {

--- a/website/versioned_docs/version-26.x/MongoDB.md
+++ b/website/versioned_docs/version-26.x/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {

--- a/website/versioned_docs/version-27.0/MongoDB.md
+++ b/website/versioned_docs/version-27.0/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {

--- a/website/versioned_docs/version-27.1/MongoDB.md
+++ b/website/versioned_docs/version-27.1/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {

--- a/website/versioned_docs/version-27.2/MongoDB.md
+++ b/website/versioned_docs/version-27.2/MongoDB.md
@@ -41,7 +41,6 @@ describe('insert', () => {
 
   afterAll(async () => {
     await connection.close();
-    await db.close();
   });
 
   it('should insert a doc into collection', async () => {


### PR DESCRIPTION
removed db.close() because it's is not defined. "close()" is not a function of an instance of Db class from the official MongoDB driver API.