### PR TITLE
fix(jest-config): add missing slash dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 - `[expect]` Allow again `expect.Matchers` generic with single value ([#11986](https://github.com/facebook/jest/pull/11986))
+- `[jest-config]` Add missing `slash` dependency to `package.json` ([#12080](https://github.com/facebook/jest/pull/12080))
 - `[jest-core]` Incorrect detection of open ZLIB handles ([#12022](https://github.com/facebook/jest/pull/12022))
 - `[jest-diff]` Break dependency cycle ([#10818](https://github.com/facebook/jest/pull/10818))
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -42,7 +42,8 @@
     "jest-util": "^27.3.1",
     "jest-validate": "^27.3.1",
     "micromatch": "^4.0.4",
-    "pretty-format": "^27.3.1"
+    "pretty-format": "^27.3.1",
+    "slash": "^4.0.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.4",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -43,7 +43,7 @@
     "jest-validate": "^27.3.1",
     "micromatch": "^4.0.4",
     "pretty-format": "^27.3.1",
-    "slash": "^4.0.0"
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.4",

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import * as fs from 'graceful-fs';
-import slash from 'slash';
+import slash = require('slash');
 import type {Config} from '@jest/types';
 import {
   JEST_CONFIG_BASE_NAME,
@@ -147,7 +147,7 @@ const makeMultipleConfigsWarning = (configPaths: Array<Config.Path>) =>
       chalk.bold('\u25cf Multiple configurations found:'),
       ...configPaths.map(
         configPath =>
-          `    * ${extraIfPackageJson(configPath)}${slash(configPath)}`,
+          `    * ${extraIfPackageJson(configPath)}${slash.default(configPath)}`,
       ),
       '',
       '  Implicit config resolution does not allow multiple configuration files.',

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import * as fs from 'graceful-fs';
-import slash = require('slash');
+import slash from 'slash';
 import type {Config} from '@jest/types';
 import {
   JEST_CONFIG_BASE_NAME,

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import * as fs from 'graceful-fs';
-import slashModule = require('slash');
+import slash = require('slash');
 import type {Config} from '@jest/types';
 import {
   JEST_CONFIG_BASE_NAME,
@@ -20,10 +20,6 @@ const isFile = (filePath: Config.Path) =>
   fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory();
 
 const getConfigFilename = (ext: string) => JEST_CONFIG_BASE_NAME + ext;
-
-// Fix incorrect TypeScript definition for `slash` package.
-const slash: typeof slashModule.default =
-  slashModule as unknown as typeof slashModule.default;
 
 export default (
   pathToResolve: Config.Path,

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import * as fs from 'graceful-fs';
-import slash = require('slash');
+import slashModule = require('slash');
 import type {Config} from '@jest/types';
 import {
   JEST_CONFIG_BASE_NAME,
@@ -20,6 +20,10 @@ const isFile = (filePath: Config.Path) =>
   fs.existsSync(filePath) && !fs.lstatSync(filePath).isDirectory();
 
 const getConfigFilename = (ext: string) => JEST_CONFIG_BASE_NAME + ext;
+
+// Fix incorrect TypeScript definition for `slash` package.
+const slash: typeof slashModule.default =
+  slashModule as unknown as typeof slashModule.default;
 
 export default (
   pathToResolve: Config.Path,
@@ -147,7 +151,7 @@ const makeMultipleConfigsWarning = (configPaths: Array<Config.Path>) =>
       chalk.bold('\u25cf Multiple configurations found:'),
       ...configPaths.map(
         configPath =>
-          `    * ${extraIfPackageJson(configPath)}${slash.default(configPath)}`,
+          `    * ${extraIfPackageJson(configPath)}${slash(configPath)}`,
       ),
       '',
       '  Implicit config resolution does not allow multiple configuration files.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -12658,6 +12658,7 @@ fsevents@^1.2.7:
     micromatch: ^4.0.4
     pretty-format: ^27.3.1
     semver: ^7.3.5
+    slash: ^4.0.0
     strip-ansi: ^6.0.0
     ts-node: ^9.0.0
     typescript: ^4.0.3
@@ -19638,6 +19639,13 @@ react-native@0.64.0:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: fc3e8597d822ee3ba6cd76e9b001cd5be315f9b81c3a03a29bb611c003d1484e3b29a9e7bc020298fa669b585ff7c9268f44513f60c186216eb6af3111a3e838
+  languageName: node
+  linkType: hard
+
+"slash@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slash@npm:4.0.0"
+  checksum: 714b10473dd5efce5ebaad47c74d69201baf7715fa58e8049d3d2716d9da25a9571bfd3ecc50c3b7f4165948e2d8d5a1aa7faeaeca4891ee71a2fbd408268091
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12658,7 +12658,7 @@ fsevents@^1.2.7:
     micromatch: ^4.0.4
     pretty-format: ^27.3.1
     semver: ^7.3.5
-    slash: ^4.0.0
+    slash: ^3.0.0
     strip-ansi: ^6.0.0
     ts-node: ^9.0.0
     typescript: ^4.0.3
@@ -19639,13 +19639,6 @@ react-native@0.64.0:
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
   checksum: fc3e8597d822ee3ba6cd76e9b001cd5be315f9b81c3a03a29bb611c003d1484e3b29a9e7bc020298fa669b585ff7c9268f44513f60c186216eb6af3111a3e838
-  languageName: node
-  linkType: hard
-
-"slash@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "slash@npm:4.0.0"
-  checksum: 714b10473dd5efce5ebaad47c74d69201baf7715fa58e8049d3d2716d9da25a9571bfd3ecc50c3b7f4165948e2d8d5a1aa7faeaeca4891ee71a2fbd408268091
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds dependency to `package.json`.

[`resolveConfigPath` requires `slash` as a dependency](https://github.com/facebook/jest/blob/main/packages/jest-config/src/resolveConfigPath.ts#L11), but this dependency is not declared in `package.json`, making it ambiguous.

![image](https://user-images.githubusercontent.com/343837/142745845-7cca3a26-6c7f-42bc-bedd-afcbf9ddc4fb.png)
