### PR TITLE
fix(docs): add missing table of contents to The Jest Object documentation page

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -443,7 +451,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -570,7 +578,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -439,7 +447,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -566,7 +574,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers()`
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -443,7 +451,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -570,7 +578,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 

--- a/website/versioned_docs/version-27.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.0/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -443,7 +451,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -570,7 +578,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 

--- a/website/versioned_docs/version-27.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.1/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -443,7 +451,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -570,7 +578,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 

--- a/website/versioned_docs/version-27.2/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.2/JestObjectAPI.md
@@ -5,6 +5,14 @@ title: The Jest Object
 
 The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
+## Methods
+
+import TOCInline from "@theme/TOCInline"
+
+<TOCInline toc={toc.slice(1)}/>
+
+---
+
 ## Mock Modules
 
 ### `jest.disableAutomock()`
@@ -443,7 +451,7 @@ jest.isolateModules(() => {
 const otherCopyOfMyModule = require('myModule');
 ```
 
-## Mock functions
+## Mock Functions
 
 ### `jest.fn(implementation)`
 
@@ -570,7 +578,7 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-## Mock timers
+## Mock Timers
 
 ### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 


### PR DESCRIPTION
## Summary

The Jest Object documentation page is missing table of contents.

All other similar pages have it (see Globals, Expect, Mock Functions, etc). Simple and useful fix.

## Test plan

N/A