### PR TITLE
Add `types` entry in export map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `[jest-runner]` Add info regarding timers to forcedExit message([#12083](https://github.com/facebook/jest/pull/12083))
 - `[*]` Replaced `substr` method with `substring` ([#12066](https://github.com/facebook/jest/pull/12066))
+- `[*]` Add `types` entry to all export maps ([#12073](https://github.com/facebook/jest/pull/12073))
 
 ### Performance
 

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -11,7 +11,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -13,7 +13,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -21,7 +21,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json",
     "./build/utils": "./build/utils.js",
     "./build/matchers": "./build/matchers.js"

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json",
     "./runner": "./runner.js"
   },

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -5,7 +5,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json",
     "./bin/jest": "./bin/jest.js"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "peerDependencies": {

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -5,7 +5,10 @@
   "main": "./build/jest.js",
   "types": "./build/jest.d.ts",
   "exports": {
-    ".": "./build/jest.js",
+    ".": {
+      "types": "./build/jest.d.ts",
+      "default": "./build/jest.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-create-cache-key-function/package.json
+++ b/packages/jest-create-cache-key-function/package.json
@@ -20,7 +20,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -5,7 +5,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -14,7 +14,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jest-globals/package.json
+++ b/packages/jest-globals/package.json
@@ -13,7 +13,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -14,7 +14,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -13,7 +13,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -17,7 +17,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -8,7 +8,10 @@
   },
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -16,7 +16,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json",
     "./bin/jest-repl": "./bin/jest-repl.js",
     "./bin/jest-runtime-cli": "./bin/jest-runtime-cli.js"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -5,7 +5,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -20,7 +20,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -13,7 +13,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -5,7 +5,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -10,7 +10,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -5,7 +5,10 @@
   "main": "./build/jest.js",
   "types": "./build/jest.d.ts",
   "exports": {
-    ".": "./build/jest.js",
+    ".": {
+      "types": "./build/jest.d.ts",
+      "default": "./build/jest.js"
+    },
     "./package.json": "./package.json",
     "./bin/jest": "./bin/jest.js"
   },

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -11,7 +11,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "author": "James Kyle <me@thejameskyle.com>",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -6,7 +6,10 @@
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "exports": {
-    ".": "./build/index.js",
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -44,7 +44,14 @@ module.exports.getPackages = function getPackages() {
     assert.deepStrictEqual(
       pkg.exports,
       {
-        '.': pkg.main,
+        '.':
+          pkg.types == null
+            ? pkg.main
+            : {
+                types: pkg.types,
+                // eslint-disable-next-line sort-keys
+                default: pkg.main,
+              },
         './package.json': './package.json',
         ...Object.values(pkg.bin || {}).reduce(
           (mem, curr) =>


### PR DESCRIPTION
## Summary

This adds a `types` entry in export map since the presence of an export map overrides any other entrypoint methods. Technically not required, since `./build/jest.d.ts` is adjacent to `./build/jest.js` and will be found via that adjacency, but can be included for completeness, just like the top-level `"types": "./build/jest.d.ts"` entry.
