### PR TITLE
docs(jest-matcher-utils): fix link

### DIFF
--- a/packages/jest-matcher-utils/README.md
+++ b/packages/jest-matcher-utils/README.md
@@ -9,7 +9,7 @@ To add this package as a dependency of a project, run either of the following co
 - `npm install jest-matcher-utils`
 - `yarn add jest-matcher-utils`
 
-## Exports ([src/index.ts](jest-matcher-utils/src/index.ts))
+## Exports ([src/index.ts](src/index.ts))
 
 ### Functions
 

--- a/packages/jest-matcher-utils/README.md
+++ b/packages/jest-matcher-utils/README.md
@@ -9,7 +9,7 @@ To add this package as a dependency of a project, run either of the following co
 - `npm install jest-matcher-utils`
 - `yarn add jest-matcher-utils`
 
-## Exports ([src/index.ts](src/index.ts))
+## Exports ([src/index.ts](https://github.com/facebook/jest/blob/HEAD/packages/jest-matcher-utils/src/index.ts))
 
 ### Functions
 


### PR DESCRIPTION
Minor, link to `src/index.ts` was broken