### PR TITLE
Should `rejects` be followed by `to Throw`?

### DIFF
--- a/website/versioned_docs/version-27.5/ExpectAPI.md
+++ b/website/versioned_docs/version-27.5/ExpectAPI.md
@@ -655,7 +655,7 @@ For example, this code tests that the promise rejects with reason `'octopus'`:
 ```js
 test('rejects to octopus', () => {
   // make sure to add a return statement
-  return expect(Promise.reject(new Error('octopus'))).rejects.toThrow(
+  return expect(Promise.reject(new Error('octopus'))).rejects.toMatch(
     'octopus',
   );
 });
@@ -667,7 +667,7 @@ Alternatively, you can use `async/await` in combination with `.rejects`.
 
 ```js
 test('rejects to octopus', async () => {
-  await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
+  await expect(Promise.reject(new Error('octopus'))).rejects.toMatch('octopus');
 });
 ```
 


### PR DESCRIPTION
This documentation page says that `.rejects` may be used with `toThrow`. However, in my case this is failing with "Received function did not throw". Asynchronous testing documentation uses it with `.toBe` and `.toMatch`: https://jestjs.io/docs/asynchronous#resolves--rejects

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Update the `.rejects` documentation.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
...