### PR TITLE
jest-worker: Unable to customize thread execArgv with enableThreadWorkers

### DIFF
--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -125,7 +125,7 @@ export type WorkerOptions = {
   setupArgs: Array<unknown>;
   maxRetries: number;
   workerId: number;
-  workerData?: any;
+  workerData?: unknown;
   workerPath: string;
 };
 

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -125,6 +125,7 @@ export type WorkerOptions = {
   setupArgs: Array<unknown>;
   maxRetries: number;
   workerId: number;
+  workerData?: any;
   workerPath: string;
 };
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -7,10 +7,7 @@
 
 import * as path from 'path';
 import {PassThrough} from 'stream';
-import {
-  Worker,
-  WorkerOptions as WorkerThreadsWorkerOptions,
-} from 'worker_threads';
+import {Worker} from 'worker_threads';
 import mergeStream = require('merge-stream');
 import {
   CHILD_MESSAGE_INITIALIZE,

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -68,8 +68,7 @@ export default class ExperimentalWorker implements WorkerInterface {
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
       },
       eval: false,
-      // Suppress --debug / --inspect flags while preserving others (like --harmony).
-      execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
+      execArgv: process.execArgv,
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
       stderr: true,

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -51,7 +51,7 @@ afterEach(() => {
   process.execArgv = originalExecArgv;
 });
 
-it('passes fork options down to child_process.fork, adding the defaults', () => {
+it('passes fork options down to worker_threads.Worker, adding the defaults', () => {
   const thread = require.resolve('../threadChild');
 
   process.execArgv = ['--inspect', '-p'];
@@ -59,25 +59,28 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
   // eslint-disable-next-line no-new
   new Worker({
     forkOptions: {
-      cwd: '/tmp',
       execPath: 'hello',
     },
     maxRetries: 3,
+    workerData: {
+      foo: 'bar',
+    },
     workerId: process.env.JEST_WORKER_ID - 1,
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
   expect(workerThreads.mock.calls[0][0]).toBe(thread.replace(/\.ts$/, '.js'));
   expect(workerThreads.mock.calls[0][1]).toEqual({
+    env: process.env, // Default option.
     eval: false,
+    execArgv: ['-p'], // Filtered option.
+    execPath: 'hello', // Added option.
+    resourceLimits: undefined,
     stderr: true,
     stdout: true,
     workerData: {
-      cwd: '/tmp', // Overridden default option.
-      env: process.env, // Default option.
-      execArgv: ['-p'], // Filtered option.
-      execPath: 'hello', // Added option.
-      silent: true, // Default option.
+      // Added option.
+      foo: 'bar',
     },
   });
 });
@@ -91,9 +94,7 @@ it('passes workerId to the thread and assign it to env.JEST_WORKER_ID', () => {
     workerPath: '/tmp/foo',
   });
 
-  expect(workerThreads.mock.calls[0][1].workerData.env.JEST_WORKER_ID).toEqual(
-    '3',
-  );
+  expect(workerThreads.mock.calls[0][1].env.JEST_WORKER_ID).toEqual('3');
 });
 
 it('initializes the thread with the given workerPath', () => {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -73,7 +73,7 @@ it('passes fork options down to worker_threads.Worker, adding the defaults', () 
   expect(workerThreads.mock.calls[0][1]).toEqual({
     env: process.env, // Default option.
     eval: false,
-    execArgv: ['-p'], // Filtered option.
+    execArgv: ['--inspect', '-p'],
     execPath: 'hello', // Added option.
     resourceLimits: undefined,
     stderr: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently it's impossible to pass custom execArgv to a worker when `enableWorkerThreads` is on.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
The existing tests were enforcing less than ideal behavior, I've updated them to pass `forkOptions` as top-level properties to the worker constructor. `worker_threads` doesn't have `cwd` or `execPath` equivalents so I've dropped those properties from the tests.