### PR TITLE
refactor(jest-worker): general clean up – remove unnecessary code, improved types and readme

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,8 +113,6 @@ module.exports = {
         'packages/jest-snapshot/src/printSnapshot.ts',
         'packages/jest-snapshot/src/types.ts',
         'packages/jest-util/src/convertDescriptorToString.ts',
-        'packages/jest-worker/src/Farm.ts',
-        'packages/jest-worker/src/index.ts',
         'packages/pretty-format/src/index.ts',
         'packages/pretty-format/src/plugins/DOMCollection.ts',
       ],

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -11,7 +11,7 @@ The list of exposed methods can be explicitly provided via the `exposedMethods` 
 ## Install
 
 ```sh
-$ yarn add jest-worker
+yarn add jest-worker
 ```
 
 ## Example
@@ -20,11 +20,11 @@ This example covers the minimal usage:
 
 ### File `parent.js`
 
-```javascript
+```js
 import {Worker as JestWorker} from 'jest-worker';
 
 async function main() {
-  const worker = new JestWorker(require.resolve('./Worker'));
+  const worker = new JestWorker(require.resolve('./worker'));
   const result = await worker.hello('Alice'); // "Hello, Alice"
 }
 
@@ -33,7 +33,7 @@ main();
 
 ### File `worker.js`
 
-```javascript
+```js
 export function hello(param) {
   return 'Hello, ' + param;
 }
@@ -41,9 +41,9 @@ export function hello(param) {
 
 ## Experimental worker
 
-Node 10 shipped with [worker-threads](https://nodejs.org/api/worker_threads.html), a "threading API" that uses SharedArrayBuffers to communicate between the main process and its child threads. This experimental Node feature can significantly improve the communication time between parent and child processes in `jest-worker`.
+Node shipped with [`worker_threads`](https://nodejs.org/api/worker_threads.html), a "threading API" that uses `SharedArrayBuffers` to communicate between the main process and its child threads. This feature can significantly improve the communication time between parent and child processes in `jest-worker`.
 
-Since `worker_threads` are considered experimental in Node, you have to opt-in to this behavior by passing `enableWorkerThreads: true` when instantiating the worker. While the feature was unflagged in Node 11.7.0, you'll need to run the Node process with the `--experimental-worker` flag for Node 10.
+To use `worker_threads` instead of default `child_process` you have to pass `enableWorkerThreads: true` when instantiating the worker.
 
 ## API
 
@@ -55,23 +55,7 @@ Node module name or absolute path of the file to be loaded in the child processe
 
 ### `options: Object` (optional)
 
-#### `exposedMethods: $ReadOnlyArray<string>` (optional)
-
-List of method names that can be called on the child processes from the parent process. You cannot expose any method named like a public `Worker` method, or starting with `_`. If you use method auto-discovery, then these methods will not be exposed, even if they exist.
-
-#### `numWorkers: number` (optional)
-
-Amount of workers to spawn. Defaults to the number of CPUs minus 1.
-
-#### `maxRetries: number` (optional)
-
-Maximum amount of times that a dead child can be re-spawned, per call. Defaults to `3`, pass `Infinity` to allow endless retries.
-
-#### `forkOptions: Object` (optional)
-
-Allow customizing all options passed to `childProcess.fork`. By default, some values are set (`cwd`, `env` and `execArgv`), but you can override them and customize the rest. For a list of valid values, check [the Node documentation](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options).
-
-#### `computeWorkerKey: (method: string, ...args: Array<any>) => ?string` (optional)
+#### `computeWorkerKey: (method: string, ...args: Array<unknown>) => string | null` (optional)
 
 Every time a method exposed via the API is called, `computeWorkerKey` is also called in order to bound the call to a worker. This is useful for workers that are able to cache the result or part of it. You bound calls to a worker by making `computeWorkerKey` return the same identifier for all different calls. If you do not want to bind the call to any worker, return `null`.
 
@@ -79,17 +63,44 @@ The callback you provide is called with the method name, plus all the rest of th
 
 By default, no process is bound to any worker.
 
-#### `setupArgs: Array<mixed>` (optional)
+#### `enableWorkerThreads: boolean` (optional)
+
+By default, `jest-worker` will use `child_process` threads to spawn new Node.js processes. If you prefer [`worker_threads`](https://nodejs.org/api/worker_threads.html) instead, pass `enableWorkerThreads: true`.
+
+#### `exposedMethods: ReadonlyArray<string>` (optional)
+
+List of method names that can be called on the child processes from the parent process. You cannot expose any method named like a public `Worker` method, or starting with `_`. If you use method auto-discovery, then these methods will not be exposed, even if they exist.
+
+#### `forkOptions: ForkOptions` (optional)
+
+Allow customizing all options passed to `child_process.fork`. By default, some values are set (`cwd`, `env` and `execArgv`), but you can override them and customize the rest. For a list of valid values, check [the Node documentation](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options).
+
+#### `maxRetries: number` (optional)
+
+Maximum amount of times that a dead child can be re-spawned, per call. Defaults to `3`, pass `Infinity` to allow endless retries.
+
+#### `numWorkers: number` (optional)
+
+Amount of workers to spawn. Defaults to the number of CPUs minus 1.
+
+#### `resourceLimits: ResourceLimits` (optional)
+
+The `resourceLimits` option which will be passed to `worker_threads` workers.
+
+#### `setupArgs: Array<unknown>` (optional)
 
 The arguments that will be passed to the `setup` method during initialization.
 
-#### `WorkerPool: (workerPath: string, options?: WorkerPoolOptions) => WorkerPoolInterface` (optional)
+### `taskQueue: TaskQueue` (optional)
 
-Provide a custom worker pool to be used for spawning child processes. By default, Jest will use a node thread pool if available and fall back to child process threads.
+The task queue defines in which order tasks (method calls) are processed by the workers. `jest-worker` ships with a `FifoQueue` and `PriorityQueue`:
 
-#### `enableWorkerThreads: boolean` (optional)
+- `FifoQueue` (default): Processes the method calls (tasks) in the call order.
+- `PriorityQueue`: Processes the method calls by a computed priority in natural ordering (lower priorities first). Tasks with the same priority are processed in any order (FIFO not guaranteed). The constructor accepts a single argument, the function that is passed the name of the called function and the arguments and returns a numerical value for the priority: `new require('jest-worker').PriorityQueue((method, filename) => filename.length)`.
 
-`jest-worker` will automatically detect if `worker_threads` are available, but will not use them unless passed `enableWorkerThreads: true`.
+#### `WorkerPool: new (workerPath: string, options?: WorkerPoolOptions) => WorkerPoolInterface` (optional)
+
+Provide a custom WorkerPool class to be used for spawning child processes.
 
 ### `workerSchedulingPolicy: 'round-robin' | 'in-order'` (optional)
 
@@ -99,13 +110,6 @@ Specifies the policy how tasks are assigned to workers if multiple workers are _
 - `in-order`: The task will be assigned to the first free worker starting with worker 1 and only assign the work to worker 2 if the worker 1 is busy.
 
 Tasks are always assigned to the first free worker as soon as tasks start to queue up. The scheduling policy does not define the task scheduling which is always first-in, first-out.
-
-### `taskQueue`: TaskQueue` (optional)
-
-The task queue defines in which order tasks (method calls) are processed by the workers. `jest-worker` ships with a `FifoQueue` and `PriorityQueue`:
-
-- `FifoQueue` (default): Processes the method calls (tasks) in the call order.
-- `PriorityQueue`: Processes the method calls by a computed priority in natural ordering (lower priorities first). Tasks with the same priority are processed in any order (FIFO not guaranteed). The constructor accepts a single argument, the function that is passed the name of the called function and the arguments and returns a numerical value for the priority: `new require('jest-worker').PriorityQueue((method, filename) => filename.length)`.
 
 ## JestWorker
 
@@ -135,7 +139,7 @@ Consider deliberately leaving this Promise floating (unhandled resolution). Afte
 
 ### Worker IDs
 
-Each worker has a unique id (index that starts with `1`), which is available inside the worker as `process.env.JEST_WORKER_ID`.
+Each worker has a unique id (index that starts with `'1'`), which is available inside the worker as `process.env.JEST_WORKER_ID`.
 
 ## Setting up and tearing down the child process
 
@@ -152,11 +156,11 @@ This example covers the standard usage:
 
 ### File `parent.js`
 
-```javascript
+```js
 import {Worker as JestWorker} from 'jest-worker';
 
 async function main() {
-  const myWorker = new JestWorker(require.resolve('./Worker'), {
+  const myWorker = new JestWorker(require.resolve('./worker'), {
     exposedMethods: ['foo', 'bar', 'getWorkerId'],
     numWorkers: 4,
   });
@@ -176,7 +180,7 @@ main();
 
 ### File `worker.js`
 
-```javascript
+```js
 export function foo(param) {
   return 'Hello from foo: ' + param;
 }
@@ -196,11 +200,11 @@ This example covers the usage with a `computeWorkerKey` method:
 
 ### File `parent.js`
 
-```javascript
+```js
 import {Worker as JestWorker} from 'jest-worker';
 
 async function main() {
-  const myWorker = new JestWorker(require.resolve('./Worker'), {
+  const myWorker = new JestWorker(require.resolve('./worker'), {
     computeWorkerKey: (method, filename) => filename,
   });
 
@@ -226,7 +230,7 @@ main();
 
 ### File `worker.js`
 
-```javascript
+```js
 import babel from '@babel/core';
 
 const cache = Object.create(null);

--- a/packages/jest-worker/src/FifoQueue.ts
+++ b/packages/jest-worker/src/FifoQueue.ts
@@ -54,8 +54,8 @@ export default class FifoQueue implements TaskQueue {
 
     // Process the top task from the shared queue if
     // - there's no task in the worker specific queue or
-    // - if the non-worker-specific task after which this worker specifif task
-    //   hasn been queued wasn't processed yet
+    // - if the non-worker-specific task after which this worker specific task
+    //   has been queued wasn't processed yet
     if (workerTop != null && sharedTaskIsProcessed) {
       return this._workerQueues[workerId]?.dequeue()?.task ?? null;
     }

--- a/packages/jest-worker/src/PriorityQueue.ts
+++ b/packages/jest-worker/src/PriorityQueue.ts
@@ -19,7 +19,7 @@ type QueueItem = {
 
 /**
  * Priority queue that processes tasks in natural ordering (lower priority first)
- * accoridng to the priority computed by the function passed in the constructor.
+ * according to the priority computed by the function passed in the constructor.
  *
  * FIFO ordering isn't guaranteed for tasks with the same priority.
  *

--- a/packages/jest-worker/src/WorkerPool.ts
+++ b/packages/jest-worker/src/WorkerPool.ts
@@ -16,15 +16,6 @@ import type {
   WorkerPoolInterface,
 } from './types';
 
-const canUseWorkerThreads = () => {
-  try {
-    require('worker_threads');
-    return true;
-  } catch {
-    return false;
-  }
-};
-
 class WorkerPool extends BaseWorkerPool implements WorkerPoolInterface {
   send(
     workerId: number,
@@ -38,7 +29,7 @@ class WorkerPool extends BaseWorkerPool implements WorkerPoolInterface {
 
   createWorker(workerOptions: WorkerOptions): WorkerInterface {
     let Worker;
-    if (this._options.enableWorkerThreads && canUseWorkerThreads()) {
+    if (this._options.enableWorkerThreads) {
       Worker = require('./workers/NodeThreadsWorker').default;
     } else {
       Worker = require('./workers/ChildProcessWorker').default;

--- a/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
+++ b/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
@@ -62,21 +62,6 @@ describe('BaseWorkerPool', () => {
     expect(pool.getWorkerById(3)).toBeDefined();
   });
 
-  it('creates and expoeses n workers', () => {
-    const pool = new MockWorkerPool('/tmp/baz.js', {
-      forkOptions: {execArgv: []},
-      maxRetries: 6,
-      numWorkers: 4,
-      setupArgs: [],
-    });
-
-    expect(pool.getWorkers()).toHaveLength(4);
-    expect(pool.getWorkerById(0)).toBeDefined();
-    expect(pool.getWorkerById(1)).toBeDefined();
-    expect(pool.getWorkerById(2)).toBeDefined();
-    expect(pool.getWorkerById(3)).toBeDefined();
-  });
-
   it('creates workers with the right options', () => {
     // eslint-disable-next-line no-new
     new MockWorkerPool('/tmp/baz.js', {

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable local/ban-types-eventually */
-
 import {cpus} from 'os';
 import Farm from './Farm';
 import WorkerPool from './WorkerPool';
@@ -18,9 +16,11 @@ import type {
   WorkerPoolInterface,
   WorkerPoolOptions,
 } from './types';
+
 export {default as PriorityQueue} from './PriorityQueue';
 export {default as FifoQueue} from './FifoQueue';
 export {default as messageParent} from './workers/messageParent';
+export type {PromiseWithCustomMessage, TaskQueue};
 
 function getExposedMethods(
   workerPath: string,
@@ -30,10 +30,9 @@ function getExposedMethods(
 
   // If no methods list is given, try getting it by auto-requiring the module.
   if (!exposedMethods) {
-    const module: Function | Record<string, unknown> = require(workerPath);
+    const module: Record<string, unknown> = require(workerPath);
 
     exposedMethods = Object.keys(module).filter(
-      // @ts-expect-error: no index
       name => typeof module[name] === 'function',
     );
 
@@ -90,7 +89,6 @@ export class Worker {
     };
 
     if (this._options.WorkerPool) {
-      // @ts-expect-error: constructor target any?
       this._workerPool = new this._options.WorkerPool(
         workerPath,
         workerPoolOptions,
@@ -132,7 +130,7 @@ export class Worker {
 
   private _callFunctionWithArgs(
     method: string,
-    ...args: Array<any>
+    ...args: Array<unknown>
   ): Promise<unknown> {
     if (this._ending) {
       throw new Error('Farm is ended, no more calls can be done to it');
@@ -158,5 +156,3 @@ export class Worker {
     return this._workerPool.end();
   }
 }
-
-export type {PromiseWithCustomMessage, TaskQueue};

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -89,7 +89,7 @@ export default class ChildProcessWorker implements WorkerInterface {
         ...process.env,
         JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
         ...forceColor,
-      } as NodeJS.ProcessEnv,
+      },
       // Suppress --debug / --inspect flags while preserving others (like --harmony).
       execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
       silent: true,

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -16,6 +16,7 @@ import {
   PARENT_MESSAGE_OK,
   PARENT_MESSAGE_SETUP_ERROR,
 } from '../types';
+import type {FunctionLike} from '../types';
 
 let file: string | null = null;
 let setupArgs: Array<unknown> = [];
@@ -113,7 +114,7 @@ function exitProcess(): void {
 function execMethod(method: string, args: Array<unknown>): void {
   const main = require(file!);
 
-  let fn: (...args: Array<unknown>) => unknown;
+  let fn: FunctionLike;
 
   if (method === 'default') {
     fn = main.__esModule ? main['default'] : main;
@@ -142,13 +143,13 @@ const isPromise = (obj: any): obj is PromiseLike<unknown> =>
   typeof obj.then === 'function';
 
 function execFunction(
-  fn: (...args: Array<unknown>) => unknown | Promise<unknown>,
+  fn: FunctionLike,
   ctx: unknown,
   args: Array<unknown>,
   onResult: (result: unknown) => void,
   onError: (error: Error) => void,
 ): void {
-  let result;
+  let result: unknown;
 
   try {
     result = fn.apply(ctx, args);

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -17,6 +17,7 @@ import {
   PARENT_MESSAGE_OK,
   PARENT_MESSAGE_SETUP_ERROR,
 } from '../types';
+import type {FunctionLike} from '../types';
 
 let file: string | null = null;
 let setupArgs: Array<unknown> = [];
@@ -115,7 +116,7 @@ function exitProcess(): void {
 function execMethod(method: string, args: Array<unknown>): void {
   const main = require(file!);
 
-  let fn: (...args: Array<unknown>) => unknown;
+  let fn: FunctionLike;
 
   if (method === 'default') {
     fn = main.__esModule ? main['default'] : main;
@@ -144,13 +145,13 @@ const isPromise = (obj: any): obj is PromiseLike<unknown> =>
   typeof obj.then === 'function';
 
 function execFunction(
-  fn: (...args: Array<unknown>) => unknown,
+  fn: FunctionLike,
   ctx: unknown,
   args: Array<unknown>,
   onResult: (result: unknown) => void,
   onError: (error: Error) => void,
 ): void {
-  let result;
+  let result: unknown;
 
   try {
     result = fn.apply(ctx, args);


### PR DESCRIPTION
## Summary

While working on #12274, I found a way to improve types and caught few typos in `jest-worker`. Perhaps it is better idea to split this into separate clean-up PR to make it easier to review.

This is also a chance to slightly rework the readme. I deleted notes on Node 10, added missing `resourceLimits` option and rearranged all options in alphabetic order for readability.

Seems like some tiny bit of Node 10 specific code can be removed now.

## Test plan

Green CI.
