### PR TITLE
Feat:-Added Manual mock extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+`[jest-haste-map]` Add support for .mock extension for manual mocks ([#12295](https://github.com/facebook/jest/pull/12295))
+
 ### Fixes
 
 - `[@jest/transform]` Update dependency package `pirates` to 4.0.4 ([#12136](https://github.com/facebook/jest/pull/12136))

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -19,6 +19,10 @@ Scoped modules (also known as [scoped packages](https://docs.npmjs.com/cli/v6/us
 
 > Warning: If we want to mock Node's core modules (e.g.: `fs` or `path`), then explicitly calling e.g. `jest.mock('path')` is **required**, because core Node modules are not mocked by default.
 
+## Avoiding name collisions with manual mocks
+
+Manual mocks in a `__mocks__/` subdirectory may also be tagged with an explicit `.mock` extension suffix to prevent filename collision with the original code. For example, a module called `account` in the `models` directory can be mocked by creating a file called `account.mock.js` in the `models/__mocks__` directory.
+
 ## Examples
 
 ```bash
@@ -28,7 +32,9 @@ Scoped modules (also known as [scoped packages](https://docs.npmjs.com/cli/v6/us
 │   └── fs.js
 ├── models
 │   ├── __mocks__
+│   │   ├── account.mock.js
 │   │   └── user.js
+│   ├── account.js
 │   └── user.js
 ├── node_modules
 └── views

--- a/e2e/resolve/__mocks__/Test9.mock.js
+++ b/e2e/resolve/__mocks__/Test9.mock.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {key: 'mock'};

--- a/e2e/resolve/__tests__/resolve.test.js
+++ b/e2e/resolve/__tests__/resolve.test.js
@@ -83,6 +83,13 @@ test('should require resolve haste files correctly', () => {
   expect(require.resolve('Test6')).toBe(require.resolve('../__mocks__/Test6'));
 
   expect(require('Test6').key).toBe('mock');
+
+  // Same as Test6
+  expect(require.resolve('Test9')).toBe(
+    require.resolve('../__mocks__/Test9.mock'),
+  );
+
+  expect(require('Test9').key).toBe('mock');
 });
 
 test('should require resolve haste mocks correctly', () => {
@@ -99,6 +106,13 @@ test('should require resolve haste mocks correctly', () => {
   expect(require.resolve('Test6')).toBe(require.resolve('../__mocks__/Test6'));
 
   expect(require('Test6').key).toBe('mock');
+
+  // Same as Test6
+  expect(require.resolve('Test9')).toBe(
+    require.resolve('../__mocks__/Test9.mock'),
+  );
+
+  expect(require('Test9').key).toBe('mock');
 });
 
 test('should throw module not found error if the module has dependencies that cannot be found', () => {

--- a/packages/jest-haste-map/src/__tests__/get_mock_name.test.js
+++ b/packages/jest-haste-map/src/__tests__/get_mock_name.test.js
@@ -17,5 +17,9 @@ describe('getMockName', () => {
     expect(getMockName(path.join('a', '__mocks__', 'c', 'd.js'))).toBe(
       path.join('c', 'd').replace(/\\/g, '/'),
     );
+
+    expect(getMockName(path.join('a', '__mocks__', 'e.mock.js'))).toBe('e');
+
+    expect(getMockName(path.join('a', '__mocks__', 'e.m.js'))).toBe('e.m');
   });
 });

--- a/packages/jest-haste-map/src/getMockName.ts
+++ b/packages/jest-haste-map/src/getMockName.ts
@@ -11,9 +11,12 @@ const MOCKS_PATTERN = path.sep + '__mocks__' + path.sep;
 
 const getMockName = (filePath: string): string => {
   const mockPath = filePath.split(MOCKS_PATTERN)[1];
-  return mockPath
+  const mockName = mockPath
     .substring(0, mockPath.lastIndexOf(path.extname(mockPath)))
     .replace(/\\/g, '/');
+
+  if (mockName.slice(-5) === '.mock') return mockName.slice(0, -5);
+  else return mockName;
 };
 
 export default getMockName;


### PR DESCRIPTION
This PR allows manual mocks files to be named either `moduleName.ext`or `moduleName.mock.ext` while still resolving to `moduleName`. This does not change the requirement that manual mocks be placed in the __mocks__ directory.

This is a very useful distinctions for IDEs with fuzzy/quick search features such as sublime or vscode. Under the existing paradigm all mocks will by necessity have name collisions with the files they are trying to mock. When attempting to navigate around a large codebase using such a search mechanism, it's easy to open the wrong file without noticing the path information which is usually presented in a dimmer color. This problem is compounded by the fact that many IDEs only display the filename, and not the path information in the editor tabs.

Adding the ability to distinguish manual mocks with a distinct extension infix fixes this problem without breaking any existing code.

Test Plan


Added unit test to validate code responsible for extracting module name from mock file path.

Added end-to-end test to validate resolution of mock file with the extended suffix.