### PR TITLE
Removed type parameters from constructors

### DIFF
--- a/examples/angular/shared/data.service.ts
+++ b/examples/angular/shared/data.service.ts
@@ -4,7 +4,7 @@ import {SubService} from './sub.service';
 
 @Injectable()
 export class DataService {
-  constructor(private subService: SubService) {}
+  constructor(subService: SubService) {}
 
   getTitle() {
     return this.subService.getTitle();

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -28,8 +28,7 @@ export abstract class AsymmetricMatcher<
 {
   $$typeof = Symbol.for('jest.asymmetricMatcher');
 
-  constructor(protected sample: T, protected inverse = false) {}
-
+  constructor(sample: T, inverse = false) {}
   protected getMatcherContext(): State {
     return {
       ...getState(),

--- a/packages/jest-core/src/FailedTestsInteractiveMode.ts
+++ b/packages/jest-core/src/FailedTestsInteractiveMode.ts
@@ -28,7 +28,7 @@ export default class FailedTestsInteractiveMode {
   private _testAssertions: Array<AssertionLocation> = [];
   private _updateTestRunnerConfig?: RunnerUpdateFunction;
 
-  constructor(private _pipe: NodeJS.WritableStream) {}
+  constructor(_pipe: NodeJS.WritableStream) {}
 
   isActive(): boolean {
     return this._isActive;

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -81,8 +81,8 @@ class ScriptTransformer {
   private _transformsAreLoaded = false;
 
   constructor(
-    private readonly _config: Config.ProjectConfig,
-    private readonly _cacheFS: StringMap,
+    readonly _config: Config.ProjectConfig,
+    readonly _cacheFS: StringMap,
   ) {
     const configString = stableStringify(this._config);
     let projectCache = projectCaches.get(configString);

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -33,8 +33,8 @@ export default class Farm {
   private readonly _taskQueue: TaskQueue;
 
   constructor(
-    private _numOfWorkers: number,
-    private _callback: Function,
+    _numOfWorkers: number,
+    _callback: Function,
     options: {
       computeWorkerKey?: FarmOptions['computeWorkerKey'];
       workerSchedulingPolicy?: FarmOptions['workerSchedulingPolicy'];

--- a/packages/jest-worker/src/PriorityQueue.ts
+++ b/packages/jest-worker/src/PriorityQueue.ts
@@ -30,8 +30,7 @@ export default class PriorityQueue implements TaskQueue {
   private _queue: Array<MinHeap<QueueItem>> = [];
   private _sharedQueue = new MinHeap<QueueItem>();
 
-  constructor(private _computePriority: ComputeTaskPriorityCallback) {}
-
+  constructor(_computePriority: ComputeTaskPriorityCallback) {}
   enqueue(task: QueueChildMessage, workerId?: number): void {
     if (workerId == null) {
       this._enqueue(task, this._sharedQueue);


### PR DESCRIPTION
Going through the official typescript documentation , i found this 

![TypeScript_ Documentation - Classes - Google Chrome 15-12-2021 8 58 25 PM](https://user-images.githubusercontent.com/72331432/146215416-13ae4547-5008-4a44-91d2-34a13e9f88b3.png)

so we should avoid the usage of parameters here too
@SimenB  waiting for your feedback