### PR TITLE
perf: only register ts-node once when loading TS config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chore & Maintenance
 
 ### Performance
+- `jest-config` perf: only register ts-node once when loading TS config files ([#12160](https://github.com/facebook/jest/pull/12160))
 
 ## 27.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chore & Maintenance
 
 ### Performance
+
 - `jest-config` perf: only register ts-node once when loading TS config files ([#12160](https://github.com/facebook/jest/pull/12160))
 
 ## 27.4.5

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -79,15 +79,15 @@ export default async function readConfigFileAndSetRootDir(
   return configObject;
 }
 
+let registerer: Service;
+
 // Load the TypeScript configuration
 const loadTSConfigFile = async (
   configPath: Config.Path,
 ): Promise<Config.InitialOptions> => {
-  let registerer: Service;
-
   // Register TypeScript compiler instance
   try {
-    registerer = require('ts-node').register({
+    registerer ||= require('ts-node').register({
       compilerOptions: {
         module: 'CommonJS',
       },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Memory usage increased linearly when using multiple `jest.config.ts` files. This seems to have been caused by the fact that we `require` and `register` a new instance of `ts-node` whenever a new `jest.config.ts` file is encountered. By only registering one instance of `ts-node`, we are able to reduce memory usage significantly in multi-config projects.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
1. Made the change in this repo.
2. Ran `yarn jest-ts` in the [issue repo](https://github.com/grxy/jest-memory-issue)
3. Added additional `jest.config.ts` files to the [issue repo](https://github.com/grxy/jest-memory-issue)
4. Noticed that heap usage remained about the same regardless of number of `jest.config.ts` files

Closes https://github.com/facebook/jest/issues/12159
