### PR TITLE
fix: binary scripts should use package exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[expect]` Add type definitions for asymmetric `closeTo` matcher ([#12304](https://github.com/facebook/jest/pull/12304))
+- `[jest-cli]` Load binary via exported API ([#12315](https://github.com/facebook/jest/pull/12315))
 - `[jest-repl]` Make module importable ([#12311](https://github.com/facebook/jest/pull/12311))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - `[expect]` Add type definitions for asymmetric `closeTo` matcher ([#12304](https://github.com/facebook/jest/pull/12304))
 - `[jest-cli]` Load binary via exported API ([#12315](https://github.com/facebook/jest/pull/12315))
-- `[jest-repl]` Make module importable ([#12311](https://github.com/facebook/jest/pull/12311))
+- `[jest-repl]` Make module importable ([#12311](https://github.com/facebook/jest/pull/12311) & [#12315](https://github.com/facebook/jest/pull/12315))
 
 ### Chore & Maintenance
 

--- a/packages/jest-repl/bin/jest-repl.js
+++ b/packages/jest-repl/bin/jest-repl.js
@@ -10,4 +10,4 @@ if (process.env.NODE_ENV == null) {
   process.env.NODE_ENV = 'test';
 }
 
-require('../build/cli')();
+require('..').repl();

--- a/packages/jest-repl/bin/jest-runtime-cli.js
+++ b/packages/jest-repl/bin/jest-runtime-cli.js
@@ -10,4 +10,4 @@ if (process.env.NODE_ENV == null) {
   process.env.NODE_ENV = 'test';
 }
 
-require('../build/cli/runtime-cli').run();
+require('..').runtime();

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -7,12 +7,12 @@
     "directory": "packages/jest-repl"
   },
   "license": "MIT",
-  "main": "./build/cli/index.js",
-  "types": "./build/cli/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
   "exports": {
     ".": {
-      "types": "./build/cli/index.d.ts",
-      "default": "./build/cli/index.js"
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
     },
     "./package.json": "./package.json",
     "./bin/jest-repl": "./bin/jest-repl.js",

--- a/packages/jest-repl/src/index.ts
+++ b/packages/jest-repl/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
@@ -6,12 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const importLocal = require('import-local');
+import replImport = require('./cli');
 
-if (!importLocal(__filename)) {
-  if (process.env.NODE_ENV == null) {
-    process.env.NODE_ENV = 'test';
-  }
-
-  require('..').run();
-}
+export const repl = replImport;
+export {run as runtime} from './cli/runtime-cli';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Instead of reaching into `build/` we should use the exported API. This also ensures it keeps working when we bundle without changes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI.

I've tested calling the binary files still work

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
