### PR TITLE
jest-haste-map: Use fs.state instead of fs.lstat when enableSymlinks is false in node crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - `[expect]` Make `expect` extension properties `configurable` ([#11978](https://github.com/facebook/jest/pull/11978))
 - `[expect]` Fix `.any()` checks on primitive wrapper classes ([#11976](https://github.com/facebook/jest/pull/11976))
+- `[jest-haste-map]` Use `fs.stat` and `fs.lstat` based on correct condition in node crawler ([#12081](https://github.com/facebook/jest/pull/12081))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -409,7 +409,7 @@ describe('node crawler', () => {
       // 3. /project/fruits/tomato.js
       // 4. /project/fruits/symlink
       // (we never call lstat on the root /project/fruits, since we know it's a directory)
-      expect(fs.lstat).toHaveBeenCalledTimes(4);
+      expect(fs.stat).toHaveBeenCalledTimes(4);
     });
 
     it('avoids calling lstat for directories and symlinks if readdir withFileTypes is supported', async () => {
@@ -437,7 +437,7 @@ describe('node crawler', () => {
       // once for /project/fruits, once for /project/fruits/directory
       expect(fs.readdir).toHaveBeenCalledTimes(2);
       // once for strawberry.js, once for tomato.js
-      expect(fs.lstat).toHaveBeenCalledTimes(2);
+      expect(fs.stat).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -99,7 +99,7 @@ function find(
 
         activeCalls++;
 
-        const stat = enableSymlinks ? fs.stat : fs.lstat;
+        const stat = enableSymlinks ? fs.lstat : fs.stat;
 
         stat(file, (err, stat) => {
           activeCalls--;


### PR DESCRIPTION
## Summary

When `enableSymlinks ` property is false, we must use `fs.stat` for getting file information in node crawler.

## Test plan

- Updated  `expect(fs.lstat)` to `expect(fs.stat)`
