### PR TITLE
fix(expect): expose `AsymmetricMatchers` and `RawMatcherFn` interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixes
 
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
+- `[expect]` Export `AsymmetricMatchers` interface ([#12363](https://github.com/facebook/jest/pull/12363))
 - `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
 - `[jest-phabricator]` [**BREAKING**] Convert to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Fixes
 
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
-- `[expect]` Export `AsymmetricMatchers` interface ([#12363](https://github.com/facebook/jest/pull/12363))
+- `[expect]` Expose `AsymmetricMatchers` and `RawMatcherFn` interfaces ([#12363](https://github.com/facebook/jest/pull/12363))
 - `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
 - `[jest-phabricator]` [**BREAKING**] Convert to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 

--- a/examples/expect-extend/__tests__/ranges.test.ts
+++ b/examples/expect-extend/__tests__/ranges.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {expect, test} from '@jest/globals';
+import '../toBeWithinRange';
+
+test('is within range', () => expect(100).toBeWithinRange(90, 110));
+
+test('is NOT within range', () => expect(101).not.toBeWithinRange(0, 100));
+
+test('asymmetric ranges', () => {
+  expect({apples: 6, bananas: 3}).toEqual({
+    apples: expect.toBeWithinRange(1, 10),
+    bananas: expect.not.toBeWithinRange(11, 20),
+  });
+});

--- a/examples/expect-extend/package.json
+++ b/examples/expect-extend/package.json
@@ -6,10 +6,10 @@
     "@babel/core": "*",
     "@babel/preset-env": "*",
     "@babel/preset-typescript": "*",
-    "@jest/globals": "*",
-    "babel-jest": "*",
-    "expect": "*",
-    "jest": "*"
+    "@jest/globals": "workspace:*",
+    "babel-jest": "workspace:*",
+    "expect": "workspace:*",
+    "jest": "workspace:*"
   },
   "scripts": {
     "test": "jest"

--- a/examples/expect-extend/package.json
+++ b/examples/expect-extend/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "version": "0.0.0",
+  "name": "example-expect-extend",
+  "devDependencies": {
+    "@babel/core": "*",
+    "@babel/preset-env": "*",
+    "@babel/preset-typescript": "*",
+    "@jest/globals": "*",
+    "babel-jest": "*",
+    "expect": "*",
+    "jest": "*"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "babel": {
+    "presets": [
+      [
+        "@babel/preset-env",
+        {
+          "targets": {
+            "node": "current"
+          }
+        }
+      ],
+      "@babel/preset-typescript"
+    ]
+  }
+}

--- a/examples/expect-extend/toBeWithinRange.ts
+++ b/examples/expect-extend/toBeWithinRange.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {expect} from '@jest/globals';
+import type {RawMatcherFn} from 'expect';
+
+const toBeWithinRange: RawMatcherFn = (
+  actual: number,
+  floor: number,
+  ceiling: number,
+) => {
+  const pass = actual >= floor && actual <= ceiling;
+  if (pass) {
+    return {
+      message: () =>
+        `expected ${actual} not to be within range ${floor} - ${ceiling}`,
+      pass: true,
+    };
+  } else {
+    return {
+      message: () =>
+        `expected ${actual} to be within range ${floor} - ${ceiling}`,
+      pass: false,
+    };
+  }
+};
+
+expect.extend({
+  toBeWithinRange,
+});
+
+declare module 'expect' {
+  interface AsymmetricMatchers {
+    toBeWithinRange(a: number, b: number): void;
+  }
+  interface Matchers<R> {
+    toBeWithinRange(a: number, b: number): R;
+  }
+}

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -5,12 +5,77 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectError} from 'tsd-lite';
-import type * as expect from 'expect';
+import {expectError, expectType} from 'tsd-lite';
+import type {EqualsFunction, Tester} from '@jest/expect-utils';
+import {type Matchers, expect} from 'expect';
+import type * as jestMatcherUtils from 'jest-matcher-utils';
 
-type M = expect.Matchers<void, unknown>;
-type N = expect.Matchers<void>;
+type M = Matchers<void, unknown>;
+type N = Matchers<void>;
 
 expectError(() => {
-  type E = expect.Matchers;
+  type E = Matchers;
 });
+
+// extend
+
+type MatcherUtils = typeof jestMatcherUtils & {
+  iterableEquality: Tester;
+  subsetEquality: Tester;
+};
+
+expectType<void>(
+  expect.extend({
+    toBeWithinRange(actual: number, floor: number, ceiling: number) {
+      expectType<number>(this.assertionCalls);
+      expectType<string | undefined>(this.currentTestName);
+      expectType<(() => void) | undefined>(this.dontThrow);
+      expectType<Error | undefined>(this.error);
+      expectType<EqualsFunction>(this.equals);
+      expectType<boolean | undefined>(this.expand);
+      expectType<number | null | undefined>(this.expectedAssertionsNumber);
+      expectType<Error | undefined>(this.expectedAssertionsNumberError);
+      expectType<boolean | undefined>(this.isExpectingAssertions);
+      expectType<Error | undefined>(this.isExpectingAssertionsError);
+      expectType<boolean>(this.isNot);
+      expectType<string>(this.promise);
+      expectType<Array<Error>>(this.suppressedErrors);
+      expectType<string | undefined>(this.testPath);
+      expectType<MatcherUtils>(this.utils);
+
+      const pass = actual >= floor && actual <= ceiling;
+      if (pass) {
+        return {
+          message: () =>
+            `expected ${actual} not to be within range ${floor} - ${ceiling}`,
+          pass: true,
+        };
+      } else {
+        return {
+          message: () =>
+            `expected ${actual} to be within range ${floor} - ${ceiling}`,
+          pass: false,
+        };
+      }
+    },
+  }),
+);
+
+declare module 'expect' {
+  interface AsymmetricMatchers {
+    toBeWithinRange(floor: number, ceiling: number): void;
+  }
+  interface Matchers<R> {
+    toBeWithinRange(floor: number, ceiling: number): void;
+  }
+}
+
+expectType<void>(expect(100).toBeWithinRange(90, 110));
+expectType<void>(expect(101).not.toBeWithinRange(0, 100));
+
+expectType<void>(
+  expect({apples: 6, bananas: 3}).toEqual({
+    apples: expect.toBeWithinRange(1, 10),
+    bananas: expect.not.toBeWithinRange(11, 20),
+  }),
+);

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -49,7 +49,13 @@ import type {
   ThrowingMatcherFn,
 } from './types';
 
-export type {AsymmetricMatchers, Expect, MatcherState, Matchers} from './types';
+export type {
+  AsymmetricMatchers,
+  Expect,
+  MatcherState,
+  Matchers,
+  RawMatcherFn,
+} from './types';
 
 export class JestAssertionError extends Error {
   matcherResult?: Omit<SyncExpectationResult, 'message'> & {message: string};

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -364,7 +364,7 @@ const makeThrowingMatcher = (
 
 expect.extend = <T extends MatcherState = MatcherState>(
   matchers: MatchersObject<T>,
-): void => setMatchers(matchers, false, expect);
+) => setMatchers(matchers, false, expect);
 
 expect.anything = anything;
 expect.any = any;

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -49,7 +49,7 @@ import type {
   ThrowingMatcherFn,
 } from './types';
 
-export type {Expect, MatcherState, Matchers} from './types';
+export type {AsymmetricMatchers, Expect, MatcherState, Matchers} from './types';
 
 export class JestAssertionError extends Error {
   matcherResult?: Omit<SyncExpectationResult, 'message'> & {message: string};

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -13,7 +13,7 @@ import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
 
 export type SyncExpectationResult = {
   pass: boolean;
-  message: () => string;
+  message(): string;
 };
 
 export type AsyncExpectationResult = Promise<SyncExpectationResult>;
@@ -21,7 +21,7 @@ export type AsyncExpectationResult = Promise<SyncExpectationResult>;
 export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
 export type RawMatcherFn<T extends MatcherState = MatcherState> = {
-  (this: T, received: any, expected: any, options?: any): ExpectationResult;
+  (this: T, actual: any, expected: any, options?: any): ExpectationResult;
   /** @internal */
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
@@ -32,7 +32,7 @@ export type PromiseMatcherFn = (actual: any) => Promise<void>;
 export type MatcherState = {
   assertionCalls: number;
   currentTestName?: string;
-  dontThrow?: () => void;
+  dontThrow?(): void;
   error?: Error;
   equals: EqualsFunction;
   expand?: boolean;
@@ -57,7 +57,7 @@ export interface AsymmetricMatcher {
   toAsymmetricMatcher?(): string;
 }
 export type MatchersObject<T extends MatcherState = MatcherState> = {
-  [id: string]: RawMatcherFn<T>;
+  [name: string]: RawMatcherFn<T>;
 };
 export type ExpectedAssertionsErrors = Array<{
   actual: string | number;
@@ -74,7 +74,7 @@ export type Expect<State extends MatcherState = MatcherState> = {
   assertions(numberOfAssertions: number): void;
   // TODO: remove this `T extends` - should get from some interface merging
   extend<T extends MatcherState = State>(matchers: MatchersObject<T>): void;
-  extractExpectedAssertionsErrors: () => ExpectedAssertionsErrors;
+  extractExpectedAssertionsErrors(): ExpectedAssertionsErrors;
   getState(): State;
   hasAssertions(): void;
   setState(state: Partial<State>): void;

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -22,6 +22,7 @@ export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
 export type RawMatcherFn<T extends MatcherState = MatcherState> = {
   (this: T, received: any, expected: any, options?: any): ExpectationResult;
+  /** @internal */
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build"
+    "outDir": "build",
+
+    "stripInternal": true
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -2,9 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build",
-
-    "stripInternal": true
+    "outDir": "build"
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],

--- a/packages/jest-jasmine2/src/jestExpect.ts
+++ b/packages/jest-jasmine2/src/jestExpect.ts
@@ -7,7 +7,7 @@
 
 /* eslint-disable local/prefer-spread-eventually */
 
-import {MatcherState, expect} from 'expect';
+import {type MatcherState, type RawMatcherFn, expect} from 'expect';
 import {
   addSerializer,
   toMatchInlineSnapshot,
@@ -15,7 +15,7 @@ import {
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
-import type {JasmineMatchersObject, RawMatcherFn} from './types';
+import type {JasmineMatchersObject} from './types';
 
 export default function jestExpect(config: {expand: boolean}): void {
   global.expect = expect;

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -7,7 +7,7 @@
 
 import type {AssertionError} from 'assert';
 import type {Config} from '@jest/types';
-import type {Expect} from 'expect';
+import type {Expect, RawMatcherFn} from 'expect';
 import type CallTracker from './jasmine/CallTracker';
 import type Env from './jasmine/Env';
 import type JsApiReporter from './jasmine/JsApiReporter';
@@ -24,25 +24,6 @@ export type SpecDefinitionsFn = () => void;
 export interface AssertionErrorWithStack extends AssertionError {
   stack: string;
 }
-
-// TODO Add expect types to @jest/types or leave it here
-// Borrowed from "expect"
-// -------START-------
-export type SyncExpectationResult = {
-  pass: boolean;
-  message: () => string;
-};
-
-export type AsyncExpectationResult = Promise<SyncExpectationResult>;
-
-export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
-
-export type RawMatcherFn = (
-  expected: unknown,
-  actual: unknown,
-  options?: unknown,
-) => ExpectationResult;
-// -------END-------
 
 export type RunDetails = {
   totalSpecsDefined?: number;

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -23,9 +23,3 @@ export type MatchSnapshotConfig = {
 };
 
 export type SnapshotData = Record<string, string>;
-
-// copied from `expect` - should be shared
-export type ExpectationResult = {
-  pass: boolean;
-  message: () => string;
-};

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -6,7 +6,9 @@
  */
 
 import {expectError, expectType} from 'tsd-lite';
+import type {EqualsFunction, Tester} from '@jest/expect-utils';
 import {expect} from '@jest/globals';
+import type * as jestMatcherUtils from 'jest-matcher-utils';
 
 // asymmetric matchers
 
@@ -349,27 +351,63 @@ expectError(expect(jest.fn()).toThrowErrorMatchingInlineSnapshot(true));
 
 // extend
 
+type MatcherUtils = typeof jestMatcherUtils & {
+  iterableEquality: Tester;
+  subsetEquality: Tester;
+};
+
 expectType<void>(
   expect.extend({
-    toBeDivisibleBy(actual: number, expected: number) {
+    toBeWithinRange(actual: number, floor: number, ceiling: number) {
+      expectType<number>(this.assertionCalls);
+      expectType<string | undefined>(this.currentTestName);
+      expectType<(() => void) | undefined>(this.dontThrow);
+      expectType<Error | undefined>(this.error);
+      expectType<EqualsFunction>(this.equals);
+      expectType<boolean | undefined>(this.expand);
+      expectType<number | null | undefined>(this.expectedAssertionsNumber);
+      expectType<Error | undefined>(this.expectedAssertionsNumberError);
+      expectType<boolean | undefined>(this.isExpectingAssertions);
+      expectType<Error | undefined>(this.isExpectingAssertionsError);
       expectType<boolean>(this.isNot);
+      expectType<string>(this.promise);
+      expectType<Array<Error>>(this.suppressedErrors);
+      expectType<string | undefined>(this.testPath);
+      expectType<MatcherUtils>(this.utils);
 
-      const pass = actual % expected === 0;
-      const message = pass
-        ? () =>
-            `expected ${this.utils.printReceived(
-              actual,
-            )} not to be divisible by ${expected}`
-        : () =>
-            `expected ${this.utils.printReceived(
-              actual,
-            )} to be divisible by ${expected}`;
-
-      return {message, pass};
+      const pass = actual >= floor && actual <= ceiling;
+      if (pass) {
+        return {
+          message: () =>
+            `expected ${actual} not to be within range ${floor} - ${ceiling}`,
+          pass: true,
+        };
+      } else {
+        return {
+          message: () =>
+            `expected ${actual} to be within range ${floor} - ${ceiling}`,
+          pass: false,
+        };
+      }
     },
   }),
 );
 
-// TODO
-// expect(4).toBeDivisibleBy(2);
-// expect.toBeDivisibleBy(2);
+declare module 'expect' {
+  interface AsymmetricMatchers {
+    toBeWithinRange(floor: number, ceiling: number): void;
+  }
+  interface Matchers<R> {
+    toBeWithinRange(floor: number, ceiling: number): R;
+  }
+}
+
+expectType<void>(expect(100).toBeWithinRange(90, 110));
+expectType<void>(expect(101).not.toBeWithinRange(0, 100));
+
+expectType<void>(
+  expect({apples: 6, bananas: 3}).toEqual({
+    apples: expect.toBeWithinRange(1, 10),
+    bananas: expect.not.toBeWithinRange(11, 20),
+  }),
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
     "composite": true,
+    "declaration": true,
     "emitDeclarationOnly": true,
-    "isolatedModules": true,
     "importsNotUsedAsValues": "error",
+    "stripInternal": true,
 
     "strict": true,
 
@@ -19,6 +19,7 @@
     "moduleResolution": "node",
     /* This needs to be false so our types are possible to consume without setting this */
     "esModuleInterop": false,
+    "isolatedModules": true,
     "skipLibCheck": false,
     "resolveJsonModule": true
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,18 +2584,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jest/environment@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/environment@npm:27.5.1"
-  dependencies:
-    "@jest/fake-timers": ^27.5.1
-    "@jest/types": ^27.5.1
-    "@types/node": "*"
-    jest-mock: ^27.5.1
-  checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
-  languageName: node
-  linkType: hard
-
 "@jest/expect-utils@^28.0.0-alpha.0, @jest/expect-utils@workspace:packages/expect-utils":
   version: 0.0.0-use.local
   resolution: "@jest/expect-utils@workspace:packages/expect-utils"
@@ -2619,20 +2607,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jest/fake-timers@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "@jest/fake-timers@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    "@sinonjs/fake-timers": ^8.0.1
-    "@types/node": "*"
-    jest-message-util: ^27.5.1
-    jest-mock: ^27.5.1
-    jest-util: ^27.5.1
-  checksum: 02a0561ed2f4586093facd4ae500b74694f187ac24d4a00e949a39a1c5325bca8932b4fcb0388a2c5ed0656506fc1cf51fd3e32cdd48cea7497ad9c6e028aba8
-  languageName: node
-  linkType: hard
-
 "@jest/globals@^28.0.0-alpha.0, @jest/globals@workspace:*, @jest/globals@workspace:packages/jest-globals":
   version: 0.0.0-use.local
   resolution: "@jest/globals@workspace:packages/jest-globals"
@@ -2642,17 +2616,6 @@ __metadata:
     expect: ^28.0.0-alpha.0
   languageName: unknown
   linkType: soft
-
-"@jest/globals@npm:*":
-  version: 27.5.1
-  resolution: "@jest/globals@npm:27.5.1"
-  dependencies:
-    "@jest/environment": ^27.5.1
-    "@jest/types": ^27.5.1
-    expect: ^27.5.1
-  checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
-  languageName: node
-  linkType: hard
 
 "@jest/monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -4409,15 +4372,6 @@ __metadata:
   dependencies:
     type-detect: 4.0.8
   checksum: 6159726db5ce6bf9f2297f8427f7ca5b3dff45b31e5cee23496f1fa6ef0bb4eab878b23fb2c5e6446381f6a66aba4968ef2fc255c1180d753d4b8c271636a2e5
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "@sinonjs/fake-timers@npm:8.1.0"
-  dependencies:
-    "@sinonjs/commons": ^1.7.0
-  checksum: 09b5a158ce013a6c37613258bad79ca4efeb99b1f59c41c73cca36cac00b258aefcf46eeea970fccf06b989414d86fe9f54c1102272c0c3bdd51a313cea80949
   languageName: node
   linkType: hard
 
@@ -8962,13 +8916,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "diff-sequences@npm:27.5.1"
-  checksum: a00db5554c9da7da225db2d2638d85f8e41124eccbd56cbaefb3b276dcbb1c1c2ad851c32defe2055a54a4806f030656cbf6638105fd6ce97bb87b90b32a33ca
-  languageName: node
-  linkType: hard
-
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -9956,10 +9903,10 @@ __metadata:
     "@babel/core": "*"
     "@babel/preset-env": "*"
     "@babel/preset-typescript": "*"
-    "@jest/globals": "*"
-    babel-jest: "*"
-    expect: "*"
-    jest: "*"
+    "@jest/globals": "workspace:*"
+    babel-jest: "workspace:*"
+    expect: "workspace:*"
+    jest: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -10172,7 +10119,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@^28.0.0-alpha.0, expect@workspace:packages/expect":
+"expect@^28.0.0-alpha.0, expect@workspace:*, expect@workspace:packages/expect":
   version: 0.0.0-use.local
   resolution: "expect@workspace:packages/expect"
   dependencies:
@@ -10189,18 +10136,6 @@ __metadata:
     tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft
-
-"expect@npm:*, expect@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "expect@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    jest-get-type: ^27.5.1
-    jest-matcher-utils: ^27.5.1
-    jest-message-util: ^27.5.1
-  checksum: b2c66beb52de53ef1872165aace40224e722bca3c2274c54cfa74b6d617d55cf0ccdbf36783ccd64dbea501b280098ed33fd0b207d4f15bc03cd3c7a24364a6a
-  languageName: node
-  linkType: hard
 
 "express@npm:^4.17.1":
   version: 4.17.2
@@ -13032,18 +12967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-diff@npm:27.5.1"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^27.5.1
-    jest-get-type: ^27.5.1
-    pretty-format: ^27.5.1
-  checksum: 8be27c1e1ee57b2bb2bef9c0b233c19621b4c43d53a3c26e2c00a4e805eb4ea11fe1694a06a9fb0e80ffdcfdc0d2b1cb0b85920b3f5c892327ecd1e7bd96b865
-  languageName: node
-  linkType: hard
-
 "jest-docblock@^28.0.0-alpha.0, jest-docblock@workspace:packages/jest-docblock":
   version: 0.0.0-use.local
   resolution: "jest-docblock@workspace:packages/jest-docblock"
@@ -13105,13 +13028,6 @@ __metadata:
   version: 26.3.0
   resolution: "jest-get-type@npm:26.3.0"
   checksum: 1cc6465ae4f5e880be22ba52fd270fa64c21994915f81b41f8f7553a7957dd8e077cc8d03035de9412e2d739f8bad6a032ebb5dab5805692a5fb9e20dd4ea666
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-get-type@npm:27.5.1"
-  checksum: 63064ab70195c21007d897c1157bf88ff94a790824a10f8c890392e7d17eda9c3900513cb291ca1c8d5722cad79169764e9a1279f7c8a9c4cd6e9109ff04bbc0
   languageName: node
   linkType: hard
 
@@ -13228,18 +13144,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"jest-matcher-utils@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-matcher-utils@npm:27.5.1"
-  dependencies:
-    chalk: ^4.0.0
-    jest-diff: ^27.5.1
-    jest-get-type: ^27.5.1
-    pretty-format: ^27.5.1
-  checksum: bb2135fc48889ff3fe73888f6cc7168ddab9de28b51b3148f820c89fdfd2effdcad005f18be67d0b9be80eda208ad47290f62f03d0a33f848db2dd0273c8217a
-  languageName: node
-  linkType: hard
-
 "jest-message-util@^28.0.0-alpha.0, jest-message-util@workspace:packages/jest-message-util":
   version: 0.0.0-use.local
   resolution: "jest-message-util@workspace:packages/jest-message-util"
@@ -13284,16 +13188,6 @@ __metadata:
     "@types/node": "*"
   languageName: unknown
   linkType: soft
-
-"jest-mock@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "jest-mock@npm:27.5.1"
-  dependencies:
-    "@jest/types": ^27.5.1
-    "@types/node": "*"
-  checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
-  languageName: node
-  linkType: hard
 
 "jest-phabricator@workspace:packages/jest-phabricator":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jest/environment@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "@jest/environment@npm:27.5.1"
+  dependencies:
+    "@jest/fake-timers": ^27.5.1
+    "@jest/types": ^27.5.1
+    "@types/node": "*"
+    jest-mock: ^27.5.1
+  checksum: 2a9e18c35a015508dbec5b90b21c150230fa6c1c8cb8fabe029d46ee2ca4c40eb832fb636157da14c66590d0a4c8a2c053226b041f54a44507d6f6a89abefd66
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@^28.0.0-alpha.0, @jest/expect-utils@workspace:packages/expect-utils":
   version: 0.0.0-use.local
   resolution: "@jest/expect-utils@workspace:packages/expect-utils"
@@ -2607,6 +2619,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jest/fake-timers@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "@jest/fake-timers@npm:27.5.1"
+  dependencies:
+    "@jest/types": ^27.5.1
+    "@sinonjs/fake-timers": ^8.0.1
+    "@types/node": "*"
+    jest-message-util: ^27.5.1
+    jest-mock: ^27.5.1
+    jest-util: ^27.5.1
+  checksum: 02a0561ed2f4586093facd4ae500b74694f187ac24d4a00e949a39a1c5325bca8932b4fcb0388a2c5ed0656506fc1cf51fd3e32cdd48cea7497ad9c6e028aba8
+  languageName: node
+  linkType: hard
+
 "@jest/globals@^28.0.0-alpha.0, @jest/globals@workspace:*, @jest/globals@workspace:packages/jest-globals":
   version: 0.0.0-use.local
   resolution: "@jest/globals@workspace:packages/jest-globals"
@@ -2616,6 +2642,17 @@ __metadata:
     expect: ^28.0.0-alpha.0
   languageName: unknown
   linkType: soft
+
+"@jest/globals@npm:*":
+  version: 27.5.1
+  resolution: "@jest/globals@npm:27.5.1"
+  dependencies:
+    "@jest/environment": ^27.5.1
+    "@jest/types": ^27.5.1
+    expect: ^27.5.1
+  checksum: 087f97047e9dcf555f76fe2ce54aee681e005eaa837a0c0c2d251df6b6412c892c9df54cb871b180342114389a5ff895a4e52e6e6d3d0015bf83c02a54f64c3c
+  languageName: node
+  linkType: hard
 
 "@jest/monorepo@workspace:.":
   version: 0.0.0-use.local
@@ -4372,6 +4409,15 @@ __metadata:
   dependencies:
     type-detect: 4.0.8
   checksum: 6159726db5ce6bf9f2297f8427f7ca5b3dff45b31e5cee23496f1fa6ef0bb4eab878b23fb2c5e6446381f6a66aba4968ef2fc255c1180d753d4b8c271636a2e5
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:^8.0.1":
+  version: 8.1.0
+  resolution: "@sinonjs/fake-timers@npm:8.1.0"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 09b5a158ce013a6c37613258bad79ca4efeb99b1f59c41c73cca36cac00b258aefcf46eeea970fccf06b989414d86fe9f54c1102272c0c3bdd51a313cea80949
   languageName: node
   linkType: hard
 
@@ -8916,6 +8962,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff-sequences@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "diff-sequences@npm:27.5.1"
+  checksum: a00db5554c9da7da225db2d2638d85f8e41124eccbd56cbaefb3b276dcbb1c1c2ad851c32defe2055a54a4806f030656cbf6638105fd6ce97bb87b90b32a33ca
+  languageName: node
+  linkType: hard
+
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -9896,6 +9949,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"example-expect-extend@workspace:examples/expect-extend":
+  version: 0.0.0-use.local
+  resolution: "example-expect-extend@workspace:examples/expect-extend"
+  dependencies:
+    "@babel/core": "*"
+    "@babel/preset-env": "*"
+    "@babel/preset-typescript": "*"
+    "@jest/globals": "*"
+    babel-jest: "*"
+    expect: "*"
+    jest: "*"
+  languageName: unknown
+  linkType: soft
+
 "example-getting-started@workspace:examples/getting-started":
   version: 0.0.0-use.local
   resolution: "example-getting-started@workspace:examples/getting-started"
@@ -10122,6 +10189,18 @@ __metadata:
     tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft
+
+"expect@npm:*, expect@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "expect@npm:27.5.1"
+  dependencies:
+    "@jest/types": ^27.5.1
+    jest-get-type: ^27.5.1
+    jest-matcher-utils: ^27.5.1
+    jest-message-util: ^27.5.1
+  checksum: b2c66beb52de53ef1872165aace40224e722bca3c2274c54cfa74b6d617d55cf0ccdbf36783ccd64dbea501b280098ed33fd0b207d4f15bc03cd3c7a24364a6a
+  languageName: node
+  linkType: hard
 
 "express@npm:^4.17.1":
   version: 4.17.2
@@ -12953,6 +13032,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-diff@npm:27.5.1"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^27.5.1
+    jest-get-type: ^27.5.1
+    pretty-format: ^27.5.1
+  checksum: 8be27c1e1ee57b2bb2bef9c0b233c19621b4c43d53a3c26e2c00a4e805eb4ea11fe1694a06a9fb0e80ffdcfdc0d2b1cb0b85920b3f5c892327ecd1e7bd96b865
+  languageName: node
+  linkType: hard
+
 "jest-docblock@^28.0.0-alpha.0, jest-docblock@workspace:packages/jest-docblock":
   version: 0.0.0-use.local
   resolution: "jest-docblock@workspace:packages/jest-docblock"
@@ -13014,6 +13105,13 @@ __metadata:
   version: 26.3.0
   resolution: "jest-get-type@npm:26.3.0"
   checksum: 1cc6465ae4f5e880be22ba52fd270fa64c21994915f81b41f8f7553a7957dd8e077cc8d03035de9412e2d739f8bad6a032ebb5dab5805692a5fb9e20dd4ea666
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-get-type@npm:27.5.1"
+  checksum: 63064ab70195c21007d897c1157bf88ff94a790824a10f8c890392e7d17eda9c3900513cb291ca1c8d5722cad79169764e9a1279f7c8a9c4cd6e9109ff04bbc0
   languageName: node
   linkType: hard
 
@@ -13130,6 +13228,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"jest-matcher-utils@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-matcher-utils@npm:27.5.1"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^27.5.1
+    jest-get-type: ^27.5.1
+    pretty-format: ^27.5.1
+  checksum: bb2135fc48889ff3fe73888f6cc7168ddab9de28b51b3148f820c89fdfd2effdcad005f18be67d0b9be80eda208ad47290f62f03d0a33f848db2dd0273c8217a
+  languageName: node
+  linkType: hard
+
 "jest-message-util@^28.0.0-alpha.0, jest-message-util@workspace:packages/jest-message-util":
   version: 0.0.0-use.local
   resolution: "jest-message-util@workspace:packages/jest-message-util"
@@ -13174,6 +13284,16 @@ __metadata:
     "@types/node": "*"
   languageName: unknown
   linkType: soft
+
+"jest-mock@npm:^27.5.1":
+  version: 27.5.1
+  resolution: "jest-mock@npm:27.5.1"
+  dependencies:
+    "@jest/types": ^27.5.1
+    "@types/node": "*"
+  checksum: f5b5904bb1741b4a1687a5f492535b7b1758dc26534c72a5423305f8711292e96a601dec966df81bb313269fb52d47227e29f9c2e08324d79529172f67311be0
+  languageName: node
+  linkType: hard
 
 "jest-phabricator@workspace:packages/jest-phabricator":
   version: 0.0.0-use.local


### PR DESCRIPTION
## Summary

Just wanted to check if now it is possible to extend interfaces of matchers for `expect.extend()`. Couple of details missing:

- `AsymmetricMatchers` interface is not yet public, but it should be. And then this is possible:

```ts
declare module 'expect' {
  interface AsymmetricMatchers {
    toBeWithinRange(floor: number, ceiling: number): void;
  }
  interface Matchers<R> {
    toBeWithinRange(floor: number, ceiling: number): void;
  }
}
```

- exposed `RawMatcherFn` is useful internally and provides type safety for this pattern:

```ts
import {expect} from '@jest/globals';
import type {RawMatcherFn} from 'expect';

const someCustomMatcher: RawMatcherFn = (x, y, z) => {
  return {
    message: () => '',
    pass: true,
  };
};

expect.extend({
  someCustomMatcher,
});
```

Nice! ~~Shall I add it to docs as well?~~

An example is added to `examples` folder. Regarding the docs update, I think it would be better idea to move `expect.extend()` to a separate guide chapter similar to "Code Transformation". The `expect.extend()` section is already too long inside `Expect` chapter. So perhaps I will make another PR with this change.

## Test plan

Type tests are added.
