### PR TITLE
feat(jest-runner): allow `setupFiles` module to export an async function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-resolve]` [**BREAKING**] Add support for `package.json` `exports` ([#11961](https://github.com/facebook/jest/pull/11961), [#12373](https://github.com/facebook/jest/pull/12373))
 - `[jest-resolve, jest-runtime]` Add support for `data:` URI import and mock ([#12392](https://github.com/facebook/jest/pull/12392))
 - `[jest-resolve, jest-runtime]` Add support for async resolver ([#11540](https://github.com/facebook/jest/pull/11540))
+- `[jest-runner]` Allow `setupFiles` module to export an async function ([#12042](https://github.com/facebook/jest/pull/12042))
 - `[jest-runner]` Allow passing `testEnvironmentOptions` via docblocks ([#12470](https://github.com/facebook/jest/pull/12470))
 - `[jest-runtime]` [**BREAKING**] `Runtime.createHasteMap` now returns a promise ([#12008](https://github.com/facebook/jest/pull/12008))
 - `[@jest/schemas]` New module for JSON schemas for Jest's config ([#12384](https://github.com/facebook/jest/pull/12384))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -925,7 +925,7 @@ Default: `[]`
 
 A list of paths to modules that run some code to configure or set up the testing environment. Each setupFile will be run once per test file. Since every test runs in its own environment, these scripts will be executed in the testing environment before executing [`setupFilesAfterEnv`](#setupfilesafterenv-array) and before the test code itself.
 
-:::note
+:::tip
 
 If your setup script is a CJS module, it may export an async function. Jest will call the function and will await for the result. This might be useful to fetch some data asynchronously. In case of ESM module, simply use top-level await to achieve the same result.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -927,7 +927,7 @@ A list of paths to modules that run some code to configure or set up the testing
 
 :::tip
 
-If your setup script is a CJS module, it may export an async function. Jest will call the function and will await for the result. This might be useful to fetch some data asynchronously. In case of ESM module, simply use top-level await to achieve the same result.
+If your setup script is a CJS module, it may export an async function. Jest will call the function and await its result. This might be useful to fetch some data asynchronously. If the file is an ESM module, simply use top-level await to achieve the same result.
 
 :::
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -925,6 +925,12 @@ Default: `[]`
 
 A list of paths to modules that run some code to configure or set up the testing environment. Each setupFile will be run once per test file. Since every test runs in its own environment, these scripts will be executed in the testing environment before executing [`setupFilesAfterEnv`](#setupfilesafterenv-array) and before the test code itself.
 
+:::note
+
+If your setup script is a CJS module, it may export an async function. Jest will call the function and will await for the result. This might be useful to fetch some data asynchronously. In case of ESM module, simply use top-level await to achieve the same result.
+
+:::
+
 ### `setupFilesAfterEnv` \[array]
 
 Default: `[]`

--- a/e2e/__tests__/setupFiles.test.ts
+++ b/e2e/__tests__/setupFiles.test.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('invokes async function exported from `setupFiles` module', () => {
+  const result = runJest('setup-files');
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/setup-files/__tests__/setup.test.js
+++ b/e2e/setup-files/__tests__/setup.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fetchedData = require('../fetched-data');
+
+test('fetches mock data', () => {
+  expect(fetchedData.RESPONSE).toBe('mock-fetched-data');
+});

--- a/e2e/setup-files/fetched-data.js
+++ b/e2e/setup-files/fetched-data.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  RESPONSE: 'not-yet-received',
+};

--- a/e2e/setup-files/package.json
+++ b/e2e/setup-files/package.json
@@ -1,0 +1,7 @@
+{
+  "jest": {
+    "setupFiles": [
+      "./setup-fetchdata.js"
+    ]
+  }
+}

--- a/e2e/setup-files/setup-fetchdata.js
+++ b/e2e/setup-files/setup-fetchdata.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const fetchedData = require('./fetched-data');
+
+function mockFetchData(mockData) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(mockData);
+    }, 2000);
+  });
+}
+
+module.exports = async () => {
+  const response = await mockFetchData('mock-fetched-data');
+  fetchedData.RESPONSE = response;
+};

--- a/packages/jest-repl/src/cli/runtime-cli.ts
+++ b/packages/jest-repl/src/cli/runtime-cli.ts
@@ -115,7 +115,6 @@ export async function run(
       if (esm) {
         await runtime.unstable_importModule(path);
       } else {
-        runtime.requireModule(path);
         const setupFile = runtime.requireModule(path);
         if (typeof setupFile === 'function') {
           await setupFile();

--- a/packages/jest-repl/src/cli/runtime-cli.ts
+++ b/packages/jest-repl/src/cli/runtime-cli.ts
@@ -116,8 +116,13 @@ export async function run(
         await runtime.unstable_importModule(path);
       } else {
         runtime.requireModule(path);
+        const setupFile = runtime.requireModule(path);
+        if (typeof setupFile === 'function') {
+          await setupFile();
+        }
       }
     }
+
     const esm = runtime.unstable_shouldLoadAsEsm(filePath);
 
     if (esm) {

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -207,7 +207,10 @@ async function runTestInternal(
     if (esm) {
       await runtime.unstable_importModule(path);
     } else {
-      runtime.requireModule(path);
+      const setupFile = runtime.requireModule(path);
+      if (typeof setupFile === 'function') {
+        await setupFile();
+      }
     }
   }
 


### PR DESCRIPTION
Closes #11038

## Summary

As it is described in the issue, async function in `setupFiles` modules might be useful to fetch data asynchronously.

I do not think it is the best place to set up a database, because there is no way to tear it down later without some additional script. But fetching some fixture data and temporary storing it in an object would work.

~~The implementation is only targeting CJS modules, because (as it was pointed out in the issue) ESM modules allow top-level await. In way this PR simply enables CJS users to have similar functionality as ESM user have.~~

## Test plan

Integration test is added.