### PR TITLE
ci(jest-changed-files): enable `mercurial` related test on CI

### DIFF
--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -466,13 +466,6 @@ testIfHg('gets changed files for hg', async () => {
 });
 
 testIfHg('monitors only root paths for hg', async () => {
-  if (process.env.CI) {
-    // Circle and Travis have very old version of hg (v2, and current
-    // version is v4.2) and its API changed since then and not compatible
-    // any more. Changing the SCM version on CIs is not trivial, so we'll just
-    // skip this test and run it only locally.
-    return;
-  }
   writeFiles(DIR, {
     'file1.txt': 'file1',
     'nested-dir/file2.txt': 'file2',


### PR DESCRIPTION
## Summary

Split from #12322

One `mercurial` related test is skipped on CI long time ago, but it works on GitHub Actions. It makes sense to enable it.

Also there is another `hg` test which is sometimes failing on CI possibly due to flakiness (some timeout, race condition or so). Seemed that adding `jest.retryTimes` is making that test pass.

## Test plan

So here is the plan. First I am simply enabling the skipped test. Will try to force-push few times, if there is flakiness I will add `jest.retryTimes` and will force-push few times to restart CI again. This way we can check if `jest.retryTimes` is really necessary.