### PR TITLE
chore: Fix typo in tests

### DIFF
--- a/e2e/__tests__/__snapshots__/listTests.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/listTests.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
-/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js
-/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js
+/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js
+/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/other.test.js
 `;
 
 exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js"]`;

--- a/e2e/__tests__/__snapshots__/listTests.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/listTests.test.ts.snap
@@ -5,4 +5,4 @@ exports[`--listTests flag causes tests to be printed in different lines 1`] = `
 /MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/other.test.js
 `;
 
-exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js"]`;
+exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/other.test.js"]`;

--- a/e2e/__tests__/listTests.test.ts
+++ b/e2e/__tests__/listTests.test.ts
@@ -14,7 +14,7 @@ const testRootDir = path.resolve(__dirname, '..', '..');
 const normalizePaths = (rawPaths: string) =>
   rawPaths
     .split(testRootDir)
-    .join(`${path.sep}MOCK_ABOLUTE_PATH`)
+    .join(`${path.sep}MOCK_ABSOLUTE_PATH`)
     .split('\\')
     .join('/');
 

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -112,7 +112,7 @@ describe('custom transformer', () => {
     'transform/custom-instrumenting-preprocessor',
   );
 
-  it('proprocesses files', () => {
+  it('preprocesses files', () => {
     const {json, stderr} = runWithJson(dir, ['--no-cache']);
     expect(stderr).toMatch(/FAIL/);
     expect(stderr).toMatch(/instruments by setting.*global\.__INSTRUMENTED__/);


### PR DESCRIPTION
`/MOCK_ABOLUTE_PATH/` ----> `/MOCK_ABSOLUTE_PATH/`
`proprocess` ----> `preprocess`

