### PR TITLE
fix(website): CSS of jest card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[babel-jest]` Add `process.version` chunk to the cache key ([#12122](https://github.com/facebook/jest/pull/12122))
+- `[website]` Fix the card front that looks overlapping part of the card back
 
 ### Chore & Maintenance
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -123,6 +123,7 @@ div.jest-card-front,
 }
 
 div.jest-card-front {
+  z-index: 1;
   background-color: #fff;
   border: 1px solid #bbb;
 }


### PR DESCRIPTION
## Summary

At some point, the elements on the back of the jest cards on the website's main page started to overlap on the front. When I first saw it, I didn't really care. Because it was a problem with the website's main page, I thought it would be fixed soon. But it seems to have been left in that state for several months, so I fix it myself and send this PR.

## Test plan

Please check in the **Chrome** browser.

Before:
![before](https://user-images.githubusercontent.com/8164191/144859911-156b2897-9733-46d1-a73f-6e11c7fcf89d.png)

After:
![after](https://user-images.githubusercontent.com/8164191/144859941-64c0f5ac-c150-4dd0-b9c9-f1027e35488e.png)
