### PR TITLE
docs: add ELI5 video to home page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -545,6 +545,37 @@ class Index extends React.Component {
           </Container>
           <Container
             padding={['bottom', 'top']}
+            className="section-container bottom-margin docs"
+          >
+            <div className="blockElement imageAlignSide gridBlock video-block">
+              <div className="blockContent ">
+                <div className="video">
+                  <iframe
+                    width="560"
+                    height="315"
+                    src="https://www.youtube.com/embed/SyHzgcFefBk"
+                    frameBorder="0"
+                    allow="autoplay; encrypted-media"
+                    allowFullScreen
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="blockElement red bottom-margin">
+              <div className="blockContent">
+                <MarkdownBlock>
+                  <Translate>
+                  The Meta Open Source team has put together a short overview of Jest, 
+                  where they explained the project in beginner's terms. 
+                  You can also find other content about [Meta Open Source projects](https://opensource.fb.com/) 
+                  on their [YouTube Channel](https://www.youtube.com/channel/UCCQY962PmHabTjaHv2wJzfQ).
+                  </Translate> 
+                </MarkdownBlock>
+              </div>
+            </div>
+          </Container>
+          <Container
+            padding={['bottom', 'top']}
             background="light"
             className="section-container community imageAlignSide twoByGridBlock"
           >

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -565,11 +565,13 @@ class Index extends React.Component {
               <div className="blockContent">
                 <MarkdownBlock>
                   <Translate>
-                  The Meta Open Source team has put together a short overview of Jest, 
-                  where they explained the project in beginner's terms. 
-                  You can also find other content about [Meta Open Source projects](https://opensource.fb.com/) 
-                  on their [YouTube Channel](https://www.youtube.com/channel/UCCQY962PmHabTjaHv2wJzfQ).
-                  </Translate> 
+                    The Meta Open Source team has put together a short overview
+                    of Jest, where they explained the project in beginner's
+                    terms. You can also find other content about [Meta Open
+                    Source projects](https://opensource.fb.com/) on their
+                    [YouTube
+                    Channel](https://www.youtube.com/channel/UCCQY962PmHabTjaHv2wJzfQ).
+                  </Translate>
                 </MarkdownBlock>
               </div>
             </div>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible. We started embedding these videos into project pages as you can see in [Hermes home page]( https://hermesengine.dev/ )or in Docusaurus home page](https://docusaurus.io/) 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
This is how the video appears on the home page:
![image](https://user-images.githubusercontent.com/77028195/153739632-8a0734a3-f0cb-49a5-bbdb-5cd160926c83.png)

