### PR TITLE
[jest-worker] Don't pass explicit `env` to `new Worker` when using `worker_threads`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Performance
 
+## 27.4.5
+
+### Fixes
+
+- `[jest-worker]` Stop explicitly passing `process.env` ([#12141](https://github.com/facebook/jest/pull/12141))
+
 ## 27.4.4
 
 ### Fixes

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -60,10 +60,6 @@ export default class ExperimentalWorker implements WorkerInterface {
 
   initialize(): void {
     this._worker = new Worker(path.resolve(__dirname, './threadChild.js'), {
-      env: {
-        ...process.env,
-        JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
-      },
       eval: false,
       // @ts-expect-error: added in newer versions
       resourceLimits: this._options.resourceLimits,
@@ -101,6 +97,7 @@ export default class ExperimentalWorker implements WorkerInterface {
       false,
       this._options.workerPath,
       this._options.setupArgs,
+      String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
     ]);
 
     this._retries++;

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -70,7 +70,6 @@ it('passes fork options down to worker_threads.Worker, adding the defaults', () 
 
   expect(workerThreads.mock.calls[0][0]).toBe(thread.replace(/\.ts$/, '.js'));
   expect(workerThreads.mock.calls[0][1]).toEqual({
-    env: process.env, // Default option.
     eval: false,
     execArgv: ['--inspect', '-p'],
     execPath: 'hello', // Added option.
@@ -84,24 +83,13 @@ it('passes fork options down to worker_threads.Worker, adding the defaults', () 
   });
 });
 
-it('passes workerId to the thread and assign it to env.JEST_WORKER_ID', () => {
-  // eslint-disable-next-line no-new
-  new Worker({
-    forkOptions: {},
-    maxRetries: 3,
-    workerId: 2,
-    workerPath: '/tmp/foo',
-  });
-
-  expect(workerThreads.mock.calls[0][1].env.JEST_WORKER_ID).toEqual('3');
-});
-
-it('initializes the thread with the given workerPath', () => {
+it('initializes the thread with the given workerPath and workerId', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
     setupArgs: ['foo', 'bar'],
     workerPath: '/tmp/foo/bar/baz.js',
+    workerId: 2,
   });
 
   expect(worker._worker.postMessage.mock.calls[0][0]).toEqual([
@@ -109,6 +97,7 @@ it('initializes the thread with the given workerPath', () => {
     false,
     '/tmp/foo/bar/baz.js',
     ['foo', 'bar'],
+    '3'
   ]);
 });
 

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -88,8 +88,8 @@ it('initializes the thread with the given workerPath and workerId', () => {
     forkOptions: {},
     maxRetries: 3,
     setupArgs: ['foo', 'bar'],
-    workerPath: '/tmp/foo/bar/baz.js',
     workerId: 2,
+    workerPath: '/tmp/foo/bar/baz.js',
   });
 
   expect(worker._worker.postMessage.mock.calls[0][0]).toEqual([
@@ -97,7 +97,7 @@ it('initializes the thread with the given workerPath and workerId', () => {
     false,
     '/tmp/foo/bar/baz.js',
     ['foo', 'bar'],
-    '3'
+    '3',
   ]);
 });
 

--- a/packages/jest-worker/src/workers/__tests__/threadChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/threadChild.test.js
@@ -128,6 +128,18 @@ afterEach(() => {
   thread.removeAllListeners('message');
 });
 
+it('sets env.JEST_WORKER_ID', () => {
+  thread.emit('message', [
+    CHILD_MESSAGE_INITIALIZE,
+    true, // Not really used here, but for flow type purity.
+    './my-fancy-worker',
+    [],
+    '3'
+  ]);
+
+  expect(process.env.JEST_WORKER_ID).toBe('3');
+})
+
 it('lazily requires the file', () => {
   expect(mockCount).toBe(0);
 

--- a/packages/jest-worker/src/workers/__tests__/threadChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/threadChild.test.js
@@ -134,11 +134,11 @@ it('sets env.JEST_WORKER_ID', () => {
     true, // Not really used here, but for flow type purity.
     './my-fancy-worker',
     [],
-    '3'
+    '3',
   ]);
 
   expect(process.env.JEST_WORKER_ID).toBe('3');
-})
+});
 
 it('lazily requires the file', () => {
   expect(mockCount).toBe(0);

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -41,6 +41,7 @@ const messageListener = (request: any) => {
       const init: ChildMessageInitialize = request;
       file = init[2];
       setupArgs = request[3];
+      process.env.JEST_WORKER_ID = request[4];
       break;
 
     case CHILD_MESSAGE_CALL:


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

#12128 wasn't enough to fix the regression introduced by #12069: it was still broken when using the `NODE_OPTIONS` env var because of https://github.com/nodejs/node/issues/41103#issuecomment-991692653.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I updated the existing tests, but I would have loved if they were not all mock-based but spawned real workers :sweat_smile: 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
