### PR TITLE
 doc (mongodb):- runInBand addition to 'Using with MongoDB' documentation

### DIFF
--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-25.x/MongoDB.md
+++ b/website/versioned_docs/version-25.x/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-26.x/MongoDB.md
+++ b/website/versioned_docs/version-26.x/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-27.0/MongoDB.md
+++ b/website/versioned_docs/version-27.0/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-27.1/MongoDB.md
+++ b/website/versioned_docs/version-27.1/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-27.2/MongoDB.md
+++ b/website/versioned_docs/version-27.2/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-27.4/MongoDB.md
+++ b/website/versioned_docs/version-27.4/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).

--- a/website/versioned_docs/version-27.5/MongoDB.md
+++ b/website/versioned_docs/version-27.5/MongoDB.md
@@ -56,6 +56,14 @@ describe('insert', () => {
 });
 ```
 
+If you are using multiple test files with many tests, you might want to consider using the following parameter:
+
+```
+jest --runInBand
+```
+
+This parameter will make sure your tests won't run in parallel, which could cause issues with data being deleted from collections while you are accessing them.
+
 There's no need to load any dependencies.
 
 See [documentation](https://github.com/shelfio/jest-mongodb) for details (configuring MongoDB version, etc).


### PR DESCRIPTION
I've had a problem with my tests being flaky while using MongoDB following the documentation that was provided, I later found out that the approach I was using (different test files for different parts of my application) was causing problems with data being deleted from my database while other tests were expecting this data to be there.
After searching for a while I found out that the different test files in jest are being ran parallel to each other, and this caused my issue... So after looking for a solution for running my tests in a serial way I came across the --runInBand option for jest and I thought this might be a nice addition to the documentation for other people who also run into this problem.

Test plan

![130093180-d1f824b3-cf82-448b-b366-dfe1ffe0dfa2](https://user-images.githubusercontent.com/72331432/152941767-1c1423ea-35b7-4112-99e1-f27949f195b4.png)
![130093182-f1bdfdb4-9498-4c7c-9d7f-23268c5d2130](https://user-images.githubusercontent.com/72331432/152941790-2d47828a-c347-4724-b310-eb8f329c8705.png)
