### PR TITLE
fix(@jest/globals): add missing `options` argument to `jest.doMock` typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Fixes
 
-- `[matcher-utils]` Correct diff for expected asymmetric matchers (#12264)[https://github.com/facebook/jest/pull/12264]
 - `[expect]` Add a fix for `.toHaveProperty('')` ([#12251](https://github.com/facebook/jest/pull/12251))
+- `[@jest/globals]` Add missing `options` argument to `jest.doMock` typing ([#12292](https://github.com/facebook/jest/pull/12292))
 - `[jest-environment-node]` Add `atob` and `btoa` ([#12269](https://github.com/facebook/jest/pull/12269))
+- `[matcher-utils]` Correct diff for expected asymmetric matchers (#12264)[https://github.com/facebook/jest/pull/12264]
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -92,7 +92,11 @@ export interface Jest {
    * the top of the code block. Use this method if you want to explicitly avoid
    * this behavior.
    */
-  doMock(moduleName: string, moduleFactory?: () => unknown): Jest;
+  doMock(
+    moduleName: string,
+    moduleFactory?: () => unknown,
+    options?: {virtual?: boolean},
+  ): Jest;
   /**
    * Indicates that the module system should never return a mocked version
    * of the specified module from require() (e.g. that it should always return

--- a/packages/jest-types/__typechecks__/jest.test.ts
+++ b/packages/jest-types/__typechecks__/jest.test.ts
@@ -20,9 +20,8 @@ expectType<typeof jest>(jest.deepUnmock('moduleName'));
 expectType<typeof jest>(jest.disableAutomock());
 expectType<typeof jest>(jest.doMock('moduleName'));
 expectType<typeof jest>(jest.doMock('moduleName', jest.fn()));
-
-expectError(jest.doMock('moduleName', jest.fn(), {}));
-expectError(jest.doMock('moduleName', jest.fn(), {virtual: true}));
+expectType<typeof jest>(jest.doMock('moduleName', jest.fn(), {}));
+expectType<typeof jest>(jest.doMock('moduleName', jest.fn(), {virtual: true}));
 
 expectType<typeof jest>(jest.dontMock('moduleName'));
 expectType<typeof jest>(jest.enableAutomock());


### PR DESCRIPTION
Fixes #12289

## Summary

As it was noted in the issue, `jest.doMock` typing is missing `options` argument. Easy to fix.

## Test plan

Type test is updated.