### PR TITLE
fix(docs) fixing error in example of `jest.mocked`

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -618,7 +618,7 @@ test('deep', () => {
 test('direct', () => {
   foo.name();
   // here only foo.name is mocked (or its methods if it's an object)
-  expect(mocked(foo.name).mock.calls).toHaveLength(1);
+  expect(jest.mocked(foo.name).mock.calls).toHaveLength(1);
 });
 ```
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -50,14 +50,14 @@ export type MaybeMockedConstructor<T> = T extends new (
 ) => infer R
   ? MockInstance<R, ConstructorArgumentsOf<T>>
   : T;
-export type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & {
+export type MockedFn<T extends MockableFunction> = MockWithArgs<T> & {
   [K in keyof T]: T[K];
 };
 export type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> &
   MockedObjectDeep<T>;
 export type MockedObject<T> = MaybeMockedConstructor<T> & {
   [K in MethodKeysOf<T>]: T[K] extends MockableFunction
-    ? MockedFunction<T[K]>
+    ? MockedFn<T[K]>
     : T[K];
 } & {[K in PropertyKeysOf<T>]: T[K]};
 export type MockedObjectDeep<T> = MaybeMockedConstructor<T> & {
@@ -73,25 +73,12 @@ export type MaybeMockedDeep<T> = T extends MockableFunction
   : T;
 
 export type MaybeMocked<T> = T extends MockableFunction
-  ? MockedFunction<T>
+  ? MockedFn<T>
   : T extends object
   ? MockedObject<T>
   : T;
 
 export type ArgsType<T> = T extends (...args: infer A) => any ? A : never;
-export type Mocked<T> = {
-  [P in keyof T]: T[P] extends (...args: Array<any>) => any
-    ? MockInstance<ReturnType<T[P]>, ArgsType<T[P]>>
-    : T[P] extends Constructable
-    ? MockedClass<T[P]>
-    : T[P];
-} & T;
-export type MockedClass<T extends Constructable> = MockInstance<
-  InstanceType<T>,
-  T extends new (...args: infer P) => any ? P : never
-> & {
-  prototype: T extends {prototype: any} ? Mocked<T['prototype']> : never;
-} & T;
 
 export interface Constructable {
   new (...args: Array<any>): any;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -56,9 +56,7 @@ export type MockedFn<T extends MockableFunction> = MockWithArgs<T> & {
 export type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> &
   MockedObjectDeep<T>;
 export type MockedObject<T> = MaybeMockedConstructor<T> & {
-  [K in MethodKeysOf<T>]: T[K] extends MockableFunction
-    ? MockedFn<T[K]>
-    : T[K];
+  [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFn<T[K]> : T[K];
 } & {[K in PropertyKeysOf<T>]: T[K]};
 export type MockedObjectDeep<T> = MaybeMockedConstructor<T> & {
   [K in MethodKeysOf<T>]: T[K] extends MockableFunction

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -77,7 +77,19 @@ export type MaybeMocked<T> = T extends MockableFunction
   : T;
 
 export type ArgsType<T> = T extends (...args: infer A) => any ? A : never;
-
+export type Mocked<T> = {
+  [P in keyof T]: T[P] extends (...args: Array<any>) => any
+    ? MockInstance<ReturnType<T[P]>, ArgsType<T[P]>>
+    : T[P] extends Constructable
+    ? MockedClass<T[P]>
+    : T[P];
+} & T;
+export type MockedClass<T extends Constructable> = MockInstance<
+  InstanceType<T>,
+  T extends new (...args: infer P) => any ? P : never
+> & {
+  prototype: T extends {prototype: any} ? Mocked<T['prototype']> : never;
+} & T;
 export interface Constructable {
   new (...args: Array<any>): any;
 }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -50,13 +50,13 @@ export type MaybeMockedConstructor<T> = T extends new (
 ) => infer R
   ? MockInstance<R, ConstructorArgumentsOf<T>>
   : T;
-export type MockedFn<T extends MockableFunction> = MockWithArgs<T> & {
+export type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & {
   [K in keyof T]: T[K];
 };
 export type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> &
   MockedObjectDeep<T>;
 export type MockedObject<T> = MaybeMockedConstructor<T> & {
-  [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFn<T[K]> : T[K];
+  [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFunction<T[K]> : T[K];
 } & {[K in PropertyKeysOf<T>]: T[K]};
 export type MockedObjectDeep<T> = MaybeMockedConstructor<T> & {
   [K in MethodKeysOf<T>]: T[K] extends MockableFunction
@@ -71,7 +71,7 @@ export type MaybeMockedDeep<T> = T extends MockableFunction
   : T;
 
 export type MaybeMocked<T> = T extends MockableFunction
-  ? MockedFn<T>
+  ? MockedFunction<T>
   : T extends object
   ? MockedObject<T>
   : T;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -56,7 +56,9 @@ export type MockedFunction<T extends MockableFunction> = MockWithArgs<T> & {
 export type MockedFunctionDeep<T extends MockableFunction> = MockWithArgs<T> &
   MockedObjectDeep<T>;
 export type MockedObject<T> = MaybeMockedConstructor<T> & {
-  [K in MethodKeysOf<T>]: T[K] extends MockableFunction ? MockedFunction<T[K]> : T[K];
+  [K in MethodKeysOf<T>]: T[K] extends MockableFunction
+    ? MockedFunction<T[K]>
+    : T[K];
 } & {[K in PropertyKeysOf<T>]: T[K]};
 export type MockedObjectDeep<T> = MaybeMockedConstructor<T> & {
   [K in MethodKeysOf<T>]: T[K] extends MockableFunction

--- a/website/versioned_docs/version-27.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.4/JestObjectAPI.md
@@ -618,7 +618,7 @@ test('deep', () => {
 test('direct', () => {
   foo.name();
   // here only foo.name is mocked (or its methods if it's an object)
-  expect(mocked(foo.name).mock.calls).toHaveLength(1);
+  expect(jest.mocked(foo.name).mock.calls).toHaveLength(1);
 });
 ```
 


### PR DESCRIPTION
## Summary


 fixing errors in example https://jestjs.io/docs/jest-object#jestmockedtitem-t-deep--false



