### PR TITLE
Doc- clarify the `describe.skip` behaviour

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -398,7 +398,7 @@ test('will not be ran', () => {
 
 Also under the alias: `xdescribe(name, fn)`
 
-You can use `describe.skip` if you do not want to run a particular describe block:
+You can use `describe.skip` if you do not want to run the tests of a particular described block:
 
 ```js
 describe('my beverage', () => {
@@ -416,7 +416,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests. Beware that the `describe` block will still be run. If you have some setup that should be skipped, do it in a `beforeAll` or `beforeEach` block.
 
 ### `describe.skip.each(table)(name, fn)`
 


### PR DESCRIPTION
@SimenB  in reference to #12164, you said you had some changes in mind, so i just pushed one change in the main doc,
lets discuss the changes and finally put the rest in other docs and complete the PR