### PR TITLE
Bump `istanbul-reports` version to 3.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "isbinaryfile": "^4.0.0",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.0",
-    "istanbul-reports": "^3.0.0",
+    "istanbul-reports": "^3.1.3",
     "jest": "workspace:*",
     "jest-changed-files": "workspace:*",
     "jest-junit": "^13.0.0",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -27,7 +27,7 @@
     "istanbul-lib-instrument": "^5.1.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
-    "istanbul-reports": "^3.0.2",
+    "istanbul-reports": "^3.1.3",
     "jest-haste-map": "^27.4.5",
     "jest-resolve": "^27.4.5",
     "jest-util": "^27.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2627,7 +2627,7 @@ __metadata:
     isbinaryfile: ^4.0.0
     istanbul-lib-coverage: ^3.0.0
     istanbul-lib-report: ^3.0.0
-    istanbul-reports: ^3.0.0
+    istanbul-reports: ^3.1.3
     jest: "workspace:*"
     jest-changed-files: "workspace:*"
     jest-junit: ^13.0.0
@@ -2692,7 +2692,7 @@ __metadata:
     istanbul-lib-instrument: ^5.1.0
     istanbul-lib-report: ^3.0.0
     istanbul-lib-source-maps: ^4.0.0
-    istanbul-reports: ^3.0.2
+    istanbul-reports: ^3.1.3
     jest-haste-map: ^27.4.5
     jest-resolve: ^27.4.5
     jest-util: ^27.4.2
@@ -12558,7 +12558,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-reports@npm:^3.0.0, istanbul-reports@npm:^3.0.2":
+"istanbul-reports@npm:^3.1.3":
   version: 3.1.3
   resolution: "istanbul-reports@npm:3.1.3"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR bumps the version of _istanbul-reports_ to version 3.1.3 which introduces a fix for an issue with "reverse tabnabbing". The description, and associated PR, for this fix can be found here:

```
https://github.com/istanbuljs/istanbuljs/pull/591
```
