### PR TITLE
refactor(jest-runner): remove unnecessary ProcessTerminatedError logic

### DIFF
--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -25,7 +25,6 @@
     "@types/node": "*",
     "chalk": "^4.0.0",
     "emittery": "^0.8.1",
-    "exit": "^0.1.2",
     "graceful-fs": "^4.2.9",
     "jest-docblock": "^27.4.0",
     "jest-environment-jsdom": "^27.4.6",

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -7,10 +7,8 @@
 
 import chalk = require('chalk');
 import Emittery = require('emittery');
-import exit = require('exit');
 import throat from 'throat';
 import type {
-  SerializableError,
   Test,
   TestEvents,
   TestFileEvent,
@@ -225,22 +223,6 @@ export default class TestRunner {
         return promise;
       });
 
-    const onError = async (err: SerializableError, test: Test) => {
-      // Remove `if(onFailure)` in Jest 27
-      if (onFailure) {
-        await onFailure(test, err);
-      } else {
-        await this.eventEmitter.emit('test-file-failure', [test, err]);
-      }
-      if (err.type === 'ProcessTerminatedError') {
-        console.error(
-          'A worker process has quit unexpectedly! ' +
-            'Most likely this is an initialization error.',
-        );
-        exit(1);
-      }
-    };
-
     const onInterrupt = new Promise((_, reject) => {
       watcher.on('change', state => {
         if (state.interrupted) {
@@ -262,7 +244,13 @@ export default class TestRunner {
               ]);
             }
           })
-          .catch(error => onError(error, test)),
+          .catch(error => {
+            if (onFailure) {
+              return onFailure(test, error);
+            } else {
+              return this.eventEmitter.emit('test-file-failure', [test, error]);
+            }
+          }),
       ),
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13064,7 +13064,6 @@ __metadata:
     "@types/source-map-support": ^0.5.0
     chalk: ^4.0.0
     emittery: ^0.8.1
-    exit: ^0.1.2
     graceful-fs: ^4.2.9
     jest-docblock: ^27.4.0
     jest-environment-jsdom: ^27.4.6


### PR DESCRIPTION
## Summary

Long story short, I was playing with a custom runner by adapting the code from Jest repo. As always I tried to understand how it works. All was more or less clear except the `if (err.type === 'ProcessTerminatedError')` part. What is this error? Is it originating from the worker, or child process, or Node in general? Seems like not.

Searching around points to `worker-farm` library which has [ProcessTerminatedError](https://github.com/rvagg/node-worker-farm/blob/24ad68de3090e6c18d37f0db8c738fa994c1d32c/lib/farm.js#L18). The `worker-farm` was introduced with #540 and remove in #4825. `if (err.type === 'ProcessTerminatedError')` got added with `worker-farm`, but was not removed later.

Perhaps there is something I missed, but it seems like `if (err.type === 'ProcessTerminatedError')` does nothing and can be safely removed. Or?

## Test plan

All test should pass.