### PR TITLE
refactor(jest-worker)!: allow only absolute `workerPath`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Features
 
-- `[jest-environment-jsdom]` [**BREAKING**] Add default `browser` condtion to `exportConditions` for `jsdom` environment ([#11924](https://github.com/facebook/jest/pull/11924))
+- `[jest-environment-jsdom]` [**BREAKING**] Add default `browser` condition to `exportConditions` for `jsdom` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[jest-environment-node]` [**BREAKING**] Add default `node` and `node-addon` conditions to `exportConditions` for `node` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[@jest/expect-utils]` New module exporting utils for `expect` ([#12323](https://github.com/facebook/jest/pull/12323))
+- `[jest-worker]` [**BREAKING**] Allow only absolute `workerPath` ([#12343](https://github.com/facebook/jest/pull/12343))
 
 ### Fixes
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -2,7 +2,7 @@
 
 Module for executing heavy tasks under forked processes in parallel, by providing a `Promise` based interface, minimum overhead, and bound workers.
 
-The module works by providing an absolute path of the module to be loaded in all forked processes. Files relative to a node module are also accepted. All methods are exposed on the parent process as promises, so they can be `await`'ed. Child (worker) methods can either be synchronous or asynchronous.
+The module works by providing an absolute path of the module to be loaded in all forked processes. All methods are exposed on the parent process as promises, so they can be `await`'ed. Child (worker) methods can either be synchronous or asynchronous.
 
 The module also implements support for bound workers. Binding a worker means that, based on certain parameters, the same task will always be executed by the same worker. The way bound workers work is by using the returned string of the `computeWorkerKey` method. If the string was used before for a task, the call will be queued to the related worker that processed the task earlier; if not, it will be executed by the first available worker, then sticked to the worker that executed it; so the next time it will be processed by the same worker. If you have no preference on the worker executing the task, but you have defined a `computeWorkerKey` method because you want _some_ of the tasks to be sticked, you can return `null` from it.
 

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -61,6 +61,13 @@ afterEach(() => {
   jest.resetModules();
 });
 
+it('makes a non-existing relative worker throw', () => {
+  expect(() => {
+    // eslint-disable-next-line no-new
+    new Farm('./relative/worker-module.js');
+  }).toThrow("'workerPath' must be absolute");
+});
+
 it('exposes the right API using default working', () => {
   const farm = new Farm('/tmp/baz.js', {
     exposedMethods: ['foo', 'bar'],

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as path from 'path';
 import mergeStream = require('merge-stream');
 import {
   CHILD_MESSAGE_END,
@@ -31,10 +30,6 @@ export default class BaseWorkerPool {
   constructor(workerPath: string, options: WorkerPoolOptions) {
     this._options = options;
     this._workers = new Array(options.numWorkers);
-
-    if (!path.isAbsolute(workerPath)) {
-      workerPath = require.resolve(workerPath);
-    }
 
     const stdout = mergeStream();
     const stderr = mergeStream();

--- a/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
+++ b/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
@@ -102,16 +102,6 @@ describe('BaseWorkerPool', () => {
     });
   });
 
-  it('makes a non-existing relative worker throw', () => {
-    expect(() => {
-      // eslint-disable-next-line no-new
-      new MockWorkerPool('./baz.js', {
-        exposedMethods: [],
-        numWorkers: 1,
-      });
-    }).toThrow();
-  });
-
   it('create multiple workers with unique worker ids', () => {
     // eslint-disable-next-line no-new
     new MockWorkerPool('/tmp/baz.js', {

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import {cpus} from 'os';
+import {isAbsolute} from 'path';
 import Farm from './Farm';
 import WorkerPool from './WorkerPool';
 import type {
@@ -78,6 +79,10 @@ export class Worker {
   constructor(workerPath: string, options?: FarmOptions) {
     this._options = {...options};
     this._ending = false;
+
+    if (!isAbsolute(workerPath)) {
+      throw new Error(`'workerPath' must be absolute, got '${workerPath}'`);
+    }
 
     const workerPoolOptions: WorkerPoolOptions = {
       enableWorkerThreads: this._options.enableWorkerThreads ?? false,


### PR DESCRIPTION
## Summary

`jest-worker` continued.

It might be good idea to accept only absolute `workerPath`.

Right now the `BaseWorkerPool` class if trying to resolve relative `workerPath` from [`node_modules/jest-worker/build/base/BaseWorkerPool.js`](https://github.com/facebook/jest/blob/5fdbf844710a7b47f79c20952a124be13a3fa33c/packages/jest-worker/src/base/BaseWorkerPool.ts#L35-L37). Seems like this might break if `jest-worker`'s build is bundled. Or I missed something?

More over the main `Worker` class is requiring the same `workerPath` to be able detect exposed methods: https://github.com/facebook/jest/blob/b89a1bbe3652a3f5a8969ce768f3b74298ca021d/packages/jest-worker/src/index.ts#L31-L33

Can the same relative path work in both of the classes, which live in different directories? Not sure. With absolute `workerPath` all is clear and simple.

## Test plan

Tests should pass.