### PR TITLE
fix(jest-config): correctly detect CI environment and update snapshots accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[expect]` Expose `AsymmetricMatchers` and `RawMatcherFn` interfaces ([#12363](https://github.com/facebook/jest/pull/12363))
 - `[jest-environment-jsdom]` Make `jsdom` accessible to extending environments again ([#12232](https://github.com/facebook/jest/pull/12232))
+- `[jest-config]` Correctly detect CI environment and update snapshots accordingly ([#12378](https://github.com/facebook/jest/pull/12378))
 - `[jest-jasmine2, jest-types]` [**BREAKING**] Move all `jasmine` specific types from `@jest/types` to its own package ([#12125](https://github.com/facebook/jest/pull/12125))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-config]` [**BREAKING**] Stop shipping `jest-environment-jsdom` by default ([#12354](https://github.com/facebook/jest/pull/12354))
 - `[jest-config]` [**BREAKING**] Stop shipping `jest-jasmine2` by default ([#12355](https://github.com/facebook/jest/pull/12355))
+- `[jest-config, @jest/types]` Add `ci` to `GlobalConfig` ([#12378](https://github.com/facebook/jest/pull/12378))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade jsdom to 19.0.0 ([#12290](https://github.com/facebook/jest/pull/12290))
 - `[jest-environment-jsdom]` [**BREAKING**] Add default `browser` condition to `exportConditions` for `jsdom` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[jest-environment-node]` [**BREAKING**] Add default `node` and `node-addon` conditions to `exportConditions` for `node` environment ([#11924](https://github.com/facebook/jest/pull/11924))

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -85,6 +85,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
   "globalConfig": {
     "bail": 0,
     "changedFilesWithAncestor": false,
+    "ci": false,
     "collectCoverage": false,
     "collectCoverageFrom": [],
     "coverageDirectory": "<<REPLACED_ROOT_DIR>>/coverage",

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -85,7 +85,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
   "globalConfig": {
     "bail": 0,
     "changedFilesWithAncestor": false,
-    "ci": false,
+    "ci": true,
     "collectCoverage": false,
     "collectCoverageFrom": [],
     "coverageDirectory": "<<REPLACED_ROOT_DIR>>/coverage",
@@ -122,7 +122,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
     "testFailureExitCode": 1,
     "testPathPattern": "",
     "testSequencer": "<<REPLACED_JEST_PACKAGES_DIR>>/jest-test-sequencer/build/index.js",
-    "updateSnapshot": "all",
+    "updateSnapshot": "none",
     "useStderr": false,
     "watch": false,
     "watchAll": false,

--- a/e2e/__tests__/showConfig.test.ts
+++ b/e2e/__tests__/showConfig.test.ts
@@ -25,7 +25,7 @@ test('--showConfig outputs config info and exits', () => {
     '--showConfig',
     '--no-cache',
     // Make the snapshot flag stable on CI.
-    '--updateSnapshot',
+    '--ci',
   ]);
 
   stdout = stdout

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1899,18 +1899,19 @@ describe('updateSnapshot', () => {
     }
   });
   it('should be none if updateSnapshot is falsy and ci mode is true', async () => {
+    const defaultCiConfig = Defaults.ci;
     {
+      Defaults.ci = false;
       const {options} = await normalize({rootDir: '/root/'}, {
         ci: true,
       } as Config.Argv);
       expect(options.updateSnapshot).toBe('none');
     }
     {
-      const defaultCiConfig = Defaults.ci;
       Defaults.ci = true;
       const {options} = await normalize({rootDir: '/root/'}, {} as Config.Argv);
       expect(options.updateSnapshot).toBe('none');
-      Defaults.ci = defaultCiConfig;
     }
+    Defaults.ci = defaultCiConfig;
   });
 });

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1888,7 +1888,10 @@ describe('updateSnapshot', () => {
   });
   it('should be new if updateSnapshot is falsy', async () => {
     {
-      const {options} = await normalize({ci: false, rootDir: '/root/'}, {} as Config.Argv);
+      const {options} = await normalize(
+        {ci: false, rootDir: '/root/'},
+        {} as Config.Argv,
+      );
       expect(options.updateSnapshot).toBe('new');
     }
     {

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1888,11 +1888,11 @@ describe('updateSnapshot', () => {
   });
   it('should be new if updateSnapshot is falsy', async () => {
     {
-      const {options} = await normalize({rootDir: '/root/'}, {} as Config.Argv);
+      const {options} = await normalize({ci: false, rootDir: '/root/'}, {} as Config.Argv);
       expect(options.updateSnapshot).toBe('new');
     }
     {
-      const {options} = await normalize({rootDir: '/root/'}, {
+      const {options} = await normalize({ci: false, rootDir: '/root/'}, {
         updateSnapshot: false,
       } as Config.Argv);
       expect(options.updateSnapshot).toBe('new');

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1844,19 +1844,22 @@ describe('extensionsToTreatAsEsm', () => {
 describe('haste.enableSymlinks', () => {
   it('should throw if watchman is not disabled', async () => {
     await expect(
-      normalize({haste: {enableSymlinks: true}, rootDir: '/root/'}, {}),
+      normalize(
+        {haste: {enableSymlinks: true}, rootDir: '/root/'},
+        {} as Config.Argv,
+      ),
     ).rejects.toThrow('haste.enableSymlinks is incompatible with watchman');
 
     await expect(
       normalize(
         {haste: {enableSymlinks: true}, rootDir: '/root/', watchman: true},
-        {},
+        {} as Config.Argv,
       ),
     ).rejects.toThrow('haste.enableSymlinks is incompatible with watchman');
 
     const {options} = await normalize(
       {haste: {enableSymlinks: true}, rootDir: '/root/', watchman: false},
-      {},
+      {} as Config.Argv,
     );
 
     expect(options.haste.enableSymlinks).toBe(true);
@@ -1868,10 +1871,46 @@ describe('haste.forceNodeFilesystemAPI', () => {
   it('should pass option through', async () => {
     const {options} = await normalize(
       {haste: {forceNodeFilesystemAPI: true}, rootDir: '/root/'},
-      {},
+      {} as Config.Argv,
     );
 
     expect(options.haste.forceNodeFilesystemAPI).toBe(true);
     expect(console.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateSnapshot', () => {
+  it('should be all if updateSnapshot is true', async () => {
+    const {options} = await normalize({rootDir: '/root/'}, {
+      updateSnapshot: true,
+    } as Config.Argv);
+    expect(options.updateSnapshot).toBe('all');
+  });
+  it('should be new if updateSnapshot is falsy', async () => {
+    {
+      const {options} = await normalize({rootDir: '/root/'}, {} as Config.Argv);
+      expect(options.updateSnapshot).toBe('new');
+    }
+    {
+      const {options} = await normalize({rootDir: '/root/'}, {
+        updateSnapshot: false,
+      } as Config.Argv);
+      expect(options.updateSnapshot).toBe('new');
+    }
+  });
+  it('should be none if updateSnapshot is falsy and ci mode is true', async () => {
+    {
+      const {options} = await normalize({rootDir: '/root/'}, {
+        ci: true,
+      } as Config.Argv);
+      expect(options.updateSnapshot).toBe('none');
+    }
+    {
+      const defaultCiConfig = Defaults.ci;
+      Defaults.ci = true;
+      const {options} = await normalize({rootDir: '/root/'}, {} as Config.Argv);
+      expect(options.updateSnapshot).toBe('none');
+      Defaults.ci = defaultCiConfig;
+    }
   });
 });

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -117,6 +117,7 @@ const groupOptions = (
     bail: options.bail,
     changedFilesWithAncestor: options.changedFilesWithAncestor,
     changedSince: options.changedSince,
+    ci: options.ci,
     collectCoverage: options.collectCoverage,
     collectCoverageFrom: options.collectCoverageFrom,
     collectCoverageOnlyFrom: options.collectCoverageOnlyFrom,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -1132,7 +1132,7 @@ export default async function normalize(
   }
 
   newOptions.updateSnapshot =
-    argv.ci && !argv.updateSnapshot
+    (!!argv.ci || DEFAULT_CONFIG.ci) && !argv.updateSnapshot
       ? 'none'
       : argv.updateSnapshot
       ? 'all'

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -1131,8 +1131,12 @@ export default async function normalize(
     newOptions.moduleNameMapper = [];
   }
 
+  if (argv.ci != null) {
+    newOptions.ci = argv.ci;
+  }
+
   newOptions.updateSnapshot =
-    (!!argv.ci || DEFAULT_CONFIG.ci) && !argv.updateSnapshot
+    newOptions.ci && !argv.updateSnapshot
       ? 'none'
       : argv.updateSnapshot
       ? 'all'

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/logDebugMessages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/logDebugMessages.test.ts.snap
@@ -62,6 +62,7 @@ exports[`prints the config object 1`] = `
     "bail": 0,
     "changedFilesWithAncestor": false,
     "changedSince": "",
+    "ci": false,
     "collectCoverage": false,
     "collectCoverageFrom": [],
     "coverageDirectory": "coverage",

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -289,6 +289,7 @@ export type GlobalConfig = {
   bail: number;
   changedSince?: string;
   changedFilesWithAncestor: boolean;
+  ci: boolean;
   collectCoverage: boolean;
   collectCoverageFrom: Array<Glob>;
   collectCoverageOnlyFrom?: {

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -11,6 +11,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   bail: 0,
   changedFilesWithAncestor: false,
   changedSince: '',
+  ci: false,
   collectCoverage: false,
   collectCoverageFrom: [],
   collectCoverageOnlyFrom: undefined,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

Fixed #12288

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The cause of this problem is that the current implementation for determining `option.updateSnapshot` does not take into account `process.env.CI`. We can know the value of `process.env.CI` in `DEFAULT_CONFIG.ci`.


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
This PR added test cases for `option.updateSnapshot` and also fixed type issues by `as` assertions.
