### PR TITLE
docs: Remove babel-jest from "required dependencies" for using Babel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Chore & Maintenance
 
+- `[docs]`  Remove babel-jest from "required dependencies" for using Babel ([#12228](https://github.com/facebook/jest/pull/12228))
 - `[*]` Update graceful-fs to ^4.2.9 ([#11749](https://github.com/facebook/jest/pull/11749))
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Chore & Maintenance
 
-- `[docs]`  Remove babel-jest from "required dependencies" for using Babel ([#12228](https://github.com/facebook/jest/pull/12228))
+- `[docs]`  Remove `babel-jest` from "required dependencies" for using Babel ([#12228](https://github.com/facebook/jest/pull/12228))
 - `[*]` Update graceful-fs to ^4.2.9 ([#11749](https://github.com/facebook/jest/pull/11749))
 
 ### Performance

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -84,7 +84,7 @@ jest --init
 To use [Babel](https://babeljs.io/), install required dependencies via `yarn`:
 
 ```bash
-yarn add --dev babel-jest @babel/core @babel/preset-env
+yarn add --dev @babel/core @babel/preset-env
 ```
 
 Configure Babel to target your current version of Node by creating a `babel.config.js` file in the root of your project:


### PR DESCRIPTION
## Summary

The "Using Babel" section of [Getting Started](https://jestjs.io/docs/getting-started) includes `babel-jest` in the step "install required dependencies." But as the same doc page [points out in a note](https://github.com/facebook/jest/blob/5d483ce07e450d7c1148ac961877ff0ac46f39a9/docs/GettingStarted.md?plain=1#L115), "`babel-jest` is automatically installed when installing Jest." It comes in as a dependency through the chain `jest` ➡️ `@jest/core` ➡️ `jest-config` ➡️ [`babel-jest`](https://github.com/facebook/jest/blob/5d483ce07e450d7c1148ac961877ff0ac46f39a9/packages/jest-config/package.json#L31).

Therefore, installing `babel-jest` is redundant at best. At worst, it means that two competing versions of `babel-jest` could exist in a project's `node_modules` tree.