### PR TITLE
make jsdom accessible to extending environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[jest-phabricator]` [**BREAKING**] Convert to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
+- `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 ### Fixes
 
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
-- `[jest-phabricator]` [**BREAKING**] Convert to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 - `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
+- `[jest-phabricator]` [**BREAKING**] Convert to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -20,14 +20,14 @@
     "@jest/environment": "^27.5.1",
     "@jest/fake-timers": "^27.5.1",
     "@jest/types": "^27.5.1",
+    "@types/jsdom": "^16.2.4",
     "@types/node": "*",
     "jest-mock": "^27.5.1",
     "jest-util": "^27.5.1",
     "jsdom": "^19.0.0"
   },
   "devDependencies": {
-    "@jest/test-utils": "^27.5.1",
-    "@types/jsdom": "^16.2.4"
+    "@jest/test-utils": "^27.5.1"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -23,7 +23,7 @@ type Win = Window &
   };
 
 export default class JSDOMEnvironment implements JestEnvironment<number> {
-  private dom: JSDOM | null;
+  dom: JSDOM | null;
   fakeTimers: LegacyFakeTimers<number> | null;
   fakeTimersModern: ModernFakeTimers | null;
   global: Win;


### PR DESCRIPTION
Fixes: https://github.com/facebook/jest/issues/12233

I initially wanted to create an issue, but thought it may be better if I opened a PR. Please let me know if you'd rather have me open an issue.

In https://github.com/facebook/jest/commit/f9814d2b4004cc99151ebaf04a2765cf0d5a844f `dom` has been made private.

This causes extending environments that depend on `this.dom` being available like [jest-environment-jsdom-global](https://www.npmjs.com/package/jest-environment-jsdom-global) to break **if** they use TypeScript. 

The error you get if you try to access `this.dom` in an environment:
```
 Property 'dom' is private and only accessible within class 'JSDOMEnvironment'.
```

```ts
export class JSDOMEnvironmentGlobal extends JSDOMEnvironment {
  constructor(config, options) {
    super(config, options);

   // this line triggers the error
    this.global.jsdom = this.dom;
  }
}
```



I prepared a [small reproduction repository](https://github.com/robin-drexler/jest-example-private-dom).
It uses a custom TS environment [that tries to access `this.dom`](https://github.com/robin-drexler/jest-example-private-dom/blob/8256f758dfc23dca2670248cd8f4d81db09e5e9a/jest-env.ts#L7) and fails.

To see for yourself: 
- clone the repo
- run `npm install`
- run `npx jest`


`jest-environment-jsdom-global` itself is actually unaffected because it uses JS and the transpiled CommonJS version of `jest-environment-jsdom` doesn't enforce `this.dom` to be private. If `jest` changes its bundling process in the future, this could also fail for projects using JS.

I think it'd be great if `jsdom` continued to be accessible for custom environments since that enables use cases that would otherwise not be possible.