### PR TITLE
fix: support `.toHaveProperty('')`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[expect]` Add a fix for `.toHaveProperty('')` ([#12251](https://github.com/facebook/jest/pull/12251))
+
 ### Chore & Maintenance
 
 - `[*]` Update graceful-fs to ^4.2.9 ([#11749](https://github.com/facebook/jest/pull/11749))

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1898,6 +1898,7 @@ describe('.toHaveProperty()', () => {
     [new E('div'), 'nodeType', 1],
     ['', 'length', 0],
     [memoized, 'memo', []],
+    [{'': 1}, '', 1],
   ].forEach(([obj, keyPath, value]) => {
     test(`{pass: true} expect(${stringify(
       obj,

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -373,9 +373,15 @@ export const partition = <T>(
 };
 
 export const pathAsArray = (propertyPath: string): Array<any> => {
+  const properties: Array<string> = [];
+
+  if (propertyPath === '') {
+    properties.push('');
+    return properties;
+  }
+
   // will match everything that's not a dot or a bracket, and "" for consecutive dots.
   const pattern = RegExp('[^.[\\]]+|(?=(?:\\.)(?:\\.|$))', 'g');
-  const properties: Array<string> = [];
 
   // Because the regex won't match a dot in the beginning of the path, if present.
   if (propertyPath[0] === '.') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When I try using `.toHaveProperty()` with an empty string:

```js
expect({ '': 1 }).toHaveProperty('', 1);
```

It gets the following error:

```
    expect(received).toHaveProperty(path, value)

    Expected path: ""

    Expected value: 1
    Received value: {"": 1}
```

I believe it's a bug.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added a failed test.
