### PR TITLE
jest-environment-node: add `atob` and `btoa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-environment-node]` Add `atob` and `btoa` ([#12269](https://github.com/facebook/jest/pull/12269))
+
 ### Chore & Maintenance
 
 - `[*]` Update graceful-fs to ^4.2.9 ([#11749](https://github.com/facebook/jest/pull/11749))

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -82,6 +82,13 @@ class NodeEnvironment implements JestEnvironment<Timer> {
     if (typeof performance !== 'undefined') {
       global.performance = performance;
     }
+    if (
+      typeof atob !== 'undefined' &&
+      typeof btoa !== 'undefined'
+    ) {
+      global.atob = atob;
+      global.btoa = btoa;
+    }
     installCommonGlobals(global, config.globals);
 
     this.moduleMocker = new ModuleMocker(global);

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -82,7 +82,7 @@ class NodeEnvironment implements JestEnvironment<Timer> {
     if (typeof performance !== 'undefined') {
       global.performance = performance;
     }
-    // performance is global in Node >= 16
+    // atob and btoa are global in Node >= 16
     if (typeof atob !== 'undefined' && typeof btoa !== 'undefined') {
       global.atob = atob;
       global.btoa = btoa;

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -82,10 +82,8 @@ class NodeEnvironment implements JestEnvironment<Timer> {
     if (typeof performance !== 'undefined') {
       global.performance = performance;
     }
-    if (
-      typeof atob !== 'undefined' &&
-      typeof btoa !== 'undefined'
-    ) {
+    // performance is global in Node >= 16
+    if (typeof atob !== 'undefined' && typeof btoa !== 'undefined') {
       global.atob = atob;
       global.btoa = btoa;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`atob` and `btoa` are [available as globals](https://nodejs.org/api/globals.html#atobdata) since Node.js 16.0.0, I think Jest should leave them available as well.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes: https://github.com/facebook/jest/issues/12268

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Does this need tests?
