### PR TITLE
chore: remove unused import from test

### DIFF
--- a/e2e/global-teardown-esm/__tests__/test.js
+++ b/e2e/global-teardown-esm/__tests__/test.js
@@ -8,7 +8,6 @@
 import os from 'os';
 import path from 'path';
 import fs from 'graceful-fs';
-import greeting from '../';
 
 const DIR = path.join(os.tmpdir(), 'jest-global-teardown-esm');
 


### PR DESCRIPTION
`import greeting from '../'` this import was just lying around so it was removed