### PR TITLE
Fix: Cleared the `describe.skip` Behaviour

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -416,8 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -417,6 +417,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-25.x/GlobalAPI.md
+++ b/website/versioned_docs/version-25.x/GlobalAPI.md
@@ -374,7 +374,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -393,6 +393,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-25.x/GlobalAPI.md
+++ b/website/versioned_docs/version-25.x/GlobalAPI.md
@@ -392,8 +392,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-26.x/GlobalAPI.md
+++ b/website/versioned_docs/version-26.x/GlobalAPI.md
@@ -374,7 +374,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -393,6 +393,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the `described` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-26.x/GlobalAPI.md
+++ b/website/versioned_docs/version-26.x/GlobalAPI.md
@@ -392,8 +392,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the `described` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `described` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.0/GlobalAPI.md
+++ b/website/versioned_docs/version-27.0/GlobalAPI.md
@@ -416,8 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.0/GlobalAPI.md
+++ b/website/versioned_docs/version-27.0/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -417,6 +417,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the described block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.1/GlobalAPI.md
+++ b/website/versioned_docs/version-27.1/GlobalAPI.md
@@ -416,8 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.1/GlobalAPI.md
+++ b/website/versioned_docs/version-27.1/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the test of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -417,6 +417,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.2/GlobalAPI.md
+++ b/website/versioned_docs/version-27.2/GlobalAPI.md
@@ -416,8 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.2/GlobalAPI.md
+++ b/website/versioned_docs/version-27.2/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -417,6 +417,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.4/GlobalAPI.md
+++ b/website/versioned_docs/version-27.4/GlobalAPI.md
@@ -416,8 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
-Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-27.4/GlobalAPI.md
+++ b/website/versioned_docs/version-27.4/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -417,6 +417,7 @@ describe.skip('my other beverage', () => {
 ```
 
 Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 


### PR DESCRIPTION
The current documentation for `describe.skip` was misleading: its tests or setup functions are not run, but any other statements are run.