### PR TITLE
Added comment to denote `global{Setup,Teardown}` can be synchronous

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -459,6 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -425,7 +425,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -425,6 +425,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -442,7 +442,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -442,6 +442,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.0/Configuration.md
+++ b/website/versioned_docs/version-27.0/Configuration.md
@@ -459,7 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.0/Configuration.md
+++ b/website/versioned_docs/version-27.0/Configuration.md
@@ -459,6 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.1/Configuration.md
+++ b/website/versioned_docs/version-27.1/Configuration.md
@@ -459,7 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.1/Configuration.md
+++ b/website/versioned_docs/version-27.1/Configuration.md
@@ -459,6 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.2/Configuration.md
+++ b/website/versioned_docs/version-27.2/Configuration.md
@@ -459,7 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.2/Configuration.md
+++ b/website/versioned_docs/version-27.2/Configuration.md
@@ -459,6 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.4/Configuration.md
+++ b/website/versioned_docs/version-27.4/Configuration.md
@@ -459,7 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
-// can be synchoronous
+// can be synchronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.

--- a/website/versioned_docs/version-27.4/Configuration.md
+++ b/website/versioned_docs/version-27.4/Configuration.md
@@ -459,6 +459,7 @@ _Note: While code transformation is applied to the linked setup-file, Jest will 
 Example:
 
 ```js title="setup.js"
+// can be synchoronous
 module.exports = async () => {
   // ...
   // Set reference to mongod in order to close the server during teardown.


### PR DESCRIPTION
here above the `module.exports = async () => {`
we can add a comment to denote that this can be synchronous

```
Example:

```js title="setup.js"
// can be synchronous
module.exports = async () => {
  // ...
  // Set reference to mongod in order to close the server during teardown.
  global.__MONGOD__ = mongod;
};
```
```js title="teardown.js"
module.exports = async function () {
  await global.__MONGOD__.stop();
};
```
### `globalTeardown` \[string]
Default: `undefined`
This option allows the use of a custom global teardown module which exports an async function that is triggered once after all test suites. This function gets Jest's `globalConfig` object as a parameter.
_Note: A global teardown module configured in a project (using multi-project runner) will be triggered only when you run at least one test from this project._
_Note: The same caveat concerning transformation of `node_modules` as for `globalSetup` applies to `globalTeardown`._


```