### PR TITLE
fix(matcher-utils): correct diff for expect asymmetric matchers

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2175,8 +2175,15 @@ Received: <r>{"0": "a", "1": "b", "2": "c"}</>
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <g>ObjectContaining {"a": 2}</>
-Received: <r>{"a": 1, "b": 2}</>
+<g>- Expected  - 2</>
+<r>+ Received  + 3</>
+
+<g>- ObjectContaining {</>
+<g>-   "a": 2,</>
+<r>+ Object {</>
+<r>+   "a": 1,</>
+<r>+   "b": 2,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1}).toEqual({"a": 2}) 1`] = `
@@ -3558,6 +3565,14 @@ exports[`.toHaveProperty() {pass: true} expect([Function memoized]).toHaveProper
 Expected path: <g>"memo"</>
 
 Expected value: not <g>[]</>
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"": 1}).toHaveProperty('', 1) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
+
+Expected path: <g>""</>
+
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [[{"c": [{"d": 1}]}]]}}).toHaveProperty('a.b[0][0].c[0].d', 1) 1`] = `

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
@@ -88,6 +88,25 @@ exports[`ensureNumbers() with options promise resolves isNot true expected 1`] =
 Expected has value: <g>null</>
 `;
 
+exports[`printDiffOrStringify expected asymmetric matchers should be diffable 1`] = `
+<g>- Expected  - 2</>
+<r>+ Received  + 2</>
+
+<g>- ObjectContaining {</>
+<r>+ Object {</>
+<d>    "array": Array [</>
+<d>      Object {</>
+<d>        "3": "three",</>
+<d>        "four": "4",</>
+<d>        "one": 1,</>
+<g>-       "two": 2,</>
+<r>+       "two": 1,</>
+<d>      },</>
+<d>    ],</>
+<d>    "foo": "bar",</>
+<d>  }</>
+`;
+
 exports[`stringify() toJSON errors when comparing two objects 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -342,3 +342,37 @@ describe('matcherHint', () => {
     expect(received).toMatch(substringPositive);
   });
 });
+
+describe('printDiffOrStringify', () => {
+  test('expected asymmetric matchers should be diffable', () => {
+    jest.dontMock('jest-diff');
+    jest.resetModules();
+    const {printDiffOrStringify} = require('../');
+
+    const expected = expect.objectContaining({
+      array: [
+        {
+          3: 'three',
+          four: '4',
+          one: 1,
+          two: 2,
+        },
+      ],
+      foo: 'bar',
+    });
+    const received = {
+      array: [
+        {
+          3: 'three',
+          four: '4',
+          one: 1,
+          two: 1,
+        },
+      ],
+      foo: 'bar',
+    };
+    expect(
+      printDiffOrStringify(expected, received, 'Expected', 'Received', false),
+    ).toMatchSnapshot();
+  });
+});

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -294,13 +294,6 @@ const isLineDiffable = (expected: unknown, received: unknown): boolean => {
   }
 
   if (
-    expectedType === 'object' &&
-    typeof (expected as any).asymmetricMatch === 'function'
-  ) {
-    return false;
-  }
-
-  if (
     receivedType === 'object' &&
     typeof (received as any).asymmetricMatch === 'function'
   ) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #10276 - I've applied @SamLee's [suggestion](https://github.com/facebook/jest/issues/10276#issuecomment-660663201)

Problem:

```javascript
// Where objectContaining is the wrapping the expectation the diff would not work as expected
expect(obj).toEqual(expect.objectContaining(obj2));
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### Before
<img width="749" alt="Screen Shot 2022-01-21 at 11 04 38" src="https://user-images.githubusercontent.com/881849/150521770-3221cfa9-d636-4b87-ae0a-ff654c2b2c19.png">

### After
<img width="646" alt="Screen Shot 2022-01-21 at 11 09 31" src="https://user-images.githubusercontent.com/881849/150521773-d70bbb88-d025-4373-a30c-35491136d93b.png">
