### PR TITLE
feat(pretty-format): expose `ConvertAnsi` plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[pretty-format]` Expose `ConvertAnsi` plugin ([#12308](https://github.com/facebook/jest/pull/12308))
+
 ### Fixes
 
 - `[expect]` Add type definitions for asymmetric `closeTo` matcher ([#12304](https://github.com/facebook/jest/pull/12304))

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,7 +34,10 @@ module.exports = {
   snapshotFormat: {
     escapeString: false,
   },
-  snapshotSerializers: [require.resolve('pretty-format/ConvertAnsi')],
+  snapshotSerializers: [
+    // change to require.resolve('pretty-format/ConvertAnsi') when we drop Node 10
+    '<rootDir>/packages/pretty-format/build/plugins/ConvertAnsi.js',
+  ],
   testPathIgnorePatterns: [
     '/__arbitraries__/',
     '/__typetests__/',

--- a/jest.config.js
+++ b/jest.config.js
@@ -34,9 +34,7 @@ module.exports = {
   snapshotFormat: {
     escapeString: false,
   },
-  snapshotSerializers: [
-    '<rootDir>/packages/pretty-format/build/plugins/ConvertAnsi.js',
-  ],
+  snapshotSerializers: [require.resolve('pretty-format/ConvertAnsi')],
   testPathIgnorePatterns: [
     '/__arbitraries__/',
     '/__typetests__/',

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -15,7 +15,8 @@
       "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./ConvertAnsi": "./build/plugins/ConvertAnsi.js"
   },
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -65,6 +65,9 @@ module.exports.getPackages = function getPackages() {
               './build/utils': './build/utils.js',
             }
           : {}),
+        ...(pkg.name === 'pretty-format'
+          ? {'./ConvertAnsi': './build/plugins/ConvertAnsi.js'}
+          : {}),
       },
       `Package ${pkg.name} does not export correct files`,
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is the only builtin plugin that's not enabled by default, and having an official way of retrieving it (at least from JS config) seems like a good idea.

E.g. https://github.com/jest-community/jest-watch-typeahead/blob/b08ae652f0c2c35f179d5f5578385fc85973dba4/package.json#L84 can stop reaching into `build`, which is not supported.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
