### PR TITLE
jest-worker: Avoid crash when "--max-old-space-size" inside process.execArgv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-worker]` Add additonal `execArgv` to filter ([#12103](https://github.com/facebook/jest/pull/12103))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -67,7 +67,7 @@ export default class ExperimentalWorker implements WorkerInterface {
       eval: false,
       // Suppress --max_old_space_size flags while preserving others (like --harmony). See https://nodejs.org/api/worker_threads.html#new-workerfilename-options
       execArgv: process.execArgv.filter(
-        v => !/^--(max_old_space_size)/.test(v),
+        v => !/^--(max_old_space_size|max-old-space-size)/.test(v),
       ),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Complement to this PR: https://github.com/facebook/jest/pull/12097

Node has previously updated the command line flag max_old_space_size to max-old-space-size, so we should support both in when filtering the flags.

## Test plan

Verifying the RegExp should be sufficient.
