### PR TITLE
fix(jest-config): add missing 'slash' dependency

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -42,7 +42,8 @@
     "jest-util": "^27.3.1",
     "jest-validate": "^27.3.1",
     "micromatch": "^4.0.4",
-    "pretty-format": "^27.3.1"
+    "pretty-format": "^27.3.1",
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12658,6 +12658,7 @@ fsevents@^1.2.7:
     micromatch: ^4.0.4
     pretty-format: ^27.3.1
     semver: ^7.3.5
+    slash: ^3.0.0
     strip-ansi: ^6.0.0
     ts-node: ^9.0.0
     typescript: ^4.0.3


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I updated my jest library to latest(27.3.1) and ran test. The following error occured:

```
Error: jest-config tried to access slash, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: slash
Required by: jest-config@virtual:1bcce2f81654c62ba2c1f43389ad4059fbcc03a8875db1c4310173c058b718cab0f288f5cb8b498bea4c346752a90efbfc010d5498d6be71854ef8949f11199a#npm:27.3.1 (via /[my-directory]/.yarn/__virtual__/jest-config-virtual-d3c1205189/0/cache/jest-config-npm-27.3.1-8c4eee5f7f-1a86b03456.zip/node_modules/jest-config/build/)
```

I was trying to find the cause of this problem. The cause was that the code using 'slash' was committed last month (#11922) but the 'slash' dependency was not added to package.json. 

So I solved this problem by adding the missing dependency.