### PR TITLE
jest-worker: Avoid crash when "--max-old-space-size" inside `process.execArgv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-worker]` Filter `execArgv` correctly ([#12097](https://github.com/facebook/jest/pull/12097))
+
 ### Chore & Maintenance
 
 ### Performance
@@ -27,6 +29,7 @@
 - `[jest-environment-jsdom]` Add `@types/jsdom` dependency ([#11999](https://github.com/facebook/jest/pull/11999))
 - `[jest-environment-jsdom]` Do not reset the global.document too early on teardown ([#11871](https://github.com/facebook/jest/pull/11871))
 - `[jest-transform]` Improve error and warning messages ([#11998](https://github.com/facebook/jest/pull/11998))
+- `[jest-worker]` Pass `execArgv` correctly to `worker_threads` worker ([#12069](https://github.com/facebook/jest/pull/12069))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -66,7 +66,9 @@ export default class ExperimentalWorker implements WorkerInterface {
       },
       eval: false,
       // Suppress --debug / --inspect / --max_old_space_size flags while preserving others (like --harmony).
-      execArgv: process.execArgv.filter(v => !/^--(debug|inspect|max_old_space_size)/.test(v)),
+      execArgv: process.execArgv.filter(
+        v => !/^--(debug|inspect|max_old_space_size)/.test(v),
+      ),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
       stderr: true,

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -65,9 +65,9 @@ export default class ExperimentalWorker implements WorkerInterface {
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
       },
       eval: false,
-      // Suppress --debug / --inspect / --max_old_space_size flags while preserving others (like --harmony).
+      // Suppress --max_old_space_size flags while preserving others (like --harmony). See https://nodejs.org/api/worker_threads.html#new-workerfilename-options
       execArgv: process.execArgv.filter(
-        v => !/^--(debug|inspect|max_old_space_size)/.test(v),
+        v => !/^--(max_old_space_size)/.test(v),
       ),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -65,7 +65,7 @@ export default class ExperimentalWorker implements WorkerInterface {
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
       },
       eval: false,
-      execArgv: process.execArgv,
+      execArgv: process.execArgv.filter(v => !/^--(max_old_space_size)/.test(v)),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
       stderr: true,

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -65,7 +65,8 @@ export default class ExperimentalWorker implements WorkerInterface {
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
       },
       eval: false,
-      execArgv: process.execArgv.filter(v => !/^--(max_old_space_size)/.test(v)),
+      // Suppress --debug / --inspect / --max_old_space_size flags while preserving others (like --harmony).
+      execArgv: process.execArgv.filter(v => !/^--(debug|inspect|max_old_space_size)/.test(v)),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
       stderr: true,


### PR DESCRIPTION
jest-worker used by [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin/blob/master/src/index.js#L407)

In our cli, we run build process with max-old-space-size flag [by default](https://github.com/TinkoffCreditSystems/tramvai/blob/main/packages/cli/bin/spawn.js#L5), and use terser-webpack-plugin inside.

So, terser-webpack-plugin initialize ExperimentalWorker, and ExperimentalWorker pass max-old-space-size to NodeJS worker, then process failed with error:

```
error GLOBAL:ERROR Error: platform.3c72a39d93fe42d9bfb2.js from Terser plugin
Initiated Worker with invalid execArgv flags: --max_old_space_size=3000
Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid execArgv flags: --max_old_space_size=3000
    at new NodeError (node:internal/errors:371:5)
    at new Worker (node:internal/worker:191:13)
    at ExperimentalWorker.initialize (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/workers/NodeThreadsWorker.js:149:20)
    at new ExperimentalWorker (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/workers/NodeThreadsWorker.js:145:10)
    at WorkerPool.createWorker (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/WorkerPool.js:44:12)
    at new BaseWorkerPool (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/base/BaseWorkerPool.js:127:27)
    at new WorkerPool (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/WorkerPool.js:30:1)
    at new Worker (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/jest-worker/build/index.js:167:26)
    at getWorker (/builds/coretech-frontend/tramvai/smokeNpm/node_modules/terser-webpack-plugin/dist/index.js:391:9)
    at /builds/coretech-frontend/tramvai/smokeNpm/node_modules/terser-webpack-plugin/dist/index.js:494:41
```
