### PR TITLE
chore(jest-runner): Add info regarding timers to forceExited message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Chore & Maintenance
 
+- `[jest-runner]` Add info regarding timers to forcedExit message([#12083](https://github.com/facebook/jest/pull/12083))
 - `[*]` Replaced `substr` method with `substring` ([#12066](https://github.com/facebook/jest/pull/12066))
 
 ### Performance

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -273,7 +273,8 @@ export default class TestRunner {
           chalk.yellow(
             'A worker process has failed to exit gracefully and has been force exited. ' +
               'This is likely caused by tests leaking due to improper teardown. ' +
-              'Try running with --detectOpenHandles to find leaks.',
+              'Try running with --detectOpenHandles to find leaks. ' +
+              'Active timers can also cause this, ensure that .unref() was called on them.',
           ),
         );
       }


### PR DESCRIPTION
## Summary

When a test finishes while a Node.js timer is still active, the worker process will have to be force-killed by jest because the active timer will keep the event loop alive.

It is often not immediately clear that such timers are the issue for this message and the suggested method of `--detectOpenHandles` will never detect them. Add a helpful message to point the user to this potential issue.

Ref: https://nodejs.org/api/timers.html#timeoutunref

## Test plan

None, It's just a small addition to a warning message.