### PR TITLE
replaced `substr` with `substring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
 - `[jest-environment-jsdom]` Do not reset the global.document too early on teardown ([#11871](https://github.com/facebook/jest/pull/11871))
 - `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
+- `[jest-config, jest-haste-map, jest-snapshot, jest-transform]` replaced string substr(deprecated) method  with substring ([#12066](https://github.com/facebook/jest/pull/12066))
+
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
 - `[jest-environment-jsdom]` Do not reset the global.document too early on teardown ([#11871](https://github.com/facebook/jest/pull/11871))
 - `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
-- `[jest-config, jest-haste-map, jest-snapshot, jest-transform]` replaced string substr(deprecated) method  with substring ([#12066](https://github.com/facebook/jest/pull/12066))
-
 
 ### Chore & Maintenance
+
+- `[*]` Replaced `substr` method with `substring` ([#12066](https://github.com/facebook/jest/pull/12066))
 
 ### Performance
 

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -65,7 +65,7 @@ export const replaceRootDirInPath = (
 
   return path.resolve(
     rootDir,
-    path.normalize('./' + filePath.substr('<rootDir>'.length)),
+    path.normalize('./' + filePath.substring('<rootDir>'.length)),
   );
 };
 

--- a/packages/jest-haste-map/src/lib/fast_path.ts
+++ b/packages/jest-haste-map/src/lib/fast_path.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 // rootDir and filename must be absolute paths (resolved)
 export function relative(rootDir: string, filename: string): string {
   return filename.indexOf(rootDir + path.sep) === 0
-    ? filename.substr(rootDir.length + 1)
+    ? filename.substring(rootDir.length + 1)
     : path.relative(rootDir, filename);
 }
 

--- a/packages/jest-haste-map/src/worker.ts
+++ b/packages/jest-haste-map/src/worker.ts
@@ -63,7 +63,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
     } catch (err: any) {
       throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`);
     }
-  } else if (!blacklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
+  } else if (!blacklist.has(filePath.substring(filePath.lastIndexOf('.')))) {
     // Process a random file that is returned as a MODULE.
     if (hasteImpl) {
       id = hasteImpl.getHasteName(filePath);

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -99,7 +99,7 @@ function stripAddedIndentation(inlineSnapshot: string) {
         return inlineSnapshot;
       }
 
-      lines[i] = lines[i].substr(indentation.length);
+      lines[i] = lines[i].substring(indentation.length);
     }
   }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -876,9 +876,9 @@ function readCodeCacheFile(cachePath: Config.Path): string | null {
   if (content == null) {
     return null;
   }
-  const code = content.substr(33);
+  const code = content.substring(33);
   const checksum = createHash('md5').update(code).digest('hex');
-  if (checksum === content.substr(0, 32)) {
+  if (checksum === content.substring(0, 32)) {
     return code;
   }
   return null;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

JS string substr  gives deprecated warning it should be avoided to use.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr


![code](https://user-images.githubusercontent.com/81867225/141694472-16a04255-af4e-4d5e-9c93-60460f27b7a1.png)

