### PR TITLE
Remove period from message

### DIFF
--- a/packages/jest-core/src/getNoTestFoundVerbose.ts
+++ b/packages/jest-core/src/getNoTestFoundVerbose.ts
@@ -39,7 +39,7 @@ export default function getNoTestFoundVerbose(
       ? `In ${chalk.bold(config.rootDir)}\n` +
           `  ${pluralize('file', testRun.matches.total || 0, 's')} checked.\n` +
           statsMessage
-      : `No files found in ${config.rootDir}.\n` +
+      : `No files found in '${config.rootDir}'\n` +
           `Make sure Jest's configuration does not exclude this directory.` +
           `\nTo set up Jest, make sure a package.json file exists.\n` +
           `Jest Documentation: ` +


### PR DESCRIPTION
## Summary

Removes a period from a verbose messaged. Removed because it looks like it's part of the file path. Confused me when investigating an error in my build system because I believed I was setting the wrong path.

## Test plan

I'm just removing a period. Hopefully this can be done without a test plan :)
