### PR TITLE
fix(jest-config): accept `snapshotFormat.compareKeys` option

### DIFF
--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {SnapshotFormat} from '@jest/schemas';
 import type {Config} from '@jest/types';
 import {replacePathSepForRegex} from 'jest-regex-util';
 import {multipleValidOptions} from 'jest-validate';
@@ -110,7 +111,10 @@ const initialOptions: Config.InitialOptions = {
   skipFilter: false,
   skipNodeResolution: false,
   slowTestThreshold: 5,
-  snapshotFormat: PRETTY_FORMAT_DEFAULTS,
+  snapshotFormat: {
+    ...PRETTY_FORMAT_DEFAULTS,
+    compareKeys: () => {},
+  } as SnapshotFormat,
   snapshotResolver: '<rootDir>/snapshotResolver.js',
   snapshotSerializers: ['my-serializer-module'],
   testEnvironment: 'jest-environment-node',

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -9,6 +9,7 @@
 import {createHash} from 'crypto';
 import path from 'path';
 import semver = require('semver');
+import type {SnapshotFormat} from '@jest/schemas';
 import type {Config} from '@jest/types';
 import {escapeStrForRegex} from 'jest-regex-util';
 import Defaults from '../Defaults';
@@ -1916,5 +1917,22 @@ describe('updateSnapshot', () => {
       expect(options.updateSnapshot).toBe('none');
     }
     Defaults.ci = defaultCiConfig;
+  });
+});
+
+describe('snapshotFormat', () => {
+  it('should accept custom `compareKeys`', async () => {
+    const compareKeys = () => 0;
+
+    const {options} = await normalize(
+      {
+        ci: false,
+        rootDir: '/root/',
+        snapshotFormat: {compareKeys} as SnapshotFormat,
+      },
+      {} as Config.Argv,
+    );
+
+    expect((options.snapshotFormat as any).compareKeys).toBe(compareKeys);
   });
 });


### PR DESCRIPTION
The [configuration docs](https://jestjs.io/docs/configuration#snapshotformat-object) states that:
> **snapshotFormat [object]**
> [...]
> Allows overriding specific snapshot formatting options documented in the [pretty-format readme](https://www.npmjs.com/package/pretty-format#usage-with-options). For example, this config would have the snapshot formatter not print a prefix for "Object" and "Array":

However, I've found out that it's not possible to configure `snapshotFormat.compareKeys` from within `jest.config.js` file.

The reason behind this is that you are outsourcing correct types for options to the `DEFAULT_OPTIONS` from the `pretty-format` that are declared here:
https://github.com/facebook/jest/blob/c8a84566be774a35a56c26a4595c553df5fc6fc1/packages/pretty-format/src/index.ts#L401
and this is used during validation. But the correct type for `snapshotFormat.compareKeys` doesn't match the `typeof DEFAULT_OPTIONS.compareKeys`.
