### PR TITLE
chore(docs): clarify timer-mocks page

### DIFF
--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -151,9 +151,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-
 ```javascript title="__tests__/timerGame-test.js"
-
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -58,6 +58,7 @@ test('do something with real timers', () => {
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -151,6 +152,8 @@ module.exports = timerGame;
 ```
 
 ```javascript
+// __tests__/timerGame-test.js
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -151,8 +151,9 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
-// __tests__/timerGame-test.js
+
+```javascript title="__tests__/timerGame-test.js"
+
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-25.x/TimerMocks.md
+++ b/website/versioned_docs/version-25.x/TimerMocks.md
@@ -137,8 +137,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
-// __tests__/timerGame-test.js
+```javascript title="__tests__/timerGame-test.js"
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-25.x/TimerMocks.md
+++ b/website/versioned_docs/version-25.x/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 
 test('waits 1 second before ending the game', () => {
   const timerGame = require('../timerGame');
@@ -35,11 +35,14 @@ test('waits 1 second before ending the game', () => {
 
 Here we enable fake timers by calling `jest.useFakeTimers();`. This mocks out setTimeout and other timer functions with mock functions. If running multiple tests inside of one file or describe block, `jest.useFakeTimers();` can be called before each test manually or with a setup function such as `beforeEach`. Not doing so will result in the internal usage counter not being reset.
 
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
+
 ## Run All Timers
 
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -135,6 +138,8 @@ module.exports = timerGame;
 ```
 
 ```javascript
+// __tests__/timerGame-test.js
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/website/versioned_docs/version-26.x/TimerMocks.md
+++ b/website/versioned_docs/version-26.x/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 
 test('waits 1 second before ending the game', () => {
   const timerGame = require('../timerGame');
@@ -35,11 +35,14 @@ test('waits 1 second before ending the game', () => {
 
 Here we enable fake timers by calling `jest.useFakeTimers();`. This mocks out setTimeout and other timer functions with mock functions. If running multiple tests inside of one file or describe block, `jest.useFakeTimers();` can be called before each test manually or with a setup function such as `beforeEach`. Not doing so will result in the internal usage counter not being reset.
 
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
+
 ## Run All Timers
 
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -135,6 +138,7 @@ module.exports = timerGame;
 ```
 
 ```javascript
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/website/versioned_docs/version-26.x/TimerMocks.md
+++ b/website/versioned_docs/version-26.x/TimerMocks.md
@@ -137,7 +137,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
+```javascript title="__tests__/timerGame-test.js"
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-27.0/TimerMocks.md
+++ b/website/versioned_docs/version-27.0/TimerMocks.md
@@ -153,8 +153,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
-// __tests__/timerGame-test.js
+```javascript title="__tests__/timerGame-test.js"
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-27.0/TimerMocks.md
+++ b/website/versioned_docs/version-27.0/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 jest.spyOn(global, 'setTimeout');
 
 test('waits 1 second before ending the game', () => {
@@ -53,11 +53,14 @@ test('do something with real timers', () => {
 });
 ```
 
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
+
 ## Run All Timers
 
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -151,6 +154,8 @@ module.exports = timerGame;
 ```
 
 ```javascript
+// __tests__/timerGame-test.js
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/website/versioned_docs/version-27.1/TimerMocks.md
+++ b/website/versioned_docs/version-27.1/TimerMocks.md
@@ -153,8 +153,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
-// __tests__/timerGame-test.js
+```javascript title="__tests__/timerGame-test.js"
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-27.1/TimerMocks.md
+++ b/website/versioned_docs/version-27.1/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 jest.spyOn(global, 'setTimeout');
 
 test('waits 1 second before ending the game', () => {
@@ -53,11 +53,14 @@ test('do something with real timers', () => {
 });
 ```
 
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
+
 ## Run All Timers
 
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -151,6 +154,8 @@ module.exports = timerGame;
 ```
 
 ```javascript
+// __tests__/timerGame-test.js
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/website/versioned_docs/version-27.2/TimerMocks.md
+++ b/website/versioned_docs/version-27.2/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 jest.spyOn(global, 'setTimeout');
 
 test('waits 1 second before ending the game', () => {
@@ -52,6 +52,8 @@ test('do something with real timers', () => {
   // ...
 });
 ```
+
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
 
 ## Run All Timers
 

--- a/website/versioned_docs/version-27.2/TimerMocks.md
+++ b/website/versioned_docs/version-27.2/TimerMocks.md
@@ -152,7 +152,8 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
+```javascript title="__tests__/timerGame-test.js"
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();

--- a/website/versioned_docs/version-27.4/TimerMocks.md
+++ b/website/versioned_docs/version-27.4/TimerMocks.md
@@ -153,8 +153,7 @@ function timerGame(callback) {
 module.exports = timerGame;
 ```
 
-```javascript
-// __tests__/timerGame-test.js
+```javascript title="__tests__/timerGame-test.js"
 jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');

--- a/website/versioned_docs/version-27.4/TimerMocks.md
+++ b/website/versioned_docs/version-27.4/TimerMocks.md
@@ -22,7 +22,7 @@ module.exports = timerGame;
 ```javascript title="__tests__/timerGame-test.js"
 'use strict';
 
-jest.useFakeTimers();
+jest.useFakeTimers(); // or you can set "timers": "fake" globally in configuration file
 jest.spyOn(global, 'setTimeout');
 
 test('waits 1 second before ending the game', () => {
@@ -53,11 +53,14 @@ test('do something with real timers', () => {
 });
 ```
 
+All of the following functions need fake timers to be set, either by `jest.useFakeTimers()` or via `"timers": "fake"` in the config file.
+
 ## Run All Timers
 
 Another test we might want to write for this module is one that asserts that the callback is called after 1 second. To do this, we're going to use Jest's timer control APIs to fast-forward time right in the middle of the test:
 
 ```javascript
+jest.useFakeTimers();
 test('calls the callback after 1 second', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
@@ -151,6 +154,8 @@ module.exports = timerGame;
 ```
 
 ```javascript
+// __tests__/timerGame-test.js
+jest.useFakeTimers();
 it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();


### PR DESCRIPTION

Documentation page:
https://jestjs.io/docs/timer-mocks

Summary
this page seems to have a lot of stuff which can make the reader confused, this need improvement

https://jestjs.io/docs/timer-mocks#run-all-timers
https://jestjs.io/docs/timer-mocks#advance-timers-by-time
All sections need fake-timers to be set and this hasn't been mentioned anywhere in the documentation!

+Some clean-up!
