### PR TITLE
[jest-worker] Don't crash when running node with flags disallowed in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[babel-jest]` Add `process.version` chunk to the cache key ([#12122](https://github.com/facebook/jest/pull/12122))
+- `[jest-worker]` Stop explicitly passing `execArgv` ([#12128](https://github.com/facebook/jest/pull/12128))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -65,10 +65,6 @@ export default class ExperimentalWorker implements WorkerInterface {
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
       },
       eval: false,
-      // Suppress --max_old_space_size flags while preserving others (like --harmony). See https://nodejs.org/api/worker_threads.html#new-workerfilename-options
-      execArgv: process.execArgv.filter(
-        v => !/^--(max_old_space_size|max-old-space-size)/.test(v),
-      ),
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
       stderr: true,

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -57,8 +57,8 @@ it('passes fork options down to worker_threads.Worker, adding the defaults', () 
   // eslint-disable-next-line no-new
   new Worker({
     forkOptions: {
+      execArgv: ['--inspect', '-p'],
       execPath: 'hello',
-      execArgv: ['--inspect', '-p']
     },
     maxRetries: 3,
     workerData: {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -54,12 +54,11 @@ afterEach(() => {
 it('passes fork options down to worker_threads.Worker, adding the defaults', () => {
   const thread = require.resolve('../threadChild');
 
-  process.execArgv = ['--inspect', '-p'];
-
   // eslint-disable-next-line no-new
   new Worker({
     forkOptions: {
       execPath: 'hello',
+      execArgv: ['--inspect', '-p']
     },
     maxRetries: 3,
     workerData: {


### PR DESCRIPTION
## Summary

I noticed that [Babel's CI started failing](https://app.circleci.com/pipelines/github/babel/babel/8660/workflows/3dc49269-3853-4631-a0a8-75655431abb7/jobs/50208) with this error a few days ago:
```
Error [ERR_WORKER_INVALID_EXEC_ARGV]: Initiated Worker with invalid NODE_OPTIONS env variable: --openssl-legacy-provider is not allowed in NODE_OPTIONS
    at new NodeError (node:internal/errors:371:5)
    at new Worker (node:internal/worker:194:13)
    at ExperimentalWorker.initialize (/home/circleci/babel/scripts/integration-tests/tmp/create-react-app/node_modules/jest-worker/build/workers/NodeThreadsWorker.js:149:20)
```

Then, I noticed #12103 which fixes the problem for a specific option, and I found the root cause in #12069. I don't understand why #12069 specifies `execArgv: process.execArgv`, but removing it should fix the bug for all the different options that currently make `jest-worker` crash (I don't even know if this list is documented, but I can try finding it again in the Node.js source if needed).

&lt;rant>
I am really annoyed by this Node.js behavior. Reading the docs it looks like the default value of `execArgv` is `process.execArgv`, but it's not. Yesterday I spent some time trying to fix this same identical bug in a non-jest-related PR I was working on for Babel (https://github.com/babel/babel/pull/14025#issuecomment-986234760) and just after reading the Node.js source code I realized that it's an important difference: if you pass `execArgv: process.execArgv` Node.js validates it; if you don't pass anything it uses `process.execArgv` without performing any validation.
If you read the docs knowing this difference you can see that it never actually says that `process.execArgv`, but it's really annoying that this difference is not explicitly stated and they make you think that it's the default value.
&lt;/rant>

## Test plan

CI :crossed_fingers:
I did this change from the GH UI; lets see if it works.
