### PR TITLE
Removed explicit type declarations

### DIFF
--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -60,7 +60,7 @@ function spawnJest(
   args: Array<string> = [],
   options: RunJestOptions = {},
   spawnAsync = false,
-  ): execa.ExecaSyncReturnValue | execa.ExecaChildProcess {
+): execa.ExecaSyncReturnValue | execa.ExecaChildProcess {
   const isRelative = !path.isAbsolute(dir);
 
   if (isRelative) {

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -59,8 +59,8 @@ function spawnJest(
   dir: string,
   args: Array<string> = [],
   options: RunJestOptions = {},
-  spawnAsync: boolean = false,
-): execa.ExecaSyncReturnValue | execa.ExecaChildProcess {
+  spawnAsync = false,
+  ): execa.ExecaSyncReturnValue | execa.ExecaChildProcess {
   const isRelative = !path.isAbsolute(dir);
 
   if (isRelative) {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -138,7 +138,7 @@ class Anything extends AsymmetricMatcher<void> {
 }
 
 class ArrayContaining extends AsymmetricMatcher<Array<unknown>> {
-  constructor(sample: Array<unknown>, inverse: boolean = false) {
+  constructor(sample: Array<unknown>, inverse = false) {
     super(sample, inverse);
   }
 
@@ -171,7 +171,7 @@ class ArrayContaining extends AsymmetricMatcher<Array<unknown>> {
 }
 
 class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
-  constructor(sample: Record<string, unknown>, inverse: boolean = false) {
+  constructor(sample: Record<string, unknown>, inverse = false) {
     super(sample, inverse);
   }
 
@@ -209,7 +209,7 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
 }
 
 class StringContaining extends AsymmetricMatcher<string> {
-  constructor(sample: string, inverse: boolean = false) {
+  constructor(sample: string, inverse = false) {
     if (!isA('String', sample)) {
       throw new Error('Expected is not a string');
     }
@@ -232,7 +232,7 @@ class StringContaining extends AsymmetricMatcher<string> {
 }
 
 class StringMatching extends AsymmetricMatcher<RegExp> {
-  constructor(sample: string | RegExp, inverse: boolean = false) {
+  constructor(sample: string | RegExp, inverse = false) {
     if (!isA('String', sample) && !isA('RegExp', sample)) {
       throw new Error('Expected is not a String or a RegExp');
     }

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -69,7 +69,7 @@ export const setMatchers = <State extends MatcherState = MatcherState>(
         State
       > {
         constructor(
-          inverse: boolean = false,
+          inverse = false,
           ...sample: [unknown, ...Array<unknown>]
         ) {
           super(sample, inverse);

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -68,10 +68,7 @@ export const setMatchers = <State extends MatcherState = MatcherState>(
         [unknown, ...Array<unknown>],
         State
       > {
-        constructor(
-          inverse = false,
-          ...sample: [unknown, ...Array<unknown>]
-        ) {
+        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
           super(sample, inverse);
         }
 

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -126,7 +126,7 @@ const matchers: MatchersObject = {
     return {actual: received, expected, message, name: matcherName, pass};
   },
 
-  toBeCloseTo(received: number, expected: number, precision: number = 2) {
+  toBeCloseTo(received: number, expected: number, precision = 2) {
     const matcherName = 'toBeCloseTo';
     const secondArgument = arguments.length === 3 ? 'precision' : undefined;
     const isNot = this.isNot;

--- a/packages/jest-cli/src/init/generateConfigFile.ts
+++ b/packages/jest-cli/src/init/generateConfigFile.ts
@@ -12,7 +12,7 @@ const stringifyOption = (
   option: keyof Config.InitialOptions,
   map: Partial<Config.InitialOptions>,
   linePrefix = '',
-  ): string => {
+): string => {
   const optionDescription = `  // ${descriptions[option]}`;
   const stringifiedObject = `${option}: ${JSON.stringify(
     map[option],

--- a/packages/jest-cli/src/init/generateConfigFile.ts
+++ b/packages/jest-cli/src/init/generateConfigFile.ts
@@ -11,8 +11,8 @@ import {defaults, descriptions} from 'jest-config';
 const stringifyOption = (
   option: keyof Config.InitialOptions,
   map: Partial<Config.InitialOptions>,
-  linePrefix: string = '',
-): string => {
+  linePrefix = '',
+  ): string => {
   const optionDescription = `  // ${descriptions[option]}`;
   const stringifiedObject = `${option}: ${JSON.stringify(
     map[option],

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -48,7 +48,7 @@ export default async (
   }
 
   const questions = defaultQuestions.slice(0);
-  let hasJestProperty: boolean = false;
+  let hasJestProperty = false;
   let projectPackageJson: ProjectPackageJson;
 
   try {
@@ -99,7 +99,7 @@ export default async (
     ),
   );
 
-  let promptAborted: boolean = false;
+  let promptAborted = false;
 
   // @ts-expect-error: Return type cannot be object - faulty typings
   const results: PromptsResults = await prompts(questions, {

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -43,7 +43,7 @@ export async function readConfig(
   // read individual configs for every project.
   skipArgvConfigOption?: boolean,
   parentConfigDirname?: Config.Path | null,
-  projectIndex: number = Infinity,
+  projectIndex = Infinity,
   skipMultipleConfigWarning = false,
 ): Promise<ReadConfig> {
   let rawOptions: Config.InitialOptions;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -551,8 +551,8 @@ export default async function normalize(
   initialOptions: Config.InitialOptions,
   argv: Config.Argv,
   configPath?: Config.Path | null,
-  projectIndex: number = Infinity,
-): Promise<{
+  projectIndex = Infinity,
+  ): Promise<{
   hasDeprecationWarnings: boolean;
   options: AllOptions;
 }> {

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -552,7 +552,7 @@ export default async function normalize(
   argv: Config.Argv,
   configPath?: Config.Path | null,
   projectIndex = Infinity,
-  ): Promise<{
+): Promise<{
   hasDeprecationWarnings: boolean;
   options: AllOptions;
 }> {


### PR DESCRIPTION
Explicit types where they can be easily inferred may add unnecessary verbosity for variables or parameters initialized to a number, string, or boolean, so this PR furthers remove it