### PR TITLE
chore: use `u` flag for regexes

### DIFF
--- a/e2e/__tests__/declarationErrors.test.ts
+++ b/e2e/__tests__/declarationErrors.test.ts
@@ -19,7 +19,7 @@ const extractMessage = (str: string) =>
       )
       .match(
         // all lines from the first to the last mentioned "describe" after the "●" line
-        /●(.|\n)*?\n(?<lines>.*describe((.|\n)*describe)*.*)(\n|$)/im,
+        /●(.|\n)*?\n(?<lines>.*describe((.|\n)*describe)*.*)(\n|$)/imu,
       )?.groups?.lines ?? '',
   );
 

--- a/packages/jest-repl/src/__tests__/jest_repl.test.js
+++ b/packages/jest-repl/src/__tests__/jest_repl.test.js
@@ -29,7 +29,7 @@ describe('Repl', () => {
         env: process.env,
       });
       expect(output.stderr.trim()).toBe('');
-      expect(output.stdout.trim()).toMatch(/›/);
+      expect(output.stdout.trim()).toMatch(/›/u);
     });
   });
 });

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -278,7 +278,7 @@ export const wrapAnsiString = (
     return string;
   }
 
-  const ANSI_REGEXP = /[\u001b\u009b]\[\d{1,2}m/g;
+  const ANSI_REGEXP = /[\u001b\u009b]\[\d{1,2}m/gu;
   const tokens = [];
   let lastIndex = 0;
   let match;


### PR DESCRIPTION
Usage of the u flag with regular expressions is recommended.

The u flag has two effects:

It enables correct handling of UTF-16 surrogate pairs.
It ensures the correct behavior of regex character ranges.

```
/^[👍]$/.test("👍") //→ false
/^[👍]$/u.test("👍") //→ true

```

Make the regular expression throwing syntax errors early as disabling JavaScript specification Annex B[1] extensions.

Because of historical reason, JavaScript regular expressions are tolerant of syntax errors. For example, /\w{1, 2/ is a syntax error, but JavaScript doesn't throw the error. It matches strings such as "a{1, 2" instead. Such a recovering logic is defined in Annex B of Javascript specification.

The u flag disables the recovering logic Annex B of the Javascript specification. As a result, you can find errors early. This is similar to the strict mode.