### PR TITLE
Added rootDir to mergedBabelTransformOptions

### DIFF
--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -172,10 +172,11 @@ const createTransformer: CreateTransformer = userOptions => {
     filename: Config.Path,
     transformOptions: JestTransformOptions,
   ): TransformOptions {
-    const {cwd} = transformOptions.config;
+    const {cwd, rootDir} = transformOptions.config;
     // `cwd` first to allow incoming options to override it
     return {
       cwd,
+      root: rootDir,
       ...options,
       caller: {
         ...options.caller,


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I am currently working with a monorepo project where the root directory of the UI module is a subdirectory the project's root directory. Both my `jest.config.json` and `babelrc.json` files are in the UI module's root dir. The build tool we are using for our project forces us to run Jest from the project root, rather than the UI module's root. Jest uses the directory of the  `jest.config.json` file by default, but babel uses the current working directory.

In order to fix this, babel-jest must set the `root` option in the babel configuration to jest's `rootDir`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
