### PR TITLE
fix: correctly resolve remapped directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[jest-environment-node]` [**BREAKING**] Add default `node` and `node-addon` conditions to `exportConditions` for `node` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[@jest/expect]` New module which extends `expect` with `jest-snapshot` matchers ([#12404](https://github.com/facebook/jest/pull/12404), [#12410](https://github.com/facebook/jest/pull/12410), [#12418](https://github.com/facebook/jest/pull/12418))
 - `[@jest/expect-utils]` New module exporting utils for `expect` ([#12323](https://github.com/facebook/jest/pull/12323))
-- `[jest-resolver]` [**BREAKING**] Add support for `package.json` `exports` ([11961](https://github.com/facebook/jest/pull/11961))
+- `[jest-resolve]` [**BREAKING**] Add support for `package.json` `exports` ([#11961](https://github.com/facebook/jest/pull/11961), [#12373](https://github.com/facebook/jest/pull/12373))
 - `[jest-resolve, jest-runtime]` Add support for `data:` URI import and mock ([#12392](https://github.com/facebook/jest/pull/12392))
 - `[@jest/schemas]` New module for JSON schemas for Jest's config ([#12384](https://github.com/facebook/jest/pull/12384))
 - `[jest-worker]` [**BREAKING**] Allow only absolute `workerPath` ([#12343](https://github.com/facebook/jest/pull/12343))

--- a/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
+++ b/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
@@ -13,10 +13,10 @@ describe('Runtime internal module registry', () => {
   it('behaves correctly when requiring a module that is used by jest internals', () => {
     const fs = require('fs');
 
-    // We require from this crazy path so that we can mimick Jest (and it's
-    // transitive deps) being installed along side a projects deps (e.g. with an
+    // We require from this crazy path so that we can mimick Jest (and its
+    // transitive deps) being installed alongside a projects deps (e.g. with an
     // NPM3 flat dep tree)
-    const jestUtil = require('../../../packages/jest-util');
+    const jestUtil = require('jest-util');
 
     // If FS is mocked correctly, this folder won't actually be created on the
     // filesystem

--- a/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
+++ b/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
@@ -16,7 +16,7 @@ describe('Runtime internal module registry', () => {
     // We require from this crazy path so that we can mimick Jest (and its
     // transitive deps) being installed alongside a projects deps (e.g. with an
     // NPM3 flat dep tree)
-    const jestUtil = require('jest-util');
+    const jestUtil = require('../../../packages/jest-util');
 
     // If FS is mocked correctly, this folder won't actually be created on the
     // filesystem

--- a/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
+++ b/e2e/runtime-internal-module-registry/__tests__/runtimeInternalModuleRegistry.test.js
@@ -16,7 +16,7 @@ describe('Runtime internal module registry', () => {
     // We require from this crazy path so that we can mimick Jest (and its
     // transitive deps) being installed alongside a projects deps (e.g. with an
     // NPM3 flat dep tree)
-    const jestUtil = require('../../../packages/jest-util');
+    const jestUtil = require('jest-util');
 
     // If FS is mocked correctly, this folder won't actually be created on the
     // filesystem

--- a/packages/jest-resolve/src/__mocks__/conditions/node_modules/exports/package.json
+++ b/packages/jest-resolve/src/__mocks__/conditions/node_modules/exports/package.json
@@ -11,6 +11,7 @@
     "./deeplyNested" : {
       "require": "./nestedRequire.js",
       "default": "./nestedDefault.js"
-    }
+    },
+    "./directory/*": "./some-other-directory/*"
   }
 }

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -234,6 +234,20 @@ describe('findNodeModule', () => {
         path.resolve(conditionsRoot, './node_modules/exports/nestedDefault.js'),
       );
     });
+
+    test('supports separate directory path', () => {
+      const result = Resolver.findNodeModule('exports/directory/file.js', {
+        basedir: conditionsRoot,
+        conditions: [],
+      });
+
+      expect(result).toEqual(
+        path.resolve(
+          conditionsRoot,
+          './node_modules/exports/some-other-directory/file.js',
+        ),
+      );
+    });
   });
 });
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -118,7 +118,7 @@ export default function defaultResolver(
     realpathSync,
   };
 
-  const pathToResolve = getPathInModule(path, options);
+  const pathToResolve = getPathInModule(path, resolveOptions);
 
   const result = resolveSync(pathToResolve, {
     ...resolveOptions,

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -120,10 +120,12 @@ export default function defaultResolver(
 
   const pathToResolve = getPathInModule(path, resolveOptions);
 
-  const result = resolveSync(pathToResolve, {
-    ...resolveOptions,
-    packageFilter: createPackageFilter(pathToResolve, options),
-  });
+  const result = isAbsolute(pathToResolve)
+    ? pathToResolve
+    : resolveSync(pathToResolve, {
+        ...resolveOptions,
+        packageFilter: createPackageFilter(pathToResolve, options),
+      });
 
   // Dereference symlinks to ensure we don't create a separate
   // module instance depending on how it was referenced.

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -120,12 +120,13 @@ export default function defaultResolver(
 
   const pathToResolve = getPathInModule(path, resolveOptions);
 
-  const result = isAbsolute(pathToResolve)
-    ? pathToResolve
-    : resolveSync(pathToResolve, {
-        ...resolveOptions,
-        packageFilter: createPackageFilter(pathToResolve, options),
-      });
+  const result =
+    pathToResolve === path
+      ? resolveSync(pathToResolve, {
+          ...resolveOptions,
+          packageFilter: createPackageFilter(pathToResolve, options),
+        })
+      : pathToResolve;
 
   // Dereference symlinks to ensure we don't create a separate
   // module instance depending on how it was referenced.

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -69,6 +69,7 @@ export default function defaultResolver(
   const pathToResolve = getPathInModule(path, resolveOptions);
 
   const result =
+    // if `getPathInModule` doesn't change the path, attempt to resolve it
     pathToResolve === path
       ? resolveSync(pathToResolve, resolveOptions)
       : pathToResolve;

--- a/packages/jest-worker/src/__tests__/leak-integration.test.ts
+++ b/packages/jest-worker/src/__tests__/leak-integration.test.ts
@@ -9,7 +9,7 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import {writeFileSync} from 'graceful-fs';
 import LeakDetector from 'jest-leak-detector';
-import {Worker} from '../..';
+import {Worker} from '../../build/index';
 
 let workerFile!: string;
 beforeAll(() => {
@@ -30,10 +30,10 @@ afterEach(async () => {
 
 it('does not retain arguments after a task finished', async () => {
   let leakDetector!: LeakDetector;
-  await new Promise(resolve => {
+  await new Promise((resolve, reject) => {
     const obj = {};
     leakDetector = new LeakDetector(obj);
-    (worker as any).fn(obj).then(resolve);
+    (worker as any).fn(obj).then(resolve, reject);
   });
 
   expect(await leakDetector.isLeaking()).toBe(false);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<details>
<summary>Old OP</summary>

For now, just a failing test.

The issue is that `resolve` tries to find a directory, and when there's a mapping, that doesn't exist. Not sure how, but `resolve` needs to find the closest package.json first, load it, pass it through filters, _then_ try to request from disk. Or something like it - we need to map the request before `resolve` checks if it's on disk. Currently neither `packageFilter` nor `pathFilter` is called before `resolves` throws `MODULE_NOT_FOUND`.

https://github.com/browserify/resolve/blob/8641b137f5fc1c4d40164c3aae7f4e492c332e42/lib/sync.js#L207-L220

/cc @ljharb any ideas on best approach here?

</details>

Rewrites the logic that respects `exports` to

1. check if it's a module that's being required (i.e. path does not start with `.` or is absolute)
2. load its `package.json` from root using `resolve` so `paths` etc is respected
3. if `exports` exist, resolve it and return the absolute path
4. if any of the above checks bail, proceed with a "normal" `resolve` lookup, like we had before #11919 and #11961

Fixes #12372

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI ~(eventually)~

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
