### PR TITLE
docs: changed 'before' and 'after' ---> 'beforeAll' and 'afterAll'

### DIFF
--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 

--- a/website/versioned_docs/version-25.x/SetupAndTeardown.md
+++ b/website/versioned_docs/version-25.x/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 

--- a/website/versioned_docs/version-26.x/SetupAndTeardown.md
+++ b/website/versioned_docs/version-26.x/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 

--- a/website/versioned_docs/version-27.0/SetupAndTeardown.md
+++ b/website/versioned_docs/version-27.0/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 

--- a/website/versioned_docs/version-27.1/SetupAndTeardown.md
+++ b/website/versioned_docs/version-27.1/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 

--- a/website/versioned_docs/version-27.2/SetupAndTeardown.md
+++ b/website/versioned_docs/version-27.2/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeAll` and `afterAll` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeAll` and `afterAll` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 


### PR DESCRIPTION
Simple doc update to Setup and Teardown

While reading, I was confused by references to before and after, which have been removed. It seems like these should be beforeAll and afterAll instead of before and after. Alternatively, we could use before* like in the Order of execution step, but it seems like beforeAll/afterAll are the better fit here.