### PR TITLE
chore: add `__typechecks__` directories to `.npmignore`

### DIFF
--- a/packages/expect/.npmignore
+++ b/packages/expect/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typechecks__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-types/.npmignore
+++ b/packages/jest-types/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typechecks__
 src
 tsconfig.json
 tsconfig.tsbuildinfo


### PR DESCRIPTION
## Summary

Unfortunately in #12099 I forgot to add `__typechecks__` directories to `.npmignore`. Now they got shipped.. Ups..

## Test plan

Running `npm publish --dry-run` proofs that all is fixed.