### PR TITLE
chore: improve `tsd` runner setup

### DIFF
--- a/jest.config.types.js
+++ b/jest.config.types.js
@@ -7,15 +7,18 @@
 
 'use strict';
 
-const {modulePathIgnorePatterns} = require('./jest.config');
+const rootDirs = ['<rootDir>/packages/expect', '<rootDir>/packages/jest-types'];
 
-module.exports = {
+const projects = rootDirs.map(rootDir => ({
   displayName: {
     color: 'blue',
     name: 'types',
   },
-  modulePathIgnorePatterns,
-  roots: ['<rootDir>/packages'],
+  rootDir,
   runner: 'jest-runner-tsd',
-  testMatch: ['**/__typechecks__/**/*.ts'],
+  testMatch: ['**/__typechecks__/**/*.test.ts'],
+}));
+
+module.exports = {
+  projects,
 };

--- a/jest.config.types.js
+++ b/jest.config.types.js
@@ -7,18 +7,15 @@
 
 'use strict';
 
-const rootDirs = ['<rootDir>/packages/expect', '<rootDir>/packages/jest-types'];
+const {modulePathIgnorePatterns} = require('./jest.config');
 
-const projects = rootDirs.map(rootDir => ({
+module.exports = {
   displayName: {
     color: 'blue',
     name: 'types',
   },
-  rootDir,
+  modulePathIgnorePatterns,
+  roots: ['<rootDir>/packages'],
   runner: 'jest-runner-tsd',
-  testMatch: ['**/__typechecks__/**/*.test.ts'],
-}));
-
-module.exports = {
-  projects,
+  testMatch: ['**/__typechecks__/**/*.ts'],
 };

--- a/packages/expect/__typechecks__/expect.test.ts
+++ b/packages/expect/__typechecks__/expect.test.ts
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @type ../
  */
 
 import type * as expect from 'expect';

--- a/packages/jest-types/__typechecks__/config.test.ts
+++ b/packages/jest-types/__typechecks__/config.test.ts
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @type ../
  */
 
 import {expectAssignable} from 'mlh-tsd';

--- a/packages/jest-types/__typechecks__/expect.test.ts
+++ b/packages/jest-types/__typechecks__/expect.test.ts
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @type ../
  */
 
 import {expectError, expectType} from 'mlh-tsd';

--- a/packages/jest-types/__typechecks__/globals.test.ts
+++ b/packages/jest-types/__typechecks__/globals.test.ts
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @type ../
  */
 
 import {expectError, expectType} from 'mlh-tsd';

--- a/packages/jest-types/__typechecks__/jest.test.ts
+++ b/packages/jest-types/__typechecks__/jest.test.ts
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @type ../
  */
 
 import {expectError, expectType} from 'mlh-tsd';


### PR DESCRIPTION
## Summary

Should unblock #12198

Looks like `tsd` is trying to make sure that `index.d.ts` file exist in the `rootDir` or that it can be resolved looking at `main` or `types` fields of `packages.json`. The resolved file is not anyhow consumed later. https://github.com/SamVerschueren/tsd/blob/0fb92456b929e71bf6266101cb11d6cc90a241a5/source/lib/index.ts#L16-L30

Currently the runner is simply passing `rootDir` to `tsd`. This is tricky with mono-repo, because `.d.ts` files cannot be resolve from the root of the repo.

Might be it is possible to improve the runner to be smarter with mono-repos. Perhaps at the moment it is enough to set `rootDir` explicitly for each package which has `tsd` tests.

## Test plan

All tests must pass.