### PR TITLE
chore: avoid backticks without template in strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -155,6 +155,17 @@ module.exports = {
         'sort-keys': 'off',
       },
     },
+    // snapshots in examples plus inline snapshots need to keep backtick
+    {
+      files: ['*.md', 'e2e/custom-inline-snapshot-matchers/__tests__/*'],
+      rules: {
+        quotes: [
+          'error',
+          'single',
+          {allowTemplateLiterals: true, avoidEscape: true},
+        ],
+      },
+    },
     {
       files: ['website/**/*'],
       rules: {
@@ -469,7 +480,7 @@ module.exports = {
     quotes: [
       'error',
       'single',
-      {allowTemplateLiterals: true, avoidEscape: true},
+      {allowTemplateLiterals: false, avoidEscape: true},
     ],
     radix: 'warn',
     'require-jsdoc': 'off',

--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -138,7 +138,7 @@ describe('Custom Reporters Integration', () => {
 
   test('prints reporter errors', () => {
     writeFiles(DIR, {
-      '__tests__/test.test.js': `test('test', () => {});`,
+      '__tests__/test.test.js': "test('test', () => {});",
       'package.json': JSON.stringify({
         jest: {
           reporters: ['default', '<rootDir>/reporter.js'],
@@ -163,7 +163,7 @@ describe('Custom Reporters Integration', () => {
   onNodeVersions('>=12.17.0', () => {
     test('supports reporter written in ESM', () => {
       writeFiles(DIR, {
-        '__tests__/test.test.js': `test('test', () => {});`,
+        '__tests__/test.test.js': "test('test', () => {});",
         'package.json': JSON.stringify({
           jest: {
             reporters: ['default', '<rootDir>/reporter.mjs'],

--- a/e2e/__tests__/executeTestsOnceInMpr.ts
+++ b/e2e/__tests__/executeTestsOnceInMpr.ts
@@ -33,13 +33,13 @@ test('Tests are executed only once even in an MPR', () => {
 
   /* eslint-disable sort-keys */
   writeFiles(DIR, {
-    'foo/folder/my-test-bar.js': `test('bar', () => console.log('Bar!'));`,
+    'foo/folder/my-test-bar.js': "test('bar', () => console.log('Bar!'));",
     'foo/folder/package.json': JSON.stringify(childConfig, null, 2),
 
-    'foo/directory/my-test-baz.js': `test('baz', () => console.log('Baz!'));`,
+    'foo/directory/my-test-baz.js': "test('baz', () => console.log('Baz!'));",
     'foo/directory/package.json': JSON.stringify(childConfig, null, 2),
 
-    'foo/whatever/my-test-qux.js': `test('qux', () => console.log('Qux!'));`,
+    'foo/whatever/my-test-qux.js': "test('qux', () => console.log('Qux!'));",
     'foo/whatever/package.json': JSON.stringify(childConfig, null, 2),
 
     'package.json': JSON.stringify(config, null, 2),

--- a/e2e/__tests__/globalSetup.test.ts
+++ b/e2e/__tests__/globalSetup.test.ts
@@ -57,7 +57,7 @@ test('globalSetup is triggered once before all test suites', () => {
   const setupPath = path.join(e2eDir, 'setup.js');
   const result = runWithJson(e2eDir, [
     `--globalSetup=${setupPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(result.exitCode).toBe(0);
@@ -71,7 +71,7 @@ test('jest throws an error when globalSetup does not export a function', () => {
   const setupPath = path.resolve(__dirname, '../global-setup/invalidSetup.js');
   const {exitCode, stderr} = runJest(e2eDir, [
     `--globalSetup=${setupPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(exitCode).toBe(1);
@@ -155,7 +155,7 @@ test('globalSetup throws with named export', () => {
 
   const {exitCode, stderr} = runJest(e2eDir, [
     `--globalSetup=${setupPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(exitCode).toBe(1);
@@ -166,13 +166,13 @@ test('globalSetup throws with named export', () => {
 });
 
 test('should not transpile the transformer', () => {
-  const {exitCode} = runJest('global-setup-custom-transform', [`--no-cache`]);
+  const {exitCode} = runJest('global-setup-custom-transform', ['--no-cache']);
 
   expect(exitCode).toBe(0);
 });
 
 test('should transform node_modules if configured by transformIgnorePatterns', () => {
-  const {exitCode} = runJest('global-setup-node-modules', [`--no-cache`]);
+  const {exitCode} = runJest('global-setup-node-modules', ['--no-cache']);
 
   expect(exitCode).toBe(0);
 });
@@ -190,7 +190,7 @@ test('properly handle rejections', () => {
     `,
   });
 
-  const {exitCode, stderr} = runJest(rejectionDir, [`--no-cache`]);
+  const {exitCode, stderr} = runJest(rejectionDir, ['--no-cache']);
 
   expect(exitCode).toBe(1);
   expect(stderr).toContain('Error: Jest: Got error running globalSetup');
@@ -199,7 +199,7 @@ test('properly handle rejections', () => {
 
 onNodeVersions('>=12.17.0', () => {
   test('globalSetup works with ESM modules', () => {
-    const {exitCode} = runJest('global-setup-esm', [`--no-cache`], {
+    const {exitCode} = runJest('global-setup-esm', ['--no-cache'], {
       nodeOptions: '--experimental-vm-modules --no-warnings',
     });
 

--- a/e2e/__tests__/globalTeardown.test.ts
+++ b/e2e/__tests__/globalTeardown.test.ts
@@ -41,7 +41,7 @@ test('globalTeardown is triggered once after all test suites', () => {
   const teardownPath = path.resolve(e2eDir, 'teardown.js');
   const result = runWithJson('global-teardown', [
     `--globalTeardown=${teardownPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(result.exitCode).toBe(0);
@@ -55,7 +55,7 @@ test('jest throws an error when globalTeardown does not export a function', () =
   const teardownPath = path.resolve(e2eDir, 'invalidTeardown.js');
   const {exitCode, stderr} = runJest(e2eDir, [
     `--globalTeardown=${teardownPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(exitCode).toBe(1);
@@ -126,7 +126,7 @@ test('globalTeardown throws with named export', () => {
 
   const {exitCode, stderr} = runJest(e2eDir, [
     `--globalTeardown=${teardownPath}`,
-    `--testPathPattern=__tests__`,
+    '--testPathPattern=__tests__',
   ]);
 
   expect(exitCode).toBe(1);
@@ -138,7 +138,7 @@ test('globalTeardown throws with named export', () => {
 
 onNodeVersions('>=12.17.0', () => {
   test('globalTeardown works with ESM modules', () => {
-    const {exitCode} = runJest('global-teardown-esm', [`--no-cache`], {
+    const {exitCode} = runJest('global-teardown-esm', ['--no-cache'], {
       nodeOptions: '--experimental-vm-modules --no-warnings',
     });
 

--- a/e2e/__tests__/jest.config.js.test.ts
+++ b/e2e/__tests__/jest.config.js.test.ts
@@ -16,8 +16,8 @@ afterAll(() => cleanup(DIR));
 
 test('works with jest.config.js', () => {
   writeFiles(DIR, {
-    '__tests__/a-banana.js': `test('banana', () => expect(1).toBe(1));`,
-    'jest.config.js': `module.exports = {testRegex: '.*-banana.js'};`,
+    '__tests__/a-banana.js': "test('banana', () => expect(1).toBe(1));",
+    'jest.config.js': "module.exports = {testRegex: '.*-banana.js'};",
     'package.json': '{}',
   });
 
@@ -35,7 +35,7 @@ test('traverses directory tree up until it finds jest.config', () => {
     test('banana', () => expect(1).toBe(1));
     test('abc', () => console.log(slash(process.cwd())));
     `,
-    'jest.config.js': `module.exports = {testRegex: '.*-banana.js'};`,
+    'jest.config.js': "module.exports = {testRegex: '.*-banana.js'};",
     'package.json': '{}',
     'some/nested/directory/file.js': '// nothing special',
   });
@@ -57,8 +57,8 @@ test('traverses directory tree up until it finds jest.config', () => {
 
 test('invalid JS in jest.config.js', () => {
   writeFiles(DIR, {
-    '__tests__/a-banana.js': `test('banana', () => expect(1).toBe(1));`,
-    'jest.config.js': `module.exports = i'll break this file yo`,
+    '__tests__/a-banana.js': "test('banana', () => expect(1).toBe(1));",
+    'jest.config.js': "module.exports = i'll break this file yo",
     'package.json': '{}',
   });
 

--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -16,8 +16,9 @@ afterAll(() => cleanup(DIR));
 
 test('works with jest.config.ts', () => {
   writeFiles(DIR, {
-    '__tests__/a-giraffe.js': `test('giraffe', () => expect(1).toBe(1));`,
-    'jest.config.ts': `export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
+    '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
+    'jest.config.ts':
+      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
     'package.json': '{}',
   });
 
@@ -30,8 +31,9 @@ test('works with jest.config.ts', () => {
 
 test('works with tsconfig.json', () => {
   writeFiles(DIR, {
-    '__tests__/a-giraffe.js': `test('giraffe', () => expect(1).toBe(1));`,
-    'jest.config.ts': `export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
+    '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
+    'jest.config.ts':
+      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
     'package.json': '{}',
     'tsconfig.json': '{ "compilerOptions": { "module": "esnext" } }',
   });
@@ -50,7 +52,8 @@ test('traverses directory tree up until it finds jest.config', () => {
     test('giraffe', () => expect(1).toBe(1));
     test('abc', () => console.log(slash(process.cwd())));
     `,
-    'jest.config.ts': `export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
+    'jest.config.ts':
+      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
     'package.json': '{}',
     'some/nested/directory/file.js': '// nothing special',
   });
@@ -72,8 +75,8 @@ test('traverses directory tree up until it finds jest.config', () => {
 
 test('it does type check the config', () => {
   writeFiles(DIR, {
-    '__tests__/a-giraffe.js': `test('giraffe', () => expect(1).toBe(1));`,
-    'jest.config.ts': `export default { testTimeout: "10000" }`,
+    '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
+    'jest.config.ts': 'export default { testTimeout: "10000" }',
     'package.json': '{}',
   });
 
@@ -84,8 +87,8 @@ test('it does type check the config', () => {
 
 test('invalid JS in jest.config.ts', () => {
   writeFiles(DIR, {
-    '__tests__/a-giraffe.js': `test('giraffe', () => expect(1).toBe(1));`,
-    'jest.config.ts': `export default i'll break this file yo`,
+    '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
+    'jest.config.ts': "export default i'll break this file yo",
     'package.json': '{}',
   });
 

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -341,7 +341,7 @@ it('does not find changes in files with no diff, for git', async () => {
 test('handles a bad revision for "changedSince", for git', async () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': '{}',
   });
@@ -494,7 +494,7 @@ testIfHg('monitors only root paths for hg', async () => {
 testIfHg('handles a bad revision for "changedSince", for hg', async () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': '{}',
   });

--- a/e2e/__tests__/jestEnvironmentJsdom.test.ts
+++ b/e2e/__tests__/jestEnvironmentJsdom.test.ts
@@ -17,8 +17,8 @@ afterAll(() => cleanup(DIR));
 
 test('check is not leaking memory', () => {
   writeFiles(DIR, {
-    '__tests__/a.test.js': `test('a', () => console.log('a'));`,
-    '__tests__/b.test.js': `test('b', () => console.log('b'));`,
+    '__tests__/a.test.js': "test('a', () => console.log('a'));",
+    '__tests__/b.test.js': "test('b', () => console.log('b'));",
     'package.json': JSON.stringify({jest: {testEnvironment: 'jsdom'}}),
   });
 

--- a/e2e/__tests__/jestRequireActual.test.ts
+++ b/e2e/__tests__/jestRequireActual.test.ts
@@ -23,8 +23,8 @@ test('understands dependencies using jest.requireActual', () => {
 
       test('a', () => {});
     `,
-    '__tests__/b.test.js': `test('b', () => {});`,
-    'a.js': `module.exports = {}`,
+    '__tests__/b.test.js': "test('b', () => {});",
+    'a.js': 'module.exports = {}',
     'package.json': JSON.stringify({jest: {}}),
   });
 

--- a/e2e/__tests__/jestRequireMock.test.ts
+++ b/e2e/__tests__/jestRequireMock.test.ts
@@ -23,8 +23,8 @@ test('understands dependencies using jest.requireMock', () => {
 
       test('a', () => {});
     `,
-    '__tests__/b.test.js': `test('b', () => {});`,
-    'a.js': `module.exports = {}`,
+    '__tests__/b.test.js': "test('b', () => {});",
+    'a.js': 'module.exports = {}',
     'package.json': JSON.stringify({jest: {}}),
   });
 

--- a/e2e/__tests__/logHeapUsage.test.ts
+++ b/e2e/__tests__/logHeapUsage.test.ts
@@ -17,7 +17,7 @@ afterAll(() => cleanup(DIR));
 
 test('logs memory usage', () => {
   writeFiles(DIR, {
-    '__tests__/a-banana.js': `test('banana', () => expect(1).toBe(1));`,
+    '__tests__/a-banana.js': "test('banana', () => expect(1).toBe(1));",
     'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
   });
 

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -20,9 +20,9 @@ afterEach(() => cleanup(DIR));
 test("--listTests doesn't duplicate the test files", () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '/project1.js': `module.exports = {rootDir: './', displayName: 'BACKEND'}`,
-    '/project2.js': `module.exports = {rootDir: './', displayName: 'BACKEND'}`,
-    '__tests__/inBothProjectsTest.js': `test('test', () => {});`,
+    '/project1.js': "module.exports = {rootDir: './', displayName: 'BACKEND'}",
+    '/project2.js': "module.exports = {rootDir: './', displayName: 'BACKEND'}",
+    '__tests__/inBothProjectsTest.js': "test('test', () => {});",
     'package.json': JSON.stringify({
       jest: {projects: ['<rootDir>/project1.js', '<rootDir>/project2.js']},
     }),
@@ -139,13 +139,13 @@ test('"No tests found" message for projects', () => {
       test('file1', () => {});
     `,
     'project1/file1.js': SAMPLE_FILE_CONTENT,
-    'project1/jest.config.js': `module.exports = {rootDir: './'}`,
+    'project1/jest.config.js': "module.exports = {rootDir: './'}",
     'project2/__tests__/file1.test.js': `
       const file1 = require('../file1');
       test('file1', () => {});
     `,
     'project2/file1.js': SAMPLE_FILE_CONTENT,
-    'project2/jest.config.js': `module.exports = {rootDir: './'}`,
+    'project2/jest.config.js': "module.exports = {rootDir: './'}",
   });
   const {stdout: verboseOutput} = runJest(DIR, [
     '--no-watchman',
@@ -352,9 +352,11 @@ test('resolves projects and their <rootDir> properly', () => {
       setupFiles: ['<rootDir>/project1_setup.js'],
       testEnvironment: 'node',
     }),
-    'project1/__tests__/test.test.js': `test('project1', () => expect(global.project1).toBe(true))`,
+    'project1/__tests__/test.test.js':
+      "test('project1', () => expect(global.project1).toBe(true))",
     'project1/project1_setup.js': 'global.project1 = true;',
-    'project2/__tests__/test.test.js': `test('project2', () => expect(global.project2).toBe(true))`,
+    'project2/__tests__/test.test.js':
+      "test('project2', () => expect(global.project2).toBe(true))",
     'project2/project2.conf.json': JSON.stringify({
       name: 'project2',
       rootDir: '../', // root dir is set to the top level
@@ -427,7 +429,7 @@ test('resolves projects and their <rootDir> properly', () => {
 
   ({stderr} = runJest(DIR, ['--no-watchman']));
   expect(stderr).toMatch(
-    `Can't find a root directory while resolving a config file path.`,
+    "Can't find a root directory while resolving a config file path.",
   );
   expect(stderr).toMatch(/banana/);
 });

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -46,7 +46,7 @@ afterEach(() => cleanup(DIR));
 test('run for "onlyChanged" and "changedSince"', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': '{}',
   });
@@ -69,7 +69,7 @@ test('run for "onlyChanged" and "changedSince"', () => {
 test('run only changed files', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': '{}',
   });
@@ -90,10 +90,10 @@ test('run only changed files', () => {
   expect(stderr).toMatch(/PASS __tests__(\/|\\)file1.test.js/);
 
   writeFiles(DIR, {
-    '__tests__/file2.test.js': `require('../file2'); test('file2', () => {});`,
-    '__tests__/file3.test.js': `require('../file3'); test('file3', () => {});`,
+    '__tests__/file2.test.js': "require('../file2'); test('file2', () => {});",
+    '__tests__/file3.test.js': "require('../file3'); test('file3', () => {});",
     'file2.js': 'module.exports = {}',
-    'file3.js': `require('./file2')`,
+    'file3.js': "require('./file2')",
   });
 
   ({stderr} = runJest(DIR, ['-o']));
@@ -249,7 +249,7 @@ test('collect test coverage when using onlyChanged', () => {
 test('onlyChanged in config is overwritten by --all or testPathPattern', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': JSON.stringify({jest: {onlyChanged: true}}),
   });
@@ -273,10 +273,10 @@ test('onlyChanged in config is overwritten by --all or testPathPattern', () => {
   expect(stderr).toMatch(/PASS __tests__(\/|\\)file1.test.js/);
 
   writeFiles(DIR, {
-    '__tests__/file2.test.js': `require('../file2'); test('file2', () => {});`,
-    '__tests__/file3.test.js': `require('../file3'); test('file3', () => {});`,
+    '__tests__/file2.test.js': "require('../file2'); test('file2', () => {});",
+    '__tests__/file3.test.js': "require('../file3'); test('file3', () => {});",
     'file2.js': 'module.exports = {}',
-    'file3.js': `require('./file2')`,
+    'file3.js': "require('./file2')",
   });
 
   ({stderr} = runJest(DIR));
@@ -321,7 +321,7 @@ testIfHg('gets changed files for hg', async () => {
   }
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
   });
@@ -337,9 +337,9 @@ testIfHg('gets changed files for hg', async () => {
   expect(stdout).toMatch('No tests found related to files changed');
 
   writeFiles(DIR, {
-    '__tests__/file2.test.js': `require('../file2'); test('file2', () => {});`,
+    '__tests__/file2.test.js': "require('../file2'); test('file2', () => {});",
     'file2.js': 'module.exports = {}',
-    'file3.js': `require('./file2')`,
+    'file3.js': "require('./file2')",
   });
 
   ({stdout, stderr} = runJest(DIR, ['-o']));
@@ -349,7 +349,7 @@ testIfHg('gets changed files for hg', async () => {
   run(`${HG} commit -m "test2"`, DIR);
 
   writeFiles(DIR, {
-    '__tests__/file3.test.js': `require('../file3'); test('file3', () => {});`,
+    '__tests__/file3.test.js': "require('../file3'); test('file3', () => {});",
   });
 
   ({stdout, stderr} = runJest(DIR, ['-o']));
@@ -372,7 +372,7 @@ test('path on Windows is case-insensitive', () => {
 
   writeFiles(modifiedDIR, {
     '.watchmanconfig': '',
-    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",
     'file1.js': 'module.exports = {}',
     'package.json': '{}',
   });
@@ -385,10 +385,10 @@ test('path on Windows is case-insensitive', () => {
   expect(stdout).toMatch('No tests found related to files');
 
   writeFiles(modifiedDIR, {
-    '__tests__/file2.test.js': `require('../file2'); test('file2', () => {});`,
-    '__tests__/file3.test.js': `require('../file3'); test('file3', () => {});`,
+    '__tests__/file2.test.js': "require('../file2'); test('file2', () => {});",
+    '__tests__/file3.test.js': "require('../file3'); test('file3', () => {});",
     'file2.js': 'module.exports = {}',
-    'file3.js': `require('./file2')`,
+    'file3.js': "require('./file2')",
   });
 
   const {stderr} = runJest(incorrectModifiedDIR, ['-o']);

--- a/e2e/__tests__/requireMainResetModules.test.ts
+++ b/e2e/__tests__/requireMainResetModules.test.ts
@@ -9,7 +9,7 @@ import runJest from '../runJest';
 
 test("`require.main` on using `--resetModules='true'` should not be undefined", () => {
   const {exitCode} = runJest('require-main-reset-modules', [
-    `--resetModules='true'`,
+    "--resetModules='true'",
     'resetModulesFlag',
   ]);
   expect(exitCode).toBe(0);

--- a/e2e/__tests__/runProgrammatically.test.ts
+++ b/e2e/__tests__/runProgrammatically.test.ts
@@ -11,11 +11,11 @@ import {run} from '../Utils';
 const dir = resolve(__dirname, '..', 'run-programmatically');
 
 test('run Jest programmatically cjs', () => {
-  const {stdout} = run(`node cjs.js --version`, dir);
+  const {stdout} = run('node cjs.js --version', dir);
   expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*-dev$/);
 });
 
 test('run Jest programmatically esm', () => {
-  const {stdout} = run(`node index.js --version`, dir);
+  const {stdout} = run('node index.js --version', dir);
   expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*-dev$/);
 });

--- a/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
+++ b/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
@@ -12,7 +12,7 @@ import {extractSummary, run} from '../Utils';
 const dir = resolve(__dirname, '../run-programmatically-multiple-projects');
 
 test('run programmatically with multiple projects', () => {
-  const {stderr, exitCode} = run(`node run-jest.js`, dir);
+  const {stderr, exitCode} = run('node run-jest.js', dir);
   const {summary} = extractSummary(stripAnsi(stderr));
   expect(exitCode).toEqual(0);
   expect(summary).toMatchSnapshot('summary');

--- a/e2e/__tests__/showConfig.test.ts
+++ b/e2e/__tests__/showConfig.test.ts
@@ -17,7 +17,7 @@ afterEach(() => cleanup(DIR));
 
 test('--showConfig outputs config info and exits', () => {
   writeFiles(DIR, {
-    '__tests__/test.test.js': `test('test', () => {});`,
+    '__tests__/test.test.js': "test('test', () => {});",
     'package.json': JSON.stringify({jest: {environment: 'node'}}),
   });
 

--- a/e2e/__tests__/snapshot.test.ts
+++ b/e2e/__tests__/snapshot.test.ts
@@ -132,8 +132,8 @@ describe('Snapshot', () => {
 
     // Write the second snapshot
     const testData =
-      `test('escape strings two', () => expect('two: \\\'\"').` +
-      `toMatchSnapshot());`;
+      "test('escape strings two', () => expect('two: \\'\"')." +
+      'toMatchSnapshot());';
     const newTestData = initialTestData + testData;
     fs.writeFileSync(snapshotEscapeTestFile, newTestData, 'utf8');
 

--- a/e2e/__tests__/testFailureExitCode.test.ts
+++ b/e2e/__tests__/testFailureExitCode.test.ts
@@ -17,7 +17,7 @@ afterAll(() => cleanup(DIR));
 
 test('exits with a specified code when test fail', () => {
   writeFiles(DIR, {
-    '__tests__/test.test.js': `test('test', () => { expect(1).toBe(2); });`,
+    '__tests__/test.test.js': "test('test', () => { expect(1).toBe(2); });",
     'package.json': JSON.stringify({
       jest: {testEnvironment: 'node', testFailureExitCode: 99},
     }),
@@ -30,7 +30,7 @@ test('exits with a specified code when test fail', () => {
   expect(exitCode).toBe(77);
 
   writeFiles(DIR, {
-    '__tests__/test.test.js': `test('test', () => { expect(1).toBe(2); });`,
+    '__tests__/test.test.js': "test('test', () => { expect(1).toBe(2); });",
     'package.json': JSON.stringify({
       jest: {testEnvironment: 'node'},
     }),
@@ -41,8 +41,8 @@ test('exits with a specified code when test fail', () => {
 
 test('exits with a specified code when bailing from a failed test', () => {
   writeFiles(DIR, {
-    '__tests__/test.test.js': `test('test', () => { expect(1).toBe(2); });`,
-    '__tests__/test2.test.js': `test('test2', () => { expect(1).toBe(2); });`,
+    '__tests__/test.test.js': "test('test', () => { expect(1).toBe(2); });",
+    '__tests__/test2.test.js': "test('test2', () => { expect(1).toBe(2); });",
     'package.json': JSON.stringify({
       jest: {testEnvironment: 'node', testFailureExitCode: 99},
     }),
@@ -55,8 +55,8 @@ test('exits with a specified code when bailing from a failed test', () => {
   expect(exitCode).toBe(77);
 
   writeFiles(DIR, {
-    '__tests__/test.test.js': `test('test', () => { expect(1).toBe(2); });`,
-    '__tests__/test2.test.js': `test('test2', () => { expect(1).toBe(2); });`,
+    '__tests__/test.test.js': "test('test', () => { expect(1).toBe(2); });",
+    '__tests__/test2.test.js': "test('test2', () => { expect(1).toBe(2); });",
     'package.json': JSON.stringify({
       jest: {testEnvironment: 'node'},
     }),

--- a/e2e/__tests__/testPathPatternReporterMessage.test.ts
+++ b/e2e/__tests__/testPathPatternReporterMessage.test.ts
@@ -18,8 +18,8 @@ afterEach(() => cleanup(DIR));
 test('prints a message with path pattern at the end', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
-    '__tests__/a.test.js': `test('a', () => {});`,
-    '__tests__/b.test.js': `test('b', () => {});`,
+    '__tests__/a.test.js': "test('a', () => {});",
+    '__tests__/b.test.js': "test('b', () => {});",
     'package.json': '{}',
   });
   let stderr;

--- a/e2e/__tests__/toMatchInlineSnapshot.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshot.test.ts
@@ -22,7 +22,7 @@ afterAll(() => cleanup(TESTS_DIR));
 test('basic support', () => {
   const filename = 'basic-support.test.js';
   const template = makeTemplate(
-    `test('inline snapshots', () => expect($1).toMatchInlineSnapshot());\n`,
+    "test('inline snapshots', () => expect($1).toMatchInlineSnapshot());\n",
   );
 
   {
@@ -73,7 +73,7 @@ test('basic support', () => {
 test('do not indent empty lines', () => {
   const filename = 'empty-line-indent.test.js';
   const template = makeTemplate(
-    `test('inline snapshots', () => expect($1).toMatchInlineSnapshot());\n`,
+    "test('inline snapshots', () => expect($1).toMatchInlineSnapshot());\n",
   );
 
   {

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -18,7 +18,7 @@ afterAll(() => cleanup(TESTS_DIR));
 test('basic support', () => {
   const filename = 'basic-support.test.js';
   const template = makeTemplate(
-    `test('snapshots', () => expect($1).toMatchSnapshot());`,
+    "test('snapshots', () => expect($1).toMatchSnapshot());",
   );
 
   {
@@ -98,14 +98,14 @@ test('first snapshot fails, second passes', () => {
     });`);
 
   {
-    writeFiles(TESTS_DIR, {[filename]: template([`'apple'`, `'banana'`])});
+    writeFiles(TESTS_DIR, {[filename]: template(["'apple'", "'banana'"])});
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('2 snapshots written from 1 test suite.');
     expect(exitCode).toBe(0);
   }
 
   {
-    writeFiles(TESTS_DIR, {[filename]: template([`'kiwi'`, `'banana'`])});
+    writeFiles(TESTS_DIR, {[filename]: template(["'kiwi'", "'banana'"])});
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `snapshots 1`');
     // Match lines separately because empty line has been replaced with space:
@@ -209,7 +209,7 @@ test('handles invalid property matchers', () => {
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Expected properties must be an object');
     expect(stderr).toMatch(
-      `To provide a hint without properties: toMatchSnapshot('hint')`,
+      "To provide a hint without properties: toMatchSnapshot('hint')",
     );
     expect(exitCode).toBe(1);
   }
@@ -223,7 +223,7 @@ test('handles invalid property matchers', () => {
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Expected properties must be an object');
     expect(stderr).toMatch(
-      `To provide a hint without properties: toMatchSnapshot('hint')`,
+      "To provide a hint without properties: toMatchSnapshot('hint')",
     );
     expect(exitCode).toBe(1);
   }

--- a/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
@@ -33,12 +33,12 @@ test('empty external', () => {
   // is not confused with new snapshot not written because of --ci option.
   const filename = 'empty-external.test.js';
   const template = makeTemplate(
-    `test('string serializer', () => { expect($1).toMatchSnapshot(); })`,
+    "test('string serializer', () => { expect($1).toMatchSnapshot(); })",
   );
 
   {
     writeFiles(TESTS_DIR, {
-      [filename]: template([`''`]),
+      [filename]: template(["''"]),
     });
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
@@ -54,7 +54,7 @@ test('empty external', () => {
 
   {
     writeFiles(TESTS_DIR, {
-      [filename]: template([`'non-empty'`]),
+      [filename]: template(["'non-empty'"]),
     });
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
@@ -69,11 +69,11 @@ test('empty internal ci false', () => {
   // is not confused with absence of snapshot.
   const filename = 'empty-internal-ci-false.test.js';
   const template = makeTemplate(
-    `test('string serializer', () => { expect($1).toMatchInlineSnapshot(); })`,
+    "test('string serializer', () => { expect($1).toMatchInlineSnapshot(); })",
   );
 
-  const received1 = `''`;
-  const received2 = `'non-empty'`;
+  const received1 = "''";
+  const received2 = "'non-empty'";
 
   {
     writeFiles(TESTS_DIR, {
@@ -101,12 +101,12 @@ test('undefined internal ci true', () => {
   // is not confused with ordinary failure for empty string as expected value.
   const filename = 'undefined-internal-ci-true.test.js';
   const template = makeTemplate(
-    `test('explicit update', () => { expect($1).toMatchInlineSnapshot(); })`,
+    "test('explicit update', () => { expect($1).toMatchInlineSnapshot(); })",
   );
 
   {
     writeFiles(TESTS_DIR, {
-      [filename]: template([`'non-empty'`]),
+      [filename]: template(["'non-empty'"]),
     });
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=true', filename]);
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');

--- a/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
@@ -33,7 +33,7 @@ test('works fine when function throws error', () => {
   }
 });
 
-test(`throws the error if tested function didn't throw error`, () => {
+test("throws the error if tested function didn't throw error", () => {
   const filename = 'throws-if-tested-function-did-not-throw.test.js';
   const template =
     makeTemplate(`test('throws the error if tested function did not throw error', () => {

--- a/e2e/__tests__/unexpectedToken.test.ts
+++ b/e2e/__tests__/unexpectedToken.test.ts
@@ -24,7 +24,8 @@ test('triggers unexpected token error message for non-JS assets', () => {
   });
 
   writeFiles(DIR, {
-    '__tests__/asset.test.js': `require('../asset.css'); test('asset', () => {});`,
+    '__tests__/asset.test.js':
+      "require('../asset.css'); test('asset', () => {});",
   });
 
   const {stdout, stderr} = runJest(DIR, ['']);
@@ -43,7 +44,8 @@ test('triggers unexpected token error message for untranspiled node_modules', ()
   });
 
   writeFiles(DIR, {
-    '__tests__/untranspiledModule.test.js': `require('untranspiled-module'); test('untranspiled', () => {});`,
+    '__tests__/untranspiledModule.test.js':
+      "require('untranspiled-module'); test('untranspiled', () => {});",
   });
 
   const {stdout, stderr} = runJest(DIR, ['']);
@@ -69,8 +71,10 @@ test('does not trigger unexpected token error message for regular syntax errors'
   });
 
   writeFiles(DIR, {
-    '__tests__/faulty.test.js': `require('../faulty'); test('faulty', () => {});`,
-    '__tests__/faulty2.test.js': `require('../faulty2'); test('faulty2', () => {});`,
+    '__tests__/faulty.test.js':
+      "require('../faulty'); test('faulty', () => {});",
+    '__tests__/faulty2.test.js':
+      "require('../faulty2'); test('faulty2', () => {});",
   });
 
   const {stdout, stderr} = runJest(DIR, ['']);

--- a/e2e/__tests__/useStderr.test.ts
+++ b/e2e/__tests__/useStderr.test.ts
@@ -29,7 +29,7 @@ test('no tests found message is redirected to stderr', () => {
   expect(stderr).toMatch('No tests found');
 
   writeFiles(DIR, {
-    '__tests__/test.test.js': `require('../file1'); test('file1', () => {});`,
+    '__tests__/test.test.js': "require('../file1'); test('file1', () => {});",
   });
 
   ({stdout, stderr} = runJest(DIR, ['--useStderr']));

--- a/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
@@ -50,6 +50,8 @@ jest.mock('../__test_modules__/f', () => {
     },
   };
 });
+// uses backticks on purpose
+// eslint-disable-next-line quotes
 jest.mock(`../__test_modules__/jestBackticks`);
 jest.mock('virtual-module', () => 'kiwi', {virtual: true});
 // This has types that should be ignored by the out-of-scope variables check.

--- a/e2e/coverage-report/notRequiredInTestSuite.js
+++ b/e2e/coverage-report/notRequiredInTestSuite.js
@@ -6,8 +6,8 @@
  */
 
 throw new Error(
-  `this error should not be a problem because` +
-    `this file is never required or executed`,
+  'this error should not be a problem because' +
+    'this file is never required or executed',
 );
 
 // Flow annotations to make sure istanbul can instrument non ES6 source

--- a/e2e/expect-async-matcher/matchers.js
+++ b/e2e/expect-async-matcher/matchers.js
@@ -15,18 +15,18 @@ export async function toHaveLengthAsync(
   const pass = received.length === length;
   const message = pass
     ? () =>
-        `Expected value to not have length:\n` +
+        'Expected value to not have length:\n' +
         `  ${length}\n` +
-        `Received:\n` +
+        'Received:\n' +
         `  ${received}\n` +
-        `received.length:\n` +
+        'received.length:\n' +
         `  ${received.length}`
     : () =>
-        `Expected value to have length:\n` +
+        'Expected value to have length:\n' +
         `  ${length}\n` +
-        `Received:\n` +
+        'Received:\n' +
         `  ${received}\n` +
-        `received.length:\n` +
+        'received.length:\n' +
         `  ${received.length}`;
 
   return {message, pass};

--- a/e2e/jasmine-async/__tests__/concurrent-many.test.js
+++ b/e2e/jasmine-async/__tests__/concurrent-many.test.js
@@ -16,7 +16,7 @@ for (let t = 0; t < 10; ++t) {
 
     if (current > 5) {
       current -= 1;
-      throw new Error(`Too many processes ran simultaneously`);
+      throw new Error('Too many processes ran simultaneously');
     } else {
       return sleep(20).then(() => {
         current -= 1;

--- a/examples/angular/app.component.spec.ts
+++ b/examples/angular/app.component.spec.ts
@@ -28,7 +28,7 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'angular'`, () => {
+  it("should have as title 'angular'", () => {
     expect(app.title).toEqual(title);
   });
 

--- a/packages/diff-sequences/src/__tests__/index.test.ts
+++ b/packages/diff-sequences/src/__tests__/index.test.ts
@@ -190,7 +190,7 @@ const countDifferences = (
       }
     }
   }
-  throw new Error(`countDifferences did not return a number`);
+  throw new Error('countDifferences did not return a number');
 };
 
 // Return array of items in a longest common subsequence of array-like objects.
@@ -785,8 +785,10 @@ describe('common substrings', () => {
     // Prevent unexpected regression. If change is incorrect, then fix code.
     // Internationalization fails for a text node.
     // English translation and French quotation by Antoine de Saint Exupéry:
-    const a = `It seems that perfection is attained not when there is nothing more to add, but when there is nothing more to remove.`;
-    const b = `Il semble que la perfection soit atteinte non quand il n'y a plus rien à ajouter, mais quand il n'y a plus rien à retrancher.`;
+    const a =
+      'It seems that perfection is attained not when there is nothing more to add, but when there is nothing more to remove.';
+    const b =
+      "Il semble que la perfection soit atteinte non quand il n'y a plus rien à ajouter, mais quand il n'y a plus rien à retrancher.";
     const abCommonSubstrings = findCommonSubstrings(a, b);
     const baCommonSubstrings = findCommonSubstrings(b, a);
     expect(abCommonSubstrings).toEqual(baCommonSubstrings);

--- a/packages/expect/src/__tests__/extend.test.ts
+++ b/packages/expect/src/__tests__/extend.test.ts
@@ -82,8 +82,8 @@ it('exposes matcherUtils in context', () => {
         }),
       );
       const message = pass
-        ? () => `expected this.utils to be defined in an extend call`
-        : () => `expected this.utils not to be defined in an extend call`;
+        ? () => 'expected this.utils to be defined in an extend call'
+        : () => 'expected this.utils not to be defined in an extend call';
 
       return {message, pass};
     },

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1717,7 +1717,7 @@ describe('.toMatch()', () => {
     ['foo', undefined],
   ].forEach(([n1, n2]) => {
     it(
-      `throws if non String/RegExp expected value passed:` +
+      'throws if non String/RegExp expected value passed:' +
         ` [${stringify(n1)}, ${stringify(n2)}]`,
       () => {
         expect(() => jestExpect(n1).toMatch(n2)).toThrowErrorMatchingSnapshot();

--- a/packages/expect/src/__tests__/spyMatchers.test.ts
+++ b/packages/expect/src/__tests__/spyMatchers.test.ts
@@ -29,13 +29,13 @@ const createSpy = (fn: jest.Mock) => {
 
 ['toBeCalled', 'toHaveBeenCalled'].forEach(called => {
   describe(`${called}`, () => {
-    test(`works only on spies or jest.fn`, () => {
+    test('works only on spies or jest.fn', () => {
       const fn = function fn() {};
 
       expect(() => jestExpect(fn)[called]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`passes when called`, () => {
+    test('passes when called', () => {
       const fn = jest.fn();
       fn('arg0', 'arg1', 'arg2');
       jestExpect(createSpy(fn))[called]();
@@ -43,7 +43,7 @@ const createSpy = (fn: jest.Mock) => {
       expect(() => jestExpect(fn).not[called]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not passes when called`, () => {
+    test('.not passes when called', () => {
       const fn = jest.fn();
       const spy = createSpy(fn);
 
@@ -52,14 +52,14 @@ const createSpy = (fn: jest.Mock) => {
       expect(() => jestExpect(spy)[called]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`fails with any argument passed`, () => {
+    test('fails with any argument passed', () => {
       const fn = jest.fn();
 
       fn();
       expect(() => jestExpect(fn)[called](555)).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not fails with any argument passed`, () => {
+    test('.not fails with any argument passed', () => {
       const fn = jest.fn();
 
       expect(() =>
@@ -67,7 +67,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`includes the custom mock name in the error message`, () => {
+    test('includes the custom mock name in the error message', () => {
       const fn = jest.fn().mockName('named-mock');
 
       fn();
@@ -191,13 +191,13 @@ const createSpy = (fn: jest.Mock) => {
     }
   };
   describe(`${calledWith}`, () => {
-    test(`works only on spies or jest.fn`, () => {
+    test('works only on spies or jest.fn', () => {
       const fn = function fn() {};
 
       expect(() => jestExpect(fn)[calledWith]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works when not called`, () => {
+    test('works when not called', () => {
       const fn = jest.fn();
       caller(jestExpect(createSpy(fn)).not[calledWith], 'foo', 'bar');
       caller(jestExpect(fn).not[calledWith], 'foo', 'bar');
@@ -207,14 +207,14 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with no arguments`, () => {
+    test('works with no arguments', () => {
       const fn = jest.fn();
       fn();
       caller(jestExpect(createSpy(fn))[calledWith]);
       caller(jestExpect(fn)[calledWith]);
     });
 
-    test(`works with arguments that don't match`, () => {
+    test("works with arguments that don't match", () => {
       const fn = jest.fn();
       fn('foo', 'bar1');
 
@@ -226,7 +226,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with arguments that match`, () => {
+    test('works with arguments that match', () => {
       const fn = jest.fn();
       fn('foo', 'bar');
 
@@ -238,7 +238,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with trailing undefined arguments`, () => {
+    test('works with trailing undefined arguments', () => {
       const fn = jest.fn();
       fn('foo', undefined);
 
@@ -247,7 +247,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Map`, () => {
+    test('works with Map', () => {
       const fn = jest.fn();
 
       const m1 = new Map([
@@ -276,7 +276,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Set`, () => {
+    test('works with Set', () => {
       const fn = jest.fn();
 
       const s1 = new Set([1, 2]);
@@ -296,7 +296,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Immutable.js objects`, () => {
+    test('works with Immutable.js objects', () => {
       const fn = jest.fn();
       const directlyCreated = Immutable.Map([['a', {b: 'c'}]]);
       const indirectlyCreated = Immutable.Map().set('a', {b: 'c'});
@@ -321,7 +321,7 @@ const createSpy = (fn: jest.Mock) => {
     ];
 
     if (basicCalledWith.indexOf(calledWith) >= 0) {
-      test(`works with many arguments`, () => {
+      test('works with many arguments', () => {
         const fn = jest.fn();
         fn('foo1', 'bar');
         fn('foo', 'bar1');
@@ -334,7 +334,7 @@ const createSpy = (fn: jest.Mock) => {
         ).toThrowErrorMatchingSnapshot();
       });
 
-      test(`works with many arguments that don't match`, () => {
+      test("works with many arguments that don't match", () => {
         const fn = jest.fn();
         fn('foo', 'bar1');
         fn('foo', 'bar2');
@@ -350,7 +350,7 @@ const createSpy = (fn: jest.Mock) => {
 
     const nthCalled = ['toHaveBeenNthCalledWith', 'nthCalledWith'];
     if (nthCalled.indexOf(calledWith) >= 0) {
-      test(`works with three calls`, () => {
+      test('works with three calls', () => {
         const fn = jest.fn();
         fn('foo1', 'bar');
         fn('foo', 'bar1');
@@ -393,7 +393,7 @@ const createSpy = (fn: jest.Mock) => {
       });
     }
 
-    test(`includes the custom mock name in the error message`, () => {
+    test('includes the custom mock name in the error message', () => {
       const fn = jest.fn().mockName('named-mock');
       fn('foo', 'bar');
 
@@ -408,7 +408,7 @@ const createSpy = (fn: jest.Mock) => {
 
 ['toReturn', 'toHaveReturned'].forEach(returned => {
   describe(`${returned}`, () => {
-    test(`.not works only on jest.fn`, () => {
+    test('.not works only on jest.fn', () => {
       const fn = function fn() {};
 
       expect(() =>
@@ -416,13 +416,13 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`throw matcher error if received is spy`, () => {
+    test('throw matcher error if received is spy', () => {
       const spy = createSpy(jest.fn());
 
       expect(() => jestExpect(spy)[returned]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`passes when returned`, () => {
+    test('passes when returned', () => {
       const fn = jest.fn(() => 42);
       fn();
       jestExpect(fn)[returned]();
@@ -431,7 +431,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`passes when undefined is returned`, () => {
+    test('passes when undefined is returned', () => {
       const fn = jest.fn(() => undefined);
       fn();
       jestExpect(fn)[returned]();
@@ -440,7 +440,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`passes when at least one call does not throw`, () => {
+    test('passes when at least one call does not throw', () => {
       const fn = jest.fn(causeError => {
         if (causeError) {
           throw new Error('Error!');
@@ -465,14 +465,14 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not passes when not returned`, () => {
+    test('.not passes when not returned', () => {
       const fn = jest.fn();
 
       jestExpect(fn).not[returned]();
       expect(() => jestExpect(fn)[returned]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not passes when all calls throw`, () => {
+    test('.not passes when all calls throw', () => {
       const fn = jest.fn(() => {
         throw new Error('Error!');
       });
@@ -493,7 +493,7 @@ const createSpy = (fn: jest.Mock) => {
       expect(() => jestExpect(fn)[returned]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not passes when a call throws undefined`, () => {
+    test('.not passes when a call throws undefined', () => {
       const fn = jest.fn(() => {
         // eslint-disable-next-line no-throw-literal
         throw undefined;
@@ -509,7 +509,7 @@ const createSpy = (fn: jest.Mock) => {
       expect(() => jestExpect(fn)[returned]()).toThrowErrorMatchingSnapshot();
     });
 
-    test(`fails with any argument passed`, () => {
+    test('fails with any argument passed', () => {
       const fn = jest.fn();
 
       fn();
@@ -518,7 +518,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`.not fails with any argument passed`, () => {
+    test('.not fails with any argument passed', () => {
       const fn = jest.fn();
 
       expect(() =>
@@ -526,7 +526,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`includes the custom mock name in the error message`, () => {
+    test('includes the custom mock name in the error message', () => {
       const fn = jest.fn(() => 42).mockName('named-mock');
       fn();
       jestExpect(fn)[returned]();
@@ -535,7 +535,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`incomplete recursive calls are handled properly`, () => {
+    test('incomplete recursive calls are handled properly', () => {
       // sums up all integers from 0 -> value, using recursion
       const fn: jest.Mock = jest.fn(value => {
         if (value === 0) {
@@ -704,7 +704,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`incomplete recursive calls are handled properly`, () => {
+    test('incomplete recursive calls are handled properly', () => {
       // sums up all integers from 0 -> value, using recursion
       const fn: jest.Mock = jest.fn(value => {
         if (value === 0) {
@@ -752,7 +752,7 @@ const createSpy = (fn: jest.Mock) => {
   };
 
   describe(`${returnedWith}`, () => {
-    test(`works only on spies or jest.fn`, () => {
+    test('works only on spies or jest.fn', () => {
       const fn = function fn() {};
 
       expect(() =>
@@ -760,7 +760,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works when not called`, () => {
+    test('works when not called', () => {
       const fn = jest.fn();
       caller(jestExpect(fn).not[returnedWith], 'foo');
 
@@ -769,7 +769,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with no arguments`, () => {
+    test('works with no arguments', () => {
       const fn = jest.fn();
       fn();
       caller(jestExpect(fn)[returnedWith]);
@@ -786,7 +786,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with argument that does match`, () => {
+    test('works with argument that does match', () => {
       const fn = jest.fn(() => 'foo');
       fn();
 
@@ -797,7 +797,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with undefined`, () => {
+    test('works with undefined', () => {
       const fn = jest.fn(() => undefined);
       fn();
 
@@ -808,7 +808,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Map`, () => {
+    test('works with Map', () => {
       const m1 = new Map([
         [1, 2],
         [2, 1],
@@ -836,7 +836,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Set`, () => {
+    test('works with Set', () => {
       const s1 = new Set([1, 2]);
       const s2 = new Set([1, 2]);
       const s3 = new Set([3, 4]);
@@ -855,7 +855,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Immutable.js objects directly created`, () => {
+    test('works with Immutable.js objects directly created', () => {
       const directlyCreated = Immutable.Map([['a', {b: 'c'}]]);
       const fn = jest.fn(() => directlyCreated);
       fn();
@@ -867,7 +867,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`works with Immutable.js objects indirectly created`, () => {
+    test('works with Immutable.js objects indirectly created', () => {
       const indirectlyCreated = Immutable.Map().set('a', {b: 'c'});
       const fn = jest.fn(() => indirectlyCreated);
       fn();
@@ -879,7 +879,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`a call that throws is not considered to have returned`, () => {
+    test('a call that throws is not considered to have returned', () => {
       const fn = jest.fn(() => {
         throw new Error('Error!');
       });
@@ -900,7 +900,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test(`a call that throws undefined is not considered to have returned`, () => {
+    test('a call that throws undefined is not considered to have returned', () => {
       const fn = jest.fn(() => {
         // eslint-disable-next-line no-throw-literal
         throw undefined;
@@ -925,7 +925,7 @@ const createSpy = (fn: jest.Mock) => {
     const basicReturnedWith = ['toHaveReturnedWith', 'toReturnWith'];
     if (basicReturnedWith.indexOf(returnedWith) >= 0) {
       describe('returnedWith', () => {
-        test(`works with more calls than the limit`, () => {
+        test('works with more calls than the limit', () => {
           const fn = jest.fn();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
@@ -948,7 +948,7 @@ const createSpy = (fn: jest.Mock) => {
           }).toThrowErrorMatchingSnapshot();
         });
 
-        test(`incomplete recursive calls are handled properly`, () => {
+        test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
           const fn: jest.Mock = jest.fn(value => {
             if (value === 0) {
@@ -975,7 +975,7 @@ const createSpy = (fn: jest.Mock) => {
     const nthReturnedWith = ['toHaveNthReturnedWith', 'nthReturnedWith'];
     if (nthReturnedWith.indexOf(returnedWith) >= 0) {
       describe('nthReturnedWith', () => {
-        test(`works with three calls`, () => {
+        test('works with three calls', () => {
           const fn = jest.fn();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
@@ -1055,7 +1055,7 @@ const createSpy = (fn: jest.Mock) => {
           }).toThrowErrorMatchingSnapshot();
         });
 
-        test(`incomplete recursive calls are handled properly`, () => {
+        test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
           const fn: jest.Mock = jest.fn(value => {
             if (value === 0) {
@@ -1096,7 +1096,7 @@ const createSpy = (fn: jest.Mock) => {
     const lastReturnedWith = ['toHaveLastReturnedWith', 'lastReturnedWith'];
     if (lastReturnedWith.indexOf(returnedWith) >= 0) {
       describe('lastReturnedWith', () => {
-        test(`works with three calls`, () => {
+        test('works with three calls', () => {
           const fn = jest.fn();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
@@ -1112,7 +1112,7 @@ const createSpy = (fn: jest.Mock) => {
           }).toThrowErrorMatchingSnapshot();
         });
 
-        test(`incomplete recursive calls are handled properly`, () => {
+        test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
           const fn: jest.Mock = jest.fn(value => {
             if (value === 0) {
@@ -1133,7 +1133,7 @@ const createSpy = (fn: jest.Mock) => {
       });
     }
 
-    test(`includes the custom mock name in the error message`, () => {
+    test('includes the custom mock name in the error message', () => {
       const fn = jest.fn().mockName('named-mock');
       caller(jestExpect(fn).not[returnedWith], 'foo');
 

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -183,7 +183,7 @@ const makeResolveMatcher =
         outerErr.message =
           matcherUtils.matcherHint(matcherName, undefined, '', options) +
           '\n\n' +
-          `Received promise rejected instead of resolved\n` +
+          'Received promise rejected instead of resolved\n' +
           `Rejected to value: ${matcherUtils.printReceived(reason)}`;
         return Promise.reject(outerErr);
       },
@@ -230,7 +230,7 @@ const makeRejectMatcher =
         outerErr.message =
           matcherUtils.matcherHint(matcherName, undefined, '', options) +
           '\n\n' +
-          `Received promise resolved instead of rejected\n` +
+          'Received promise resolved instead of rejected\n' +
           `Resolved to value: ${matcherUtils.printReceived(result)}`;
         return Promise.reject(outerErr);
       },

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -485,7 +485,7 @@ const createToBeCalledTimesMatcher = (matcherName: string) =>
     const message = pass
       ? () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
-          `\n\n` +
+          '\n\n' +
           `Expected number of calls: not ${printExpected(expected)}`
       : () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
@@ -523,7 +523,7 @@ const createToReturnTimesMatcher = (matcherName: string) =>
     const message = pass
       ? () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
-          `\n\n` +
+          '\n\n' +
           `Expected number of returns: not ${printExpected(expected)}` +
           (received.mock.calls.length !== count
             ? `\n\nReceived number of calls:       ${printReceived(

--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -20,7 +20,7 @@ const adapter: SCMAdapter = {
 
     const args = ['status', '-amnu'];
     if (options && options.withAncestor) {
-      args.push('--rev', `min((!public() & ::.)+.)^`);
+      args.push('--rev', 'min((!public() & ::.)+.)^');
     } else if (options && options.changedSince) {
       args.push('--rev', `ancestor(., ${options.changedSince})`);
     } else if (options && options.lastCommit === true) {

--- a/packages/jest-circus/src/__tests__/circusItTestError.test.ts
+++ b/packages/jest-circus/src/__tests__/circusItTestError.test.ts
@@ -22,12 +22,12 @@ const aliasCircusIt = () => {
 aliasCircusIt();
 
 describe('test/it error throwing', () => {
-  it(`it doesn't throw an error with valid arguments`, () => {
+  it("it doesn't throw an error with valid arguments", () => {
     expect(() => {
       circusIt('test1', () => {});
     }).not.toThrowError();
   });
-  it(`it throws error with missing callback function`, () => {
+  it('it throws error with missing callback function', () => {
     expect(() => {
       // @ts-expect-error: Easy, we're testing runtime errors here
       circusIt('test2');
@@ -35,7 +35,7 @@ describe('test/it error throwing', () => {
       'Missing second argument. It must be a callback function. Perhaps you want to use `test.todo` for a test placeholder.',
     );
   });
-  it(`it throws an error when first argument isn't a string`, () => {
+  it("it throws an error when first argument isn't a string", () => {
     expect(() => {
       // @ts-expect-error: Easy, we're testing runtime errors here
       circusIt(() => {});
@@ -49,12 +49,12 @@ describe('test/it error throwing', () => {
       'Invalid second argument, test4b. It must be a callback function.',
     );
   });
-  it(`test doesn't throw an error with valid arguments`, () => {
+  it("test doesn't throw an error with valid arguments", () => {
     expect(() => {
       circusTest('test5', () => {});
     }).not.toThrowError();
   });
-  it(`test throws error with missing callback function`, () => {
+  it('test throws error with missing callback function', () => {
     expect(() => {
       // @ts-expect-error: Easy, we're testing runtime errors here
       circusTest('test6');
@@ -62,7 +62,7 @@ describe('test/it error throwing', () => {
       'Missing second argument. It must be a callback function. Perhaps you want to use `test.todo` for a test placeholder.',
     );
   });
-  it(`test throws an error when first argument isn't a string`, () => {
+  it("test throws an error when first argument isn't a string", () => {
     expect(() => {
       // @ts-expect-error: Easy, we're testing runtime errors here
       circusTest(() => {});

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -54,7 +54,7 @@ const eventHandler: Circus.EventHandler = (
     }
     case 'finish_describe_definition': {
       const {currentDescribeBlock} = state;
-      invariant(currentDescribeBlock, `currentDescribeBlock must be there`);
+      invariant(currentDescribeBlock, 'currentDescribeBlock must be there');
 
       if (!describeBlockHasTests(currentDescribeBlock)) {
         currentDescribeBlock.hooks.forEach(hook => {

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -144,8 +144,8 @@ function assertionErrorMessage(
   if (operatorName === 'doesNotThrow') {
     return (
       buildHintString(assertThrowingMatcherHint(operatorName)) +
-      chalk.reset(`Expected the function not to throw an error.\n`) +
-      chalk.reset(`Instead, it threw:\n`) +
+      chalk.reset('Expected the function not to throw an error.\n') +
+      chalk.reset('Instead, it threw:\n') +
       `  ${printReceived(actual)}` +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
       trimmedStack
@@ -155,8 +155,8 @@ function assertionErrorMessage(
   if (operatorName === 'throws') {
     return (
       buildHintString(assertThrowingMatcherHint(operatorName)) +
-      chalk.reset(`Expected the function to throw an error.\n`) +
-      chalk.reset(`But it didn't throw anything.`) +
+      chalk.reset('Expected the function to throw an error.\n') +
+      chalk.reset("But it didn't throw anything.") +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
       trimmedStack
     );
@@ -174,7 +174,7 @@ function assertionErrorMessage(
     buildHintString(assertMatcherHint(operator, operatorName, expected)) +
     chalk.reset(`Expected value ${operatorMessage(operator)}`) +
     `  ${printExpected(expected)}\n` +
-    chalk.reset(`Received:\n`) +
+    chalk.reset('Received:\n') +
     `  ${printReceived(actual)}` +
     chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
     (diffString ? `\n\nDifference:\n\n${diffString}` : '') +

--- a/packages/jest-circus/src/index.ts
+++ b/packages/jest-circus/src/index.ts
@@ -46,7 +46,8 @@ const _dispatchDescribe = (
 ) => {
   const asyncError = new ErrorWithStack(undefined, describeFn);
   if (blockFn === undefined) {
-    asyncError.message = `Missing second argument. It must be a callback function.`;
+    asyncError.message =
+      'Missing second argument. It must be a callback function.';
     throw asyncError;
   }
   if (typeof blockFn !== 'function') {

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -168,7 +168,7 @@ const _callCircusTest = async (
 ): Promise<void> => {
   await dispatch({name: 'test_fn_start', test});
   const timeout = test.timeout || getState().testTimeout;
-  invariant(test.fn, `Tests with no 'fn' should have 'mode' set to 'skipped'`);
+  invariant(test.fn, "Tests with no 'fn' should have 'mode' set to 'skipped'");
 
   if (test.errors.length) {
     return; // We don't run the test if there's already an error in before hooks.

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -33,7 +33,7 @@ export function check(argv: Config.Argv): true {
 
   if (argv.onlyFailures && argv.watchAll) {
     throw new Error(
-      `Both --onlyFailures and --watchAll were specified, but these two ` +
+      'Both --onlyFailures and --watchAll were specified, but these two ' +
         'options do not make sense together.',
     );
   }

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -95,7 +95,7 @@ export default async function init(
   console.log();
   console.log(
     chalk.underline(
-      `The following questions will help Jest to create a suitable configuration for your project\n`,
+      'The following questions will help Jest to create a suitable configuration for your project\n',
     ),
   );
 

--- a/packages/jest-config/src/ReporterValidationErrors.ts
+++ b/packages/jest-config/src/ReporterValidationErrors.ts
@@ -29,7 +29,7 @@ export function createReporterError(
   const errorMessage =
     `  Reporter at index ${reporterIndex} must be of type:\n` +
     `    ${chalk.bold.green(validReporterTypes.join(' or '))}\n` +
-    `  but instead received:\n` +
+    '  but instead received:\n' +
     `    ${chalk.bold.red(getType(reporterValue))}`;
 
   return new ValidationError(ERROR, errorMessage, DOCUMENTATION_NOTE);
@@ -50,7 +50,7 @@ export function createArrayReporterError(
     `    ${chalk.bold.red(expectedType)}\n` +
     '  Got:\n' +
     `    ${chalk.bold.green(getType(value))}\n` +
-    `  Reporter configuration:\n` +
+    '  Reporter configuration:\n' +
     `    ${chalk.bold.green(
       JSON.stringify(arrayReporter, null, 2).split('\n').join('\n    '),
     )}`;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -438,7 +438,7 @@ const normalizeReporters = (options: Config.InitialOptionsWithRootDir) => {
       });
       if (!reporter) {
         throw new Resolver.ModuleNotFoundError(
-          `Could not resolve a module for a custom reporter.\n` +
+          'Could not resolve a module for a custom reporter.\n' +
             `  Module name: ${reporterPath}`,
         );
       }
@@ -485,7 +485,7 @@ const showTestPathPatternError = (testPathPattern: string) => {
   console.log(
     chalk.red(
       `  Invalid testPattern ${testPathPattern} supplied. ` +
-        `Running all tests instead.`,
+        'Running all tests instead.',
     ),
   );
 };
@@ -878,8 +878,8 @@ export default async function normalize(
           !value.includes('js')
         ) {
           const errorMessage =
-            `  moduleFileExtensions must include 'js':\n` +
-            `  but instead received:\n` +
+            "  moduleFileExtensions must include 'js':\n" +
+            '  but instead received:\n' +
             `    ${chalk.bold.red(JSON.stringify(value))}`;
 
           // If `js` is not included, any dependency Jest itself injects into

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -49,7 +49,7 @@ export default function resolveConfigPath(
   // try to run all tests it finds under `my_project` directory.
   if (!fs.existsSync(absolutePath)) {
     throw new Error(
-      `Can't find a root directory while resolving a config file path.\n` +
+      "Can't find a root directory while resolving a config file path.\n" +
         `Provided path to resolve: ${pathToResolve}\n` +
         `cwd: ${cwd}`,
     );

--- a/packages/jest-core/src/getNoTestFoundVerbose.ts
+++ b/packages/jest-core/src/getNoTestFoundVerbose.ts
@@ -40,10 +40,10 @@ export default function getNoTestFoundVerbose(
           `  ${pluralize('file', testRun.matches.total || 0, 's')} checked.\n` +
           statsMessage
       : `No files found in ${config.rootDir}.\n` +
-          `Make sure Jest's configuration does not exclude this directory.` +
-          `\nTo set up Jest, make sure a package.json file exists.\n` +
-          `Jest Documentation: ` +
-          `https://jestjs.io/docs/configuration`;
+          "Make sure Jest's configuration does not exclude this directory." +
+          '\nTo set up Jest, make sure a package.json file exists.\n' +
+          'Jest Documentation: ' +
+          'https://jestjs.io/docs/configuration';
   });
   let dataMessage;
 

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -398,14 +398,14 @@ export default class FakeTimers<TimerRef> {
   private _checkFakeTimers() {
     if (this._global.setTimeout !== this._fakeTimerAPIs?.setTimeout) {
       this._global.console.warn(
-        `A function to advance timers was called but the timers API is not ` +
-          `mocked with fake timers. Call \`jest.useFakeTimers()\` in this ` +
-          `test or enable fake timers globally by setting ` +
-          `\`"timers": "fake"\` in ` +
-          `the configuration file. This warning is likely a result of a ` +
-          `default configuration change in Jest 15.\n\n` +
-          `Release Blog Post: https://jestjs.io/blog/2016/09/01/jest-15\n` +
-          `Stack Trace:\n` +
+        'A function to advance timers was called but the timers API is not ' +
+          'mocked with fake timers. Call `jest.useFakeTimers()` in this ' +
+          'test or enable fake timers globally by setting ' +
+          '`"timers": "fake"` in ' +
+          'the configuration file. This warning is likely a result of a ' +
+          'default configuration change in Jest 15.\n\n' +
+          'Release Blog Post: https://jestjs.io/blog/2016/09/01/jest-15\n' +
+          'Stack Trace:\n' +
           formatStackTrace(new Error().stack!, this._config, {
             noStackTrace: false,
           }),

--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -222,10 +222,10 @@ class DuplicateHasteCandidatesError extends Error {
     const platformMessage = getPlatformMessage(platform);
     super(
       `The name \`${name}\` was looked up in the Haste module map. It ` +
-        `cannot be resolved, because there exists several different ` +
-        `files, or packages, that provide a module for ` +
+        'cannot be resolved, because there exists several different ' +
+        'files, or packages, that provide a module for ' +
         `that particular name and platform. ${platformMessage} You must ` +
-        `delete or exclude files until there remains only one of these:\n\n` +
+        'delete or exclude files until there remains only one of these:\n\n' +
         Array.from(duplicatesSet)
           .map(
             ([dupFilePath, dupFileType]) =>

--- a/packages/jest-haste-map/src/__tests__/worker.test.js
+++ b/packages/jest-haste-map/src/__tests__/worker.test.js
@@ -142,7 +142,7 @@ describe('worker', () => {
       error = err;
     }
 
-    expect(error.message).toEqual(`Cannot read path '/kiwi.js'.`);
+    expect(error.message).toEqual("Cannot read path '/kiwi.js'.");
   });
 
   it('simply computes SHA-1s when requested (works well with binary data)', async () => {

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -771,17 +771,17 @@ export default class HasteMap extends EventEmitter {
     const retry = (error: Error) => {
       if (crawl === watchmanCrawl) {
         this._console.warn(
-          `jest-haste-map: Watchman crawl failed. Retrying once with node ` +
-            `crawler.\n` +
-            `  Usually this happens when watchman isn't running. Create an ` +
-            `empty \`.watchmanconfig\` file in your project's root folder or ` +
-            `initialize a git or hg repository in your project.\n` +
-            `  ` +
+          'jest-haste-map: Watchman crawl failed. Retrying once with node ' +
+            'crawler.\n' +
+            "  Usually this happens when watchman isn't running. Create an " +
+            "empty `.watchmanconfig` file in your project's root folder or " +
+            'initialize a git or hg repository in your project.\n' +
+            '  ' +
             error,
         );
         return nodeCrawl(crawlerOptions).catch(e => {
           throw new Error(
-            `Crawler retry failed:\n` +
+            'Crawler retry failed:\n' +
               `  Original error: ${error.message}\n` +
               `  Retry error: ${e.message}\n`,
           );

--- a/packages/jest-jasmine2/src/__tests__/itTestError.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/itTestError.test.ts
@@ -7,18 +7,18 @@
  */
 
 describe('test/it error throwing', () => {
-  it(`it throws error with missing callback function`, () => {
+  it('it throws error with missing callback function', () => {
     expect(() => {
       it('test1');
     }).toThrowError(
       'Missing second argument. It must be a callback function. Perhaps you want to use `test.todo` for a test placeholder.',
     );
   });
-  it(`it throws an error when first argument isn't a string`, () => {
+  it("it throws an error when first argument isn't a string", () => {
     expect(() => {
       // @ts-expect-error
       it(() => {});
-    }).toThrowError(`Invalid first argument, () => {}. It must be a string.`);
+    }).toThrowError('Invalid first argument, () => {}. It must be a string.');
   });
   it('it throws an error when callback function is not a function', () => {
     expect(() => {
@@ -28,18 +28,18 @@ describe('test/it error throwing', () => {
       'Invalid second argument, test3b. It must be a callback function.',
     );
   });
-  test(`test throws error with missing callback function`, () => {
+  test('test throws error with missing callback function', () => {
     expect(() => {
       test('test4');
     }).toThrowError(
       'Missing second argument. It must be a callback function. Perhaps you want to use `test.todo` for a test placeholder.',
     );
   });
-  test(`test throws an error when first argument isn't a string`, () => {
+  test("test throws an error when first argument isn't a string", () => {
     expect(() => {
       // @ts-expect-error
       test(() => {});
-    }).toThrowError(`Invalid first argument, () => {}. It must be a string.`);
+    }).toThrowError('Invalid first argument, () => {}. It must be a string.');
   });
   test('test throws an error when callback function is not a function', () => {
     expect(() => {

--- a/packages/jest-jasmine2/src/assertionErrorMessage.ts
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.ts
@@ -107,8 +107,8 @@ function assertionErrorMessage(
   if (operatorName === 'doesNotThrow') {
     return (
       buildHintString(assertThrowingMatcherHint(operatorName)) +
-      chalk.reset(`Expected the function not to throw an error.\n`) +
-      chalk.reset(`Instead, it threw:\n`) +
+      chalk.reset('Expected the function not to throw an error.\n') +
+      chalk.reset('Instead, it threw:\n') +
       `  ${printReceived(actual)}` +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
       trimmedStack
@@ -118,8 +118,8 @@ function assertionErrorMessage(
   if (operatorName === 'throws') {
     return (
       buildHintString(assertThrowingMatcherHint(operatorName)) +
-      chalk.reset(`Expected the function to throw an error.\n`) +
-      chalk.reset(`But it didn't throw anything.`) +
+      chalk.reset('Expected the function to throw an error.\n') +
+      chalk.reset("But it didn't throw anything.") +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
       trimmedStack
     );
@@ -137,7 +137,7 @@ function assertionErrorMessage(
     buildHintString(assertMatcherHint(operator, operatorName, expected)) +
     chalk.reset(`Expected value ${operatorMessage(operator)}`) +
     `  ${printExpected(expected)}\n` +
-    chalk.reset(`Received:\n`) +
+    chalk.reset('Received:\n') +
     `  ${printReceived(actual)}` +
     chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
     (diffString ? `\n\nDifference:\n\n${diffString}` : '') +

--- a/packages/jest-jasmine2/src/jasmine/Env.ts
+++ b/packages/jest-jasmine2/src/jasmine/Env.ts
@@ -384,7 +384,7 @@ export default function jasmineEnv(j$: Jasmine) {
         const suite = suiteFactory(description);
         if (specDefinitions === undefined) {
           throw new Error(
-            `Missing second argument. It must be a callback function.`,
+            'Missing second argument. It must be a callback function.',
           );
         }
         if (typeof specDefinitions !== 'function') {

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -24,7 +24,7 @@ jest.mock('graceful-fs', () => ({
 }));
 
 const unixStackTrace =
-  `  ` +
+  '  ' +
   `at stack (../jest-jasmine2/build/jasmine-2.4.1.js:1580:17)
   at Object.addResult (../jest-jasmine2/build/jasmine-2.4.1.js:1550:14)
   at jasmine.addResult (../jest-jasmine2/build/index.js:82:44)

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -759,7 +759,7 @@ describe('moduleMocker', () => {
       ]);
     });
 
-    it(`a call that throws undefined is tracked properly`, () => {
+    it('a call that throws undefined is tracked properly', () => {
       const fn = moduleMocker.fn(() => {
         // eslint-disable-next-line no-throw-literal
         throw undefined;

--- a/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
@@ -389,7 +389,7 @@ describe('onRunComplete', () => {
       });
   });
 
-  test(`that files are matched by all matching threshold groups`, () => {
+  test('that files are matched by all matching threshold groups', () => {
     const testReporter = new CoverageReporter(
       {
         collectCoverage: true,
@@ -420,7 +420,7 @@ describe('onRunComplete', () => {
       });
   });
 
-  test(`that it passes custom options when creating reporters`, () => {
+  test('that it passes custom options when creating reporters', () => {
     const testReporter = new CoverageReporter({
       coverageReporters: ['json', ['lcov', {maxCols: 10, projectRoot: './'}]],
     });

--- a/packages/jest-reporters/src/__tests__/getWatermarks.test.ts
+++ b/packages/jest-reporters/src/__tests__/getWatermarks.test.ts
@@ -9,7 +9,7 @@ import {makeGlobalConfig} from '@jest/test-utils';
 import getWatermarks from '../getWatermarks';
 
 describe('getWatermarks', () => {
-  test(`that watermarks use thresholds as upper target`, () => {
+  test('that watermarks use thresholds as upper target', () => {
     const watermarks = getWatermarks(
       makeGlobalConfig({
         coverageThreshold: {
@@ -31,7 +31,7 @@ describe('getWatermarks', () => {
     });
   });
 
-  test(`that watermarks are created always created`, () => {
+  test('that watermarks are created always created', () => {
     const watermarks = getWatermarks(makeGlobalConfig());
 
     expect(watermarks).toEqual({

--- a/packages/jest-reporters/src/__tests__/utils.test.ts
+++ b/packages/jest-reporters/src/__tests__/utils.test.ts
@@ -16,15 +16,15 @@ describe('wrapAnsiString()', () => {
     const string =
       `abcde ${chalk.red.bold('red-bold')} 1234456` +
       `${chalk.dim('bcd')} ` +
-      `123ttttttththththththththththththththththththththth` +
+      '123ttttttththththththththththththththththththththth' +
       `tetetetetettetetetetetetetete${chalk.underline.bold('stnhsnthsnth')}` +
-      `ssot`;
+      'ssot';
     expect(wrapAnsiString(string, 10)).toMatchSnapshot();
     expect(stripAnsi(wrapAnsiString(string, 10))).toMatchSnapshot();
   });
 
   it('returns the string unaltered if given a terminal width of zero', () => {
-    const string = `This string shouldn't cause you any trouble`;
+    const string = "This string shouldn't cause you any trouble";
     expect(wrapAnsiString(string, 0)).toMatchSnapshot();
     expect(stripAnsi(wrapAnsiString(string, 0))).toMatchSnapshot();
   });

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -174,7 +174,7 @@ export const getSummary = (
     (suitesRun !== suitesTotal
       ? suitesRun + ' of ' + suitesTotal
       : suitesTotal) +
-    ` total`;
+    ' total';
 
   const updatedTestsFailed =
     testsFailed + valuesForCurrentTestCases.numFailingTests;
@@ -244,7 +244,7 @@ const renderTime = (runTime: number, estimatedTime: number, width: number) => {
     estimatedTime && runTime >= estimatedTime + 1
       ? chalk.bold.yellow(formatTime(runTime, 0))
       : formatTime(runTime, 0);
-  let time = chalk.bold(`Time:`) + `        ${renderedTime}`;
+  let time = chalk.bold('Time:') + `        ${renderedTime}`;
   if (runTime < estimatedTime) {
     time += `, estimated ${formatTime(estimatedTime, 0)}`;
   }

--- a/packages/jest-runtime/src/__tests__/instrumentation.test.ts
+++ b/packages/jest-runtime/src/__tests__/instrumentation.test.ts
@@ -34,5 +34,5 @@ it('instruments files', async () => {
   // We can't really snapshot the resulting coverage, because it depends on
   // absolute path of the file, which will be different on different
   // machines
-  expect(instrumented.code).toMatch(`gcv = "__coverage__"`);
+  expect(instrumented.code).toMatch('gcv = "__coverage__"');
 });

--- a/packages/jest-runtime/src/__tests__/runtime_node_path.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_node_path.test.js
@@ -67,7 +67,7 @@ describe('Runtime', () => {
       );
     }).toThrow(
       new Error(
-        `Cannot find module 'regular_module_in_node_path' from 'root.js'`,
+        "Cannot find module 'regular_module_in_node_path' from 'root.js'",
       ),
     );
   });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -240,7 +240,7 @@ describe('Runtime requireModule', () => {
     expect(exports.isExclusivelyManualMockModule).toBe(true);
   });
 
-  it(`doesn't override real modules with manual mocks when explicitly unmocked`, async () => {
+  it("doesn't override real modules with manual mocks when explicitly unmocked", async () => {
     const runtime = await createRuntime(__filename, {
       automock: true,
     });
@@ -420,7 +420,7 @@ describe('Runtime requireModule', () => {
       // createRequire with relative module path
       expect(() => exports.createRequireFromPath('./relative/path')).toThrow(
         new TypeError(
-          `The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received './relative/path'`,
+          "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received './relative/path'",
         ),
       );
 

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
@@ -36,7 +36,7 @@ it('mocks modules by default when using automocking', async () => {
   expect(exports.setModuleStateValue._isMockFunction).toBe(true);
 });
 
-it(`doesn't mock modules when explicitly unmocked when using automocking`, async () => {
+it("doesn't mock modules when explicitly unmocked when using automocking", async () => {
   const runtime = await createRuntime(__filename, {
     automock: true,
     moduleNameMapper,
@@ -50,7 +50,7 @@ it(`doesn't mock modules when explicitly unmocked when using automocking`, async
   expect(exports.isRealModule).toBe(true);
 });
 
-it(`doesn't mock modules when explicitly unmocked via a different name`, async () => {
+it("doesn't mock modules when explicitly unmocked via a different name", async () => {
   const runtime = await createRuntime(__filename, {
     automock: true,
     moduleNameMapper,
@@ -64,7 +64,7 @@ it(`doesn't mock modules when explicitly unmocked via a different name`, async (
   expect(exports.isRealModule).toBe(true);
 });
 
-it(`doesn't mock modules when disableAutomock() has been called`, async () => {
+it("doesn't mock modules when disableAutomock() has been called", async () => {
   const runtime = await createRuntime(__filename, {moduleNameMapper});
   const root = runtime.requireModule(runtime.__mockRootPath);
   root.jest.disableAutomock();

--- a/packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts
@@ -69,7 +69,7 @@ describe('Runtime require.resolve', () => {
       'utf-8',
     );
 
-    await fs.writeFile(target, `module.exports = {}`, 'utf-8');
+    await fs.writeFile(target, 'module.exports = {}', 'utf-8');
 
     const runtime = await createRuntime(__filename);
     const resolved = runtime.requireModule(runtime.__mockRootPath, entrypoint);

--- a/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
+++ b/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
@@ -7,4 +7,4 @@
 
 'use strict';
 
-module.exports = `in_mapped`;
+module.exports = 'in_mapped';

--- a/packages/jest-runtime/src/__tests__/test_root/test_preprocessor.js
+++ b/packages/jest-runtime/src/__tests__/test_root/test_preprocessor.js
@@ -7,4 +7,4 @@
 
 'use strict';
 
-module.exports.process = () => `throw new Error('preprocessor must not run.');`;
+module.exports.process = () => "throw new Error('preprocessor must not run.');";

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1672,7 +1672,7 @@ export default class Runtime {
       if (mockMetadata == null) {
         throw new Error(
           `Failed to get mock metadata: ${modulePath}\n\n` +
-            `See: https://jestjs.io/docs/manual-mocks#content`,
+            'See: https://jestjs.io/docs/manual-mocks#content',
         );
       }
       this._mockMetaDataCache.set(modulePath, mockMetadata);

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -252,7 +252,7 @@ const traverseAst = (
   });
 
   if (remainingSnapshots.size) {
-    throw new Error(`Jest: Couldn't locate all inline snapshots.`);
+    throw new Error("Jest: Couldn't locate all inline snapshots.");
   }
 };
 

--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -26,13 +26,13 @@ beforeEach(() => {
 
 test('saveInlineSnapshots() replaces empty function call with a template literal', () => {
   const filename = path.join(dir, 'my.test.js');
-  fs.writeFileSync(filename, `expect(1).toMatchInlineSnapshot();\n`);
+  fs.writeFileSync(filename, 'expect(1).toMatchInlineSnapshot();\n');
 
   saveInlineSnapshots(
     [
       {
         frame: {column: 11, file: filename, line: 1} as Frame,
-        snapshot: `1`,
+        snapshot: '1',
       },
     ],
     'prettier',
@@ -59,7 +59,7 @@ expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
   saveInlineSnapshots(
     [2, 4, 5].map(line => ({
       frame: {column: 11, file: filename, line} as Frame,
-      snapshot: `[1, 2]`,
+      snapshot: '[1, 2]',
     })),
     null,
   );
@@ -89,7 +89,7 @@ expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
   saveInlineSnapshots(
     [2, 4, 5].map(line => ({
       frame: {column: 11, file: filename, line} as Frame,
-      snapshot: `[1, 2]`,
+      snapshot: '[1, 2]',
     })),
     'bad-prettier',
   );
@@ -120,7 +120,7 @@ expect(a).toMatchInlineSnapshot();
     [
       {
         frame: {column: 11, file: filename, line: 5} as Frame,
-        snapshot: `[{ foo: 'one' }, { foo: 'two' }]`,
+        snapshot: "[{ foo: 'one' }, { foo: 'two' }]",
       },
     ],
     null,
@@ -154,7 +154,7 @@ it('foos', async () => {
     [
       {
         frame: {column: 13, file: filename, line: 4} as Frame,
-        snapshot: `<div>hello</div>`,
+        snapshot: '<div>hello</div>',
       },
     ],
     null,
@@ -195,7 +195,7 @@ expect(a).toMatchInlineSnapshot();
     [
       {
         frame: {column: 11, file: filename, line: 3} as Frame,
-        snapshot: `<div>hello</div>`,
+        snapshot: '<div>hello</div>',
       },
     ],
     null,
@@ -226,7 +226,7 @@ expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
   saveInlineSnapshots(
     [2, 4, 5].map(line => ({
       frame: {column: 11, file: filename, line} as Frame,
-      snapshot: `[1, 2]`,
+      snapshot: '[1, 2]',
     })),
     'prettier',
   );
@@ -252,7 +252,7 @@ test.each([['babel'], ['flow'], ['typescript']])(
       [
         {
           frame: {column: 11, file: filename, line: 1} as Frame,
-          snapshot: `1`,
+          snapshot: '1',
         },
       ],
       'prettier',
@@ -276,7 +276,7 @@ test('saveInlineSnapshots() replaces existing template literal with property mat
     [
       {
         frame: {column: 11, file: filename, line: 1} as Frame,
-        snapshot: `1`,
+        snapshot: '1',
       },
     ],
     'prettier',
@@ -297,7 +297,7 @@ test.each(['prettier', null])(
       [
         {
           frame: {column: 11, file: filename, line: 1} as Frame,
-          snapshot: `1`,
+          snapshot: '1',
         },
       ],
       prettierModule,
@@ -322,7 +322,7 @@ test('saveInlineSnapshots() throws if frame does not match', () => {
             file: filename,
             line: 1,
           } as Frame,
-          snapshot: `1`,
+          snapshot: '1',
         },
       ],
       'prettier',
@@ -339,8 +339,8 @@ test('saveInlineSnapshots() throws if multiple calls to to the same location', (
   const save = () =>
     saveInlineSnapshots(
       [
-        {frame, snapshot: `1`},
-        {frame, snapshot: `2`},
+        {frame, snapshot: '1'},
+        {frame, snapshot: '2'},
       ],
       'prettier',
     );
@@ -364,7 +364,7 @@ test('saveInlineSnapshots() uses escaped backticks', () => {
 
 test('saveInlineSnapshots() works with non-literals in expect call', () => {
   const filename = path.join(dir, 'my.test.js');
-  fs.writeFileSync(filename, `expect({a: 'a'}).toMatchInlineSnapshot();\n`);
+  fs.writeFileSync(filename, "expect({a: 'a'}).toMatchInlineSnapshot();\n");
   (prettier.resolveConfig.sync as jest.Mock).mockReturnValue({
     bracketSpacing: false,
     singleQuote: true,
@@ -374,7 +374,7 @@ test('saveInlineSnapshots() works with non-literals in expect call', () => {
     [
       {
         frame: {column: 18, file: filename, line: 1} as Frame,
-        snapshot: `{a: 'a'}`,
+        snapshot: "{a: 'a'}",
       },
     ],
     'prettier',
@@ -402,7 +402,7 @@ test('saveInlineSnapshots() indents multi-line snapshots with spaces', () => {
     [
       {
         frame: {column: 20, file: filename, line: 2} as Frame,
-        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+        snapshot: "\nObject {\n  a: 'a'\n}\n",
       },
     ],
     'prettier',
@@ -444,7 +444,7 @@ test('saveInlineSnapshots() does not re-indent error snapshots', () => {
     [
       {
         frame: {column: 20, file: filename, line: 10} as Frame,
-        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+        snapshot: "\nObject {\n  a: 'a'\n}\n",
       },
     ],
     'prettier',
@@ -493,7 +493,7 @@ test('saveInlineSnapshots() does not re-indent already indented snapshots', () =
     [
       {
         frame: {column: 20, file: filename, line: 2} as Frame,
-        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+        snapshot: "\nObject {\n  a: 'a'\n}\n",
       },
     ],
     'prettier',
@@ -535,7 +535,7 @@ test('saveInlineSnapshots() indents multi-line snapshots with tabs', () => {
     [
       {
         frame: {column: 20, file: filename, line: 2} as Frame,
-        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+        snapshot: "\nObject {\n  a: 'a'\n}\n",
       },
     ],
     'prettier',
@@ -567,7 +567,7 @@ test('saveInlineSnapshots() indents snapshots after prettier reformats', () => {
     [
       {
         frame: {column: 40, file: filename, line: 1} as Frame,
-        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+        snapshot: "\nObject {\n  a: 'a'\n}\n",
       },
     ],
     'prettier',
@@ -598,7 +598,7 @@ test('saveInlineSnapshots() does not indent empty lines', () => {
     [
       {
         frame: {column: 9, file: filename, line: 3} as Frame,
-        snapshot: `\nhello\n\nworld\n`,
+        snapshot: '\nhello\n\nworld\n',
       },
     ],
     'prettier',

--- a/packages/jest-snapshot/src/__tests__/matcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/matcher.test.ts
@@ -9,7 +9,7 @@ import jestSnapshot from '../';
 
 const {toMatchSnapshot} = jestSnapshot;
 
-it(`matcher returns matcher name, expected and actual values`, () => {
+it('matcher returns matcher name, expected and actual values', () => {
   const actual = 'a';
   const expected = 'b';
   const matcher = toMatchSnapshot.bind({

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -156,7 +156,7 @@ describe('chalk', () => {
     return [
       aColor(`- delete 1${changeLineTrailingSpaceColor(' ')}`),
       cColor(`  common 2${commonLineTrailingSpaceColor('  ')}`),
-      bColor(`+ insert 0`),
+      bColor('+ insert 0'),
     ].join('\n');
   };
 
@@ -1332,7 +1332,7 @@ describe('printSnapshotAndReceived', () => {
         'printWidth: 80',
         '                                                                                | printWidth',
         '=====================================input======================================',
-        `<img src="test.png" alt='John "ShotGun" Nelson'>`,
+        '<img src="test.png" alt=\'John "ShotGun" Nelson\'>',
         '',
         '=====================================output=====================================',
         '<img src="test.png" alt="John &quot;ShotGun&quot; Nelson" />',
@@ -1345,10 +1345,10 @@ describe('printSnapshotAndReceived', () => {
         'printWidth: 80',
         '                                                                                | printWidth',
         '=====================================input======================================',
-        `<img src="test.png" alt='John "ShotGun" Nelson'>`,
+        '<img src="test.png" alt=\'John "ShotGun" Nelson\'>',
         '',
         '=====================================output=====================================',
-        `<img src="test.png" alt='John "ShotGun" Nelson' />`,
+        '<img src="test.png" alt=\'John "ShotGun" Nelson\' />',
         '',
         '================================================================================',
       ].join('\n');

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -80,9 +80,9 @@ test('getSnapshotData() throws when no snapshot version', () => {
   expect(() => getSnapshotData(filename, update)).toThrowError(
     chalk.red(
       `${chalk.bold('Outdated snapshot')}: No snapshot header found. ` +
-        `Jest 19 introduced versioned snapshots to ensure all developers on ` +
-        `a project are using the same version of Jest. ` +
-        `Please update all snapshots during this upgrade of Jest.\n\n`,
+        'Jest 19 introduced versioned snapshots to ensure all developers on ' +
+        'a project are using the same version of Jest. ' +
+        'Please update all snapshots during this upgrade of Jest.\n\n',
     ) + SNAPSHOT_VERSION_WARNING,
   );
 });
@@ -99,13 +99,13 @@ test('getSnapshotData() throws for older snapshot version', () => {
   expect(() => getSnapshotData(filename, update)).toThrowError(
     chalk.red(
       `${chalk.red.bold('Outdated snapshot')}: The version of the snapshot ` +
-        `file associated with this test is outdated. The snapshot file ` +
-        `version ensures that all developers on a project are using ` +
-        `the same version of Jest. ` +
-        `Please update all snapshots during this upgrade of Jest.\n\n`,
+        'file associated with this test is outdated. The snapshot file ' +
+        'version ensures that all developers on a project are using ' +
+        'the same version of Jest. ' +
+        'Please update all snapshots during this upgrade of Jest.\n\n',
     ) +
       `Expected: v${SNAPSHOT_VERSION}\n` +
-      `Received: v0.99\n\n` +
+      'Received: v0.99\n\n' +
       SNAPSHOT_VERSION_WARNING,
   );
 });
@@ -122,14 +122,14 @@ test('getSnapshotData() throws for newer snapshot version', () => {
   expect(() => getSnapshotData(filename, update)).toThrowError(
     chalk.red(
       `${chalk.red.bold('Outdated Jest version')}: The version of this ` +
-        `snapshot file indicates that this project is meant to be used ` +
-        `with a newer version of Jest. ` +
-        `The snapshot file version ensures that all developers on a project ` +
-        `are using the same version of Jest. ` +
-        `Please update your version of Jest and re-run the tests.\n\n`,
+        'snapshot file indicates that this project is meant to be used ' +
+        'with a newer version of Jest. ' +
+        'The snapshot file version ensures that all developers on a project ' +
+        'are using the same version of Jest. ' +
+        'Please update your version of Jest and re-run the tests.\n\n',
     ) +
       `Expected: v${SNAPSHOT_VERSION}\n` +
-      `Received: v2`,
+      'Received: v2',
   );
 });
 

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -184,7 +184,8 @@ const toMatchSnapshot = function (
         options.secondArgumentColor = BOLD_WEIGHT;
 
         if (propertiesOrHint == null) {
-          printedWithType += `\n\nTo provide a hint without properties: toMatchSnapshot('hint')`;
+          printedWithType +=
+            "\n\nTo provide a hint without properties: toMatchSnapshot('hint')";
         }
       }
 
@@ -256,7 +257,7 @@ const toMatchInlineSnapshot = function (
       throw new Error(
         matcherErrorMessage(
           matcherHint(matcherName, undefined, PROPERTIES_ARG, options),
-          `Inline snapshot must be a string`,
+          'Inline snapshot must be a string',
           printWithType('Inline snapshot', inlineSnapshot, utils.serialize),
         ),
       );
@@ -303,7 +304,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     throw new Error(
       matcherHintFromConfig(config, false) +
         '\n\n' +
-        `Snapshot state must be initialized` +
+        'Snapshot state must be initialized' +
         '\n\n' +
         printWithType('Snapshot state', snapshotState, stringify),
     );
@@ -377,9 +378,9 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
           printSnapshotName(currentTestName, hint, count) +
           '\n\n' +
           `New snapshot was ${BOLD_WEIGHT('not written')}. The update flag ` +
-          `must be explicitly passed to write a new snapshot.\n\n` +
-          `This is likely because this test is run in a continuous integration ` +
-          `(CI) environment in which snapshots are not written by default.\n\n` +
+          'must be explicitly passed to write a new snapshot.\n\n' +
+          'This is likely because this test is run in a continuous integration ' +
+          '(CI) environment in which snapshots are not written by default.\n\n' +
           `Received:${actual.includes('\n') ? '\n' : ' '}${bReceivedColor(
             actual,
           )}`
@@ -448,7 +449,7 @@ const toThrowErrorMatchingInlineSnapshot = function (
     throw new Error(
       matcherErrorMessage(
         matcherHint(matcherName, undefined, SNAPSHOT_ARG, options),
-        `Inline snapshot must be a string`,
+        'Inline snapshot must be a string',
         printWithType('Inline snapshot', inlineSnapshot, utils.serialize),
       ),
     );

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -22,8 +22,8 @@ const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
 export const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
 export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
   `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
-    `we recommend that you revert any local changes to tests or other code, ` +
-    `to ensure that you do not store invalid state.`,
+    'we recommend that you revert any local changes to tests or other code, ' +
+    'to ensure that you do not store invalid state.',
 );
 
 const writeSnapshotVersion = () =>
@@ -37,9 +37,9 @@ const validateSnapshotVersion = (snapshotContents: string) => {
     return new Error(
       chalk.red(
         `${chalk.bold('Outdated snapshot')}: No snapshot header found. ` +
-          `Jest 19 introduced versioned snapshots to ensure all developers ` +
-          `on a project are using the same version of Jest. ` +
-          `Please update all snapshots during this upgrade of Jest.\n\n`,
+          'Jest 19 introduced versioned snapshots to ensure all developers ' +
+          'on a project are using the same version of Jest. ' +
+          'Please update all snapshots during this upgrade of Jest.\n\n',
       ) + SNAPSHOT_VERSION_WARNING,
     );
   }
@@ -48,10 +48,10 @@ const validateSnapshotVersion = (snapshotContents: string) => {
     return new Error(
       chalk.red(
         `${chalk.red.bold('Outdated snapshot')}: The version of the snapshot ` +
-          `file associated with this test is outdated. The snapshot file ` +
-          `version ensures that all developers on a project are using ` +
-          `the same version of Jest. ` +
-          `Please update all snapshots during this upgrade of Jest.\n\n`,
+          'file associated with this test is outdated. The snapshot file ' +
+          'version ensures that all developers on a project are using ' +
+          'the same version of Jest. ' +
+          'Please update all snapshots during this upgrade of Jest.\n\n',
       ) +
         `Expected: v${SNAPSHOT_VERSION}\n` +
         `Received: v${version}\n\n` +
@@ -63,10 +63,10 @@ const validateSnapshotVersion = (snapshotContents: string) => {
     return new Error(
       chalk.red(
         `${chalk.red.bold('Outdated Jest version')}: The version of this ` +
-          `snapshot file indicates that this project is meant to be used ` +
-          `with a newer version of Jest. The snapshot file version ensures ` +
-          `that all developers on a project are using the same version of ` +
-          `Jest. Please update your version of Jest and re-run the tests.\n\n`,
+          'snapshot file indicates that this project is meant to be used ' +
+          'with a newer version of Jest. The snapshot file version ensures ' +
+          'that all developers on a project are using the same version of ' +
+          'Jest. Please update your version of Jest and re-run the tests.\n\n',
       ) +
         `Expected: v${SNAPSHOT_VERSION}\n` +
         `Received: v${version}`,

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -53,7 +53,7 @@ jest
 jest.mock(
   'test_preprocessor',
   () => {
-    const escapeStrings = (str: string) => str.replace(/'/, `'`);
+    const escapeStrings = (str: string) => str.replace(/'/, "'");
 
     const transformer: Transformer = {
       getCacheKey: jest.fn(() => 'ab'),
@@ -74,7 +74,7 @@ jest.mock(
 jest.mock(
   'test_async_preprocessor',
   () => {
-    const escapeStrings = (str: string) => str.replace(/'/, `'`);
+    const escapeStrings = (str: string) => str.replace(/'/, "'");
 
     const transformer: Transformer = {
       getCacheKeyAsync: jest.fn().mockResolvedValue('ab'),

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -19,7 +19,7 @@ export const makeInvalidReturnValueError = (): string =>
   chalk.red(
     [
       chalk.bold(BULLET + 'Invalid return value:'),
-      `  Code transformer's \`process\` function must return a string or an object`,
+      "  Code transformer's `process` function must return a string or an object",
       '  with `code` key containing a string. If `processAsync` function is implemented,',
       '  it must return a Promise resolving to one of these values.',
       '',

--- a/packages/jest-validate/src/__tests__/validate.test.ts
+++ b/packages/jest-validate/src/__tests__/validate.test.ts
@@ -51,7 +51,7 @@ test.each([
   ).toThrowErrorMatchingSnapshot();
 });
 
-test(`pretty prints valid config for Function`, () => {
+test('pretty prints valid config for Function', () => {
   const config = {fn: 'test'};
   const validConfig = {fn: (_config, _option, _deprecatedOptions) => true};
   expect(() =>

--- a/packages/jest-validate/src/validate.ts
+++ b/packages/jest-validate/src/validate.ts
@@ -57,7 +57,7 @@ const _validate = (
           throw new ValidationError(
             'Validation Error',
             `${key} has to be of type string or number`,
-            `maxWorkers=50% or\nmaxWorkers=3`,
+            'maxWorkers=50% or\nmaxWorkers=3',
           );
         }
       }

--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -27,7 +27,7 @@ const createCLIValidationError = (
   let message;
   const comment =
     `  ${chalk.bold('CLI Options Documentation')}:\n` +
-    `  https://jestjs.io/docs/cli\n`;
+    '  https://jestjs.io/docs/cli\n';
 
   if (unrecognizedOptions.length === 1) {
     const unrecognized = unrecognizedOptions[0];
@@ -41,7 +41,7 @@ const createCLIValidationError = (
   } else {
     title += 's';
     message =
-      `  Following options were not recognized:\n` +
+      '  Following options were not recognized:\n' +
       `  ${chalk.bold(format(unrecognizedOptions))}`;
   }
 

--- a/packages/jest-validate/src/warnings.ts
+++ b/packages/jest-validate/src/warnings.ts
@@ -30,7 +30,7 @@ export const unknownOptionWarning = (
       `"${path && path.length > 0 ? path.join('.') + '.' : ''}${option}"`,
     )} with value ${chalk.bold(format(config[option]))} was found.` +
     (didYouMean && ` ${didYouMean}`) +
-    `\n  This is probably a typing mistake. Fixing it will remove this message.`;
+    '\n  This is probably a typing mistake. Fixing it will remove this message.';
 
   const comment = options.comment;
   const name = (options.title && options.title.warning) || WARNING;

--- a/packages/jest-watcher/src/PatternPrompt.ts
+++ b/packages/jest-watcher/src/PatternPrompt.ts
@@ -18,7 +18,7 @@ const usage = (entity: string) =>
   ` ${chalk.dim('\u203A Press')} Esc ${chalk.dim('to exit pattern mode.')}\n` +
   ` ${chalk.dim('\u203A Press')} Enter ` +
   `${chalk.dim(`to filter by a ${entity} regex pattern.`)}\n` +
-  `\n`;
+  '\n';
 
 const usageRows = usage('').split('\n').length;
 

--- a/packages/jest-worker/src/__tests__/leak-integration.test.ts
+++ b/packages/jest-worker/src/__tests__/leak-integration.test.ts
@@ -14,7 +14,7 @@ import {Worker} from '../..';
 let workerFile!: string;
 beforeAll(() => {
   workerFile = join(tmpdir(), 'baz.js');
-  writeFileSync(workerFile, `module.exports.fn = () => {};`);
+  writeFileSync(workerFile, 'module.exports.fn = () => {};');
 });
 
 let worker!: Worker;

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -57,12 +57,12 @@ beforeEach(() => {
   });
 });
 
-test(`anything()`, () => {
+test('anything()', () => {
   const result = prettyFormat(expect.anything(), options);
   expect(result).toEqual('Anything');
 });
 
-test(`arrayContaining()`, () => {
+test('arrayContaining()', () => {
   const result = prettyFormat(expect.arrayContaining([1, 2]), options);
   expect(result).toEqual(`ArrayContaining [
   1,
@@ -70,7 +70,7 @@ test(`arrayContaining()`, () => {
 ]`);
 });
 
-test(`arrayNotContaining()`, () => {
+test('arrayNotContaining()', () => {
   const result = prettyFormat(expect.not.arrayContaining([1, 2]), options);
   expect(result).toEqual(`ArrayNotContaining [
   1,
@@ -78,14 +78,14 @@ test(`arrayNotContaining()`, () => {
 ]`);
 });
 
-test(`objectContaining()`, () => {
+test('objectContaining()', () => {
   const result = prettyFormat(expect.objectContaining({a: 'test'}), options);
   expect(result).toEqual(`ObjectContaining {
   "a": "test",
 }`);
 });
 
-test(`objectNotContaining()`, () => {
+test('objectNotContaining()', () => {
   const result = prettyFormat(
     expect.not.objectContaining({a: 'test'}),
     options,
@@ -95,43 +95,43 @@ test(`objectNotContaining()`, () => {
 }`);
 });
 
-test(`stringContaining(string)`, () => {
+test('stringContaining(string)', () => {
   const result = prettyFormat(expect.stringContaining('jest'), options);
-  expect(result).toEqual(`StringContaining "jest"`);
+  expect(result).toEqual('StringContaining "jest"');
 });
 
-test(`not.stringContaining(string)`, () => {
+test('not.stringContaining(string)', () => {
   const result = prettyFormat(expect.not.stringContaining('jest'), options);
-  expect(result).toEqual(`StringNotContaining "jest"`);
+  expect(result).toEqual('StringNotContaining "jest"');
 });
 
-test(`stringMatching(string)`, () => {
+test('stringMatching(string)', () => {
   const result = prettyFormat(expect.stringMatching('jest'), options);
   expect(result).toEqual('StringMatching /jest/');
 });
 
-test(`stringMatching(regexp)`, () => {
+test('stringMatching(regexp)', () => {
   const result = prettyFormat(expect.stringMatching(/(jest|niema).*/), options);
   expect(result).toEqual('StringMatching /(jest|niema).*/');
 });
 
-test(`stringMatching(regexp) {escapeRegex: false}`, () => {
+test('stringMatching(regexp) {escapeRegex: false}', () => {
   const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
   expect(result).toEqual('StringMatching /regexp\\d/gi');
 });
 
-test(`stringMatching(regexp) {escapeRegex: true}`, () => {
+test('stringMatching(regexp) {escapeRegex: true}', () => {
   options.escapeRegex = true;
   const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
   expect(result).toEqual('StringMatching /regexp\\\\d/gi');
 });
 
-test(`stringNotMatching(string)`, () => {
+test('stringNotMatching(string)', () => {
   const result = prettyFormat(expect.not.stringMatching('jest'), options);
   expect(result).toEqual('StringNotMatching /jest/');
 });
 
-test(`supports multiple nested asymmetric matchers`, () => {
+test('supports multiple nested asymmetric matchers', () => {
   const result = prettyFormat(
     {
       test: {
@@ -165,7 +165,7 @@ test(`supports multiple nested asymmetric matchers`, () => {
 }`);
 });
 
-describe(`indent option`, () => {
+describe('indent option', () => {
   const val = {
     nested: expect.objectContaining({
       a: expect.arrayContaining([1]),
@@ -198,16 +198,16 @@ describe(`indent option`, () => {
   },
 }`;
 
-  test(`default implicit: 2 spaces`, () => {
+  test('default implicit: 2 spaces', () => {
     expect(prettyFormat(val, options)).toEqual(result);
   });
-  test(`default explicit: 2 spaces`, () => {
+  test('default explicit: 2 spaces', () => {
     options.indent = 2;
     expect(prettyFormat(val, options)).toEqual(result);
   });
 
   // Tests assume that no strings in val contain multiple adjacent spaces!
-  test(`non-default: 0 spaces`, () => {
+  test('non-default: 0 spaces', () => {
     options.indent = 0;
     expect(prettyFormat(val, options)).toEqual(result.replace(/ {2}/g, ''));
   });
@@ -219,8 +219,8 @@ describe(`indent option`, () => {
   });
 });
 
-describe(`maxDepth option`, () => {
-  test(`matchers as leaf nodes`, () => {
+describe('maxDepth option', () => {
+  test('matchers as leaf nodes', () => {
     options.maxDepth = 2;
     const val = {
       // ++depth === 1
@@ -253,7 +253,7 @@ describe(`maxDepth option`, () => {
   ],
 }`);
   });
-  test(`matchers as internal nodes`, () => {
+  test('matchers as internal nodes', () => {
     options.maxDepth = 2;
     const val = [
       // ++depth === 1
@@ -290,7 +290,7 @@ describe(`maxDepth option`, () => {
   });
 });
 
-test(`min option`, () => {
+test('min option', () => {
   options.min = true;
   const result = prettyFormat(
     {
@@ -308,6 +308,6 @@ test(`min option`, () => {
     options,
   );
   expect(result).toEqual(
-    `{"test": {"nested": ObjectContaining {"a": ArrayContaining [1], "b": Anything, "c": Any<String>, "d": StringContaining "jest", "e": StringMatching /jest/, "f": ObjectContaining {"test": "case"}}}}`,
+    '{"test": {"nested": ObjectContaining {"a": ArrayContaining [1], "b": Anything, "c": Any<String>, "d": StringContaining "jest", "e": StringMatching /jest/, "f": ObjectContaining {"test": "case"}}}}',
   );
 });

--- a/packages/pretty-format/src/__tests__/setPrettyPrint.ts
+++ b/packages/pretty-format/src/__tests__/setPrettyPrint.ts
@@ -30,9 +30,9 @@ const setPrettyPrint = (plugins: Plugins) => {
         ? () =>
             this.utils.matcherHint('.not.toBe') +
             '\n\n' +
-            `Expected value to not be:\n` +
+            'Expected value to not be:\n' +
             `  ${this.utils.printExpected(expected)}\n` +
-            `Received:\n` +
+            'Received:\n' +
             `  ${this.utils.printReceived(prettyFormatted)}`
         : () => {
             const diffString = this.utils.diff(expected, prettyFormatted, {
@@ -41,9 +41,9 @@ const setPrettyPrint = (plugins: Plugins) => {
             return (
               this.utils.matcherHint('.toBe') +
               '\n\n' +
-              `Expected value to be:\n` +
+              'Expected value to be:\n' +
               `  ${this.utils.printExpected(expected)}\n` +
-              `Received:\n` +
+              'Received:\n' +
               `  ${this.utils.printReceived(prettyFormatted)}` +
               (diffString ? `\n\nDifference:\n\n${diffString}` : '')
             );

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -426,7 +426,7 @@ function validateOptions(options: OptionsReceived) {
 
   if (options.theme !== undefined) {
     if (options.theme === null) {
-      throw new Error(`pretty-format: Option "theme" must not be null.`);
+      throw new Error('pretty-format: Option "theme" must not be null.');
     }
 
     if (typeof options.theme !== 'object') {

--- a/packages/pretty-format/src/plugins/DOMElement.ts
+++ b/packages/pretty-format/src/plugins/DOMElement.ts
@@ -80,7 +80,7 @@ export const serialize: NewPlugin['serialize'] = (
   }
 
   const type = nodeIsFragment(node)
-    ? `DocumentFragment`
+    ? 'DocumentFragment'
     : node.tagName.toLowerCase();
 
   if (++depth > config.maxDepth) {

--- a/scripts/verifyPnP.js
+++ b/scripts/verifyPnP.js
@@ -33,7 +33,7 @@ try {
     JSON.stringify(
       {
         dependencies: {
-          jest: `*`,
+          jest: '*',
         },
         name: 'test-pnp',
         resolutions: {
@@ -62,7 +62,7 @@ try {
   });
   execa.sync('yarn', ['jest'], {cwd, stdio: 'inherit'});
 
-  console.log(chalk.inverse.green(` Successfully ran Jest with PnP linker `));
+  console.log(chalk.inverse.green(' Successfully ran Jest with PnP linker '));
 } finally {
   rimraf.sync(cwd);
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -75,7 +75,7 @@ module.exports = {
           {
             tagName: 'link',
             rel: 'manifest',
-            href: `manifest.json`,
+            href: 'manifest.json',
           },
           {
             tagName: 'meta',

--- a/website/src/pages/versions.js
+++ b/website/src/pages/versions.js
@@ -33,7 +33,7 @@ export default function VersionsPage() {
                 <tr>
                   <th>{latestVersion}</th>
                   <td>
-                    <Link to={`/docs/getting-started`}>Documentation</Link>
+                    <Link to="/docs/getting-started">Documentation</Link>
                   </td>
                   <td>
                     <a href="https://github.com/facebook/jest/blob/main/CHANGELOG.md">
@@ -52,7 +52,7 @@ export default function VersionsPage() {
                 <tr>
                   <th>main</th>
                   <td>
-                    <Link to={`/docs/next/getting-started`}>Documentation</Link>
+                    <Link to="/docs/next/getting-started">Documentation</Link>
                   </td>
                   <td>
                     <a href="https://github.com/facebook/jest">Source Code</a>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

There's a bit of cognitive overhead when seeing a backtick \` in a string literal when there's no interpolation happening. This lint rule autofixes to `'` (or `"` if there is a `'` inside the string).

Note that we cannot use single quotes in snapshots, so any `md` file is excluded. Inline snapshots as well (only an issue if it's a single line. But snapshots on a single line shouldn't be snapshots)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
