### PR TITLE
fix:Added allowing for tests in node modules

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -508,6 +508,8 @@ type HasteConfig = {
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
   /** Whether to throw on error on module collision. */
+  // Whether to search for tests in node_modules.
+  retainAllFiles?: boolean;
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -64,6 +64,7 @@ const initialOptions: Config.InitialOptions = {
     hasteImplModulePath: '<rootDir>/haste_impl.js',
     hasteMapModulePath: '',
     platforms: ['ios', 'android'],
+    retainAllFiles: false,
     throwOnModuleCollision: false,
   },
   injectGlobals: true,

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -58,6 +58,7 @@ export type WorkerMessage = {
   rootDir: string;
   filePath: string;
   hasteImplModulePath?: string;
+  retainAllFiles?: boolean;
 };
 
 export type WorkerMetadata = {

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -37,6 +37,8 @@ export type HasteConfig = {
   /** Whether to throw on error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
+  /** Whether to search for tests in node_modules. */
+  retainAllFiles?: boolean;
   hasteMapModulePath?: string;
 };
 


### PR DESCRIPTION
In order to be able to inherit a common Jest test from an npm module, the user needs to be able to search for tests in the node_modules directory. The boolean "retainAllFiles" had been hard-coded to false, preventing this inheritance from being possible. The changes here expose the variable via the "haste" configuration property and allow the user to optionally scan the node_modules for test patterns.

```
$ npx jest --testRegex "/*(.pact.test.js)" --runInBand
 PASS  test/src/Health.pact.test.js (9.646 s)
 PASS  node_modules/@aw/node-testing/dist/test/health.pact.test.js (5.922 s)

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        15.733 s
Ran all test suites.

```