### PR TITLE
fix: update `pirates` to 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Performance
 
+## 27.4.6
+
+### Fixes
+
+- `[@jest/transform]` Update dependency package `pirates` to 4.0.4  ([#12136](https://github.com/facebook/jest/pull/12136))
+
 ## 27.4.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[@jest/transform]` Update dependency package `pirates` to 4.0.4  ([#12136](https://github.com/facebook/jest/pull/12136))
+- `[@jest/transform]` Update dependency package `pirates` to 4.0.4 ([#12136](https://github.com/facebook/jest/pull/12136))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,11 @@
 
 ### Fixes
 
+- `[@jest/transform]` Update dependency package `pirates` to 4.0.4  ([#12136](https://github.com/facebook/jest/pull/12136))
+
 ### Chore & Maintenance
 
 ### Performance
-
-## 27.4.6
-
-### Fixes
-
-- `[@jest/transform]` Update dependency package `pirates` to 4.0.4  ([#12136](https://github.com/facebook/jest/pull/12136))
 
 ## 27.4.5
 

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -28,7 +28,7 @@
     "jest-regex-util": "^27.4.0",
     "jest-util": "^27.4.2",
     "micromatch": "^4.0.4",
-    "pirates": "^4.0.1",
+    "pirates": "^4.0.4",
     "slash": "^3.0.0",
     "source-map": "^0.6.1",
     "write-file-atomic": "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16668,16 +16668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "pirates@npm:4.0.1"
-  dependencies:
-    node-modules-regexp: ^1.0.0
-  checksum: 21604008c36ab6e14ac458e1a267dd7322cfd36b9e1042e9e277dd064582717e30b9aba8c0a47d738bf004ee7946ed27f6b982d30968534f2c6b5b168a52b555
-  languageName: node
-  linkType: hard
-
-"pirates@npm:^4.0.4":
+"pirates@npm:^4.0.0, pirates@npm:^4.0.4":
   version: 4.0.4
   resolution: "pirates@npm:4.0.4"
   checksum: eabc769e9b3387a0494327134ae7a8c770c102f232ac59e45363a1d64089ff1762b1162926a3c577e5d747c27a7248a072d517a8105c6751e390fcc25b0d1f23

--- a/yarn.lock
+++ b/yarn.lock
@@ -2764,7 +2764,7 @@ __metadata:
     jest-snapshot-serializer-raw: ^1.1.0
     jest-util: ^27.4.2
     micromatch: ^4.0.4
-    pirates: ^4.0.1
+    pirates: ^4.0.4
     slash: ^3.0.0
     source-map: ^0.6.1
     write-file-atomic: ^3.0.0
@@ -16668,12 +16668,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.0, pirates@npm:^4.0.1":
+"pirates@npm:^4.0.0":
   version: 4.0.1
   resolution: "pirates@npm:4.0.1"
   dependencies:
     node-modules-regexp: ^1.0.0
   checksum: 21604008c36ab6e14ac458e1a267dd7322cfd36b9e1042e9e277dd064582717e30b9aba8c0a47d738bf004ee7946ed27f6b982d30968534f2c6b5b168a52b555
+  languageName: node
+  linkType: hard
+
+"pirates@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "pirates@npm:4.0.4"
+  checksum: eabc769e9b3387a0494327134ae7a8c770c102f232ac59e45363a1d64089ff1762b1162926a3c577e5d747c27a7248a072d517a8105c6751e390fcc25b0d1f23
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15565,13 +15565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-modules-regexp@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "node-modules-regexp@npm:1.0.0"
-  checksum: 90f928a1dbc3c98d39b3d133f8c910e6bd8e45416f8e15151a31c41550cffe4e3022a39c38c20ae4ceca56b6e63741def4f3a2018080d13f5be245f4b060a9b1
-  languageName: node
-  linkType: hard
-
 "node-notifier@npm:^10.0.0":
   version: 10.0.0
   resolution: "node-notifier@npm:10.0.0"


### PR DESCRIPTION
Related to issue [#75](https://github.com/danez/pirates/issues/75)

> Cannot find module '/Users/Ritchie/Developer/@fastcms/fastcms/node_modules/.pnpm/@jest+transform@27.4.2/node_modules/pirates/lib/index.js'. Please verify that the package.json has a valid "main" entry