### PR TITLE
Adds needed capitalization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ module.exports = {
 
 ### Using webpack
 
-Jest can be used in projects that use [webpack](https://webpack.js.org/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](https://jestjs.io/docs/webpack) to get started.
+Jest can be used in projects that use [webpack](https://webpack.js.org/) to manage assets, styles, and compilation. Webpack does offer some unique challenges over other tools. Refer to the [webpack guide](https://jestjs.io/docs/webpack) to get started.
 
 ### Using parcel
 


### PR DESCRIPTION
Webpack was not capitalized, noticed it on https://jestjs.io/docs/getting-started and then found it here.