### PR TITLE
perf(haste-map): default to node crawl if watchman is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Performance
 
+- `[jest-haste-map]` [**BREAKING**] Default to `node` crawler over shelling out to `find` if `watchman` is not enabled ([#12320](https://github.com/facebook/jest/pull/12320))
+
 ## 27.5.1
 
 ### Features

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -22,7 +22,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       "haste": {
         "computeSha1": false,
         "enableSymlinks": false,
-        "forceNodeFilesystemAPI": false,
+        "forceNodeFilesystemAPI": true,
         "throwOnModuleCollision": false
       },
       "injectGlobals": true,

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -36,7 +36,7 @@ const defaultOptions: Config.DefaultOptions = {
   haste: {
     computeSha1: false,
     enableSymlinks: false,
-    forceNodeFilesystemAPI: false,
+    forceNodeFilesystemAPI: true,
     throwOnModuleCollision: false,
   },
   injectGlobals: true,

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -60,7 +60,7 @@ const initialOptions: Config.InitialOptions = {
     computeSha1: true,
     defaultPlatform: 'ios',
     enableSymlinks: false,
-    forceNodeFilesystemAPI: false,
+    forceNodeFilesystemAPI: true,
     hasteImplModulePath: '<rootDir>/haste_impl.js',
     hasteMapModulePath: '',
     platforms: ['ios', 'android'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Toggling option from #11264.

On my machine the node crawl is even faster than watchman for `--list-tests`, while both beat `find` into dust.

This branch:

```sh-session
$  hyperfine 'yarn jest --list-tests' 'yarn jest --list-tests --no-watchman'
Benchmark 1: yarn jest --list-tests
  Time (mean ± σ):      2.921 s ±  0.750 s    [User: 3.143 s, System: 0.549 s]
  Range (min … max):    2.261 s …  4.519 s    10 runs

Benchmark 2: yarn jest --list-tests --no-watchman
  Time (mean ± σ):      2.197 s ±  0.216 s    [User: 2.367 s, System: 0.414 s]
  Range (min … max):    2.074 s …  2.801 s    10 runs
```

`main`:

```sh-session
$ hyperfine 'yarn jest --list-tests --no-watchman'
Benchmark 1: yarn jest --list-tests --no-watchman
  Time (mean ± σ):      3.684 s ±  0.364 s    [User: 2.878 s, System: 1.415 s]
  Range (min … max):    3.225 s …  4.341 s    10 runs
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
