### PR TITLE
fix(expect): add type definitions for asymmetric `closeTo` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[expect]` Add type definitions for asymmetric `closeTo` matcher ([#12304](https://github.com/facebook/jest/pull/12304))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -74,6 +74,7 @@ interface AsymmetricMatchers {
   any(sample: unknown): AsymmetricMatcher;
   anything(): AsymmetricMatcher;
   arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
+  closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -25,6 +25,17 @@ expectType<void>(expect(['B']).toEqual(expect.not.arrayContaining(['A'])));
 expectError(expect(['A']).toEqual(expect.not.arrayContaining('A')));
 expectError(expect(['A']).toEqual(expect.not.arrayContaining()));
 
+expectType<void>(expect(0.1 + 0.2).toEqual(expect.closeTo(0.3)));
+expectType<void>(expect(0.1 + 0.2).toEqual(expect.closeTo(0.3, 5)));
+expectError(expect(0.1 + 0.2).toEqual(expect.closeTo('three')));
+expectError(expect(0.1 + 0.2).toEqual(expect.closeTo(0.3, false)));
+expectError(expect(0.1 + 0.2).toEqual(expect.closeTo()));
+expectType<void>(expect(0.1 + 0.2).toEqual(expect.not.closeTo(0.3)));
+expectType<void>(expect(0.1 + 0.2).toEqual(expect.not.closeTo(0.3, 5)));
+expectError(expect(0.1 + 0.2).toEqual(expect.not.closeTo('three')));
+expectError(expect(0.1 + 0.2).toEqual(expect.not.closeTo(0.3, false)));
+expectError(expect(0.1 + 0.2).toEqual(expect.not.closeTo()));
+
 expectType<void>(expect({a: 1}).toEqual(expect.objectContaining({a: 1})));
 expectError(expect({a: 1}).toEqual(expect.objectContaining(1)));
 expectError(expect({a: 1}).toEqual(expect.objectContaining()));


### PR DESCRIPTION
## Summary

#12243 landed with new asymmetric `closeTo` matcher, but seems like type definitions went missing. Easy to fix (;

## Test plan

Type tests included.