### PR TITLE
fix(message-utils): convert URLs to paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-message-util]` Fix `.getTopFrame()` (and `toMatchInlineSnapshot()`) with `mjs` files ([#12277](https://github.com/facebook/jest/pull/12277))
 - `[expect]` Add a fix for `.toHaveProperty('')` ([#12251](https://github.com/facebook/jest/pull/12251))
 - `[jest-environment-node]` Add `atob` and `btoa` ([#12269](https://github.com/facebook/jest/pull/12269))
 

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -373,7 +373,7 @@ describe('formatStackTrace', () => {
 
 it('getTopFrame should return a path for mjs files', () => {
   const frame = getTopFrame([
-    '  at stack (file:///Users/user/project/inline.mjs:1:1)'
+    '  at stack (file:///Users/user/project/inline.mjs:1:1)',
   ]);
 
   expect(frame.file).toBe('/Users/user/project/inline.mjs');

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,7 +9,7 @@
 import {readFileSync} from 'graceful-fs';
 import slash = require('slash');
 import tempy = require('tempy');
-import {formatExecError, formatResultsErrors, formatStackTrace} from '..';
+import {formatExecError, formatResultsErrors, formatStackTrace, getTopFrame} from '..';
 
 const rootDir = tempy.directory();
 
@@ -364,4 +364,10 @@ describe('formatStackTrace', () => {
 
     expect(message).toMatchSnapshot();
   });
+});
+
+it('getTopFrame should return a path for mjs files', () => {
+  const frame = getTopFrame(['  at stack (file:///Users/user/project/inline.mjs:1:1)']);
+
+  expect(frame.file).toBe('/Users/user/project/inline.mjs');
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,7 +9,12 @@
 import {readFileSync} from 'graceful-fs';
 import slash = require('slash');
 import tempy = require('tempy');
-import {formatExecError, formatResultsErrors, formatStackTrace, getTopFrame} from '..';
+import {
+  formatExecError,
+  formatResultsErrors,
+  formatStackTrace,
+  getTopFrame,
+} from '..';
 
 const rootDir = tempy.directory();
 
@@ -367,7 +372,9 @@ describe('formatStackTrace', () => {
 });
 
 it('getTopFrame should return a path for mjs files', () => {
-  const frame = getTopFrame(['  at stack (file:///Users/user/project/inline.mjs:1:1)']);
+  const frame = getTopFrame([
+    '  at stack (file:///Users/user/project/inline.mjs:1:1)'
+  ]);
 
   expect(frame.file).toBe('/Users/user/project/inline.mjs');
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -372,9 +372,16 @@ describe('formatStackTrace', () => {
 });
 
 it('getTopFrame should return a path for mjs files', () => {
-  const frame = getTopFrame([
-    '  at stack (file:///Users/user/project/inline.mjs:1:1)',
-  ]);
+  let stack: Array<string>;
+  let expectedFile: string;
+  if (process.platform === 'win32') {
+    stack = ['  at stack (file:///C:/Users/user/project/inline.mjs:1:1)'];
+    expectedFile = 'C:/Users/user/project/inline.mjs';
+  } else {
+    stack = ['  at stack (file:///Users/user/project/inline.mjs:1:1)'];
+    expectedFile = '/Users/user/project/inline.mjs';
+  }
+  const frame = getTopFrame(stack);
 
-  expect(frame.file).toBe('/Users/user/project/inline.mjs');
+  expect(frame.file).toBe(expectedFile);
 });

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -14,6 +14,7 @@ import slash = require('slash');
 import StackUtils = require('stack-utils');
 import type {Config, TestResult} from '@jest/types';
 import {format as prettyFormat} from 'pretty-format';
+import {fileURLToPath} from 'url';
 import type {Frame} from './types';
 
 export type {Frame} from './types';
@@ -273,6 +274,9 @@ export const getTopFrame = (lines: Array<string>): Frame | null => {
     const parsedFrame = stackUtils.parseLine(line.trim());
 
     if (parsedFrame && parsedFrame.file) {
+      if (parsedFrame.file.startsWith('file://')) {
+        parsedFrame.file = fileURLToPath(parsedFrame.file);
+      }
       return parsedFrame as Frame;
     }
   }

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import {fileURLToPath} from 'url';
 import {codeFrameColumns} from '@babel/code-frame';
 import chalk = require('chalk');
 import * as fs from 'graceful-fs';
@@ -14,7 +15,6 @@ import slash = require('slash');
 import StackUtils = require('stack-utils');
 import type {Config, TestResult} from '@jest/types';
 import {format as prettyFormat} from 'pretty-format';
-import {fileURLToPath} from 'url';
 import type {Frame} from './types';
 
 export type {Frame} from './types';
@@ -275,7 +275,7 @@ export const getTopFrame = (lines: Array<string>): Frame | null => {
 
     if (parsedFrame && parsedFrame.file) {
       if (parsedFrame.file.startsWith('file://')) {
-        parsedFrame.file = fileURLToPath(parsedFrame.file);
+        parsedFrame.file = slash(fileURLToPath(parsedFrame.file));
       }
       return parsedFrame as Frame;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Workaround for tapjs/stack-utils#60

`toMatchInlineSnapshot` with mjs files causes the following error:
```
     Error: ENOENT: no such file or directory, open 'file:///Users/mshima/git/test/inline.mjs'
      at Object.openSync (node:fs:585:3)
      at readFileSync (node:fs:453:35)
      at saveSnapshotsForFile (node_modules/jest-snapshot/build/InlineSnapshots.js:127:22)
      at saveInlineSnapshots (node_modules/jest-snapshot/build/InlineSnapshots.js:116:5)
      at SnapshotState.save (node_modules/jest-snapshot/build/State.js:191:50)
```

Inspired by https://github.com/microsoft/playwright/pull/10043.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
