### PR TITLE
fix: deprecate `jest-serializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[jest-phabricator]` [**BREAKING**] Migrate to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 - `[jest-resolve]` [**BREAKING**] Make `requireResolveFunction` argument mandatory ([#12353](https://github.com/facebook/jest/pull/12353))
 - `[jest-runner]` [**BREAKING**] Remove some type exports from `@jest/test-result` ([#12353](https://github.com/facebook/jest/pull/12353))
+- `[jest-serializer]` [**BREAKING**] Deprecate package in favour of using `v8` APIs directly ([#12391](https://github.com/facebook/jest/pull/12391))
 - `[jest-snapshot]` [**BREAKING**] Migrate to ESM ([#12342](https://github.com/facebook/jest/pull/12342))
 - `[jest-transform]` Update `write-file-atomic` to v4 ([#12357](https://github.com/facebook/jest/pull/12357))
 - `[jest]` Use `index.ts` instead of `jest.ts` as main export ([#12329](https://github.com/facebook/jest/pull/12329))

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -24,7 +24,6 @@
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.2.9",
     "jest-regex-util": "^28.0.0-alpha.0",
-    "jest-serializer": "^28.0.0-alpha.0",
     "jest-util": "^28.0.0-alpha.0",
     "jest-worker": "^28.0.0-alpha.0",
     "micromatch": "^4.0.4",

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -12,10 +12,10 @@ import {createHash} from 'crypto';
 import {EventEmitter} from 'events';
 import {tmpdir} from 'os';
 import * as path from 'path';
-import type {Stats} from 'graceful-fs';
+import {deserialize, serialize} from 'v8';
+import {Stats, readFileSync, writeFileSync} from 'graceful-fs';
 import type {Config} from '@jest/types';
 import {escapePathForRegex} from 'jest-regex-util';
-import serializer from 'jest-serializer';
 import {Worker} from 'jest-worker';
 import HasteFS from './HasteFS';
 import HasteModuleMap from './ModuleMap';
@@ -402,7 +402,7 @@ export default class HasteMap extends EventEmitter {
     let hasteMap: InternalHasteMap;
 
     try {
-      hasteMap = serializer.readFileSync(this._cachePath) as any;
+      hasteMap = deserialize(readFileSync(this._cachePath));
     } catch {
       hasteMap = this._createEmptyMap();
     }
@@ -729,7 +729,7 @@ export default class HasteMap extends EventEmitter {
    * 4. serialize the new `HasteMap` in a cache file.
    */
   private _persist(hasteMap: InternalHasteMap) {
-    serializer.writeFileSync(this._cachePath, hasteMap);
+    writeFileSync(this._cachePath, serialize(hasteMap));
   }
 
   /**

--- a/packages/jest-haste-map/tsconfig.json
+++ b/packages/jest-haste-map/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["./**/__tests__/**/*"],
   "references": [
     {"path": "../jest-regex-util"},
-    {"path": "../jest-serializer"},
     {"path": "../jest-types"},
     {"path": "../jest-util"},
     {"path": "../jest-worker"},

--- a/packages/jest-serializer/README.md
+++ b/packages/jest-serializer/README.md
@@ -1,6 +1,8 @@
 # jest-serializer
 
-Module for serializing and deserializing object into memory and disk. By default, the `v8` implementations are used, but if not present, it defaults to `JSON` implementation. Both serializers have the advantage of being able to serialize `Map`, `Set`, `undefined`, `NaN`, etc, although the JSON one does it through a replacer/reviver.
+> DEPRECATED: Use `v8` APIs directly: https://nodejs.org/api/v8.html#serialization-api
+
+Module for serializing and deserializing object into memory and disk. The Node core `v8` implementations are used. This seriializer have the advantage of being able to serialize `Map`, `Set`, `undefined`, `NaN`, etc..
 
 ## Install
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13110,7 +13110,6 @@ __metadata:
     fsevents: ^2.3.2
     graceful-fs: ^4.2.9
     jest-regex-util: ^28.0.0-alpha.0
-    jest-serializer: ^28.0.0-alpha.0
     jest-util: ^28.0.0-alpha.0
     jest-worker: ^28.0.0-alpha.0
     micromatch: ^4.0.4
@@ -13430,16 +13429,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"jest-serializer@^28.0.0-alpha.0, jest-serializer@workspace:packages/jest-serializer":
-  version: 0.0.0-use.local
-  resolution: "jest-serializer@workspace:packages/jest-serializer"
-  dependencies:
-    "@types/graceful-fs": ^4.1.3
-    "@types/node": "*"
-    graceful-fs: ^4.2.9
-  languageName: unknown
-  linkType: soft
-
 "jest-serializer@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-serializer@npm:26.6.2"
@@ -13449,6 +13438,16 @@ __metadata:
   checksum: dbecfb0d01462fe486a0932cf1680cf6abb204c059db2a8f72c6c2a7c9842a82f6d256874112774cea700764ed8f38fc9e3db982456c138d87353e3390e746fe
   languageName: node
   linkType: hard
+
+"jest-serializer@workspace:packages/jest-serializer":
+  version: 0.0.0-use.local
+  resolution: "jest-serializer@workspace:packages/jest-serializer"
+  dependencies:
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    graceful-fs: ^4.2.9
+  languageName: unknown
+  linkType: soft
 
 "jest-silent-reporter@npm:^0.5.0":
   version: 0.5.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Since #8455 (https://github.com/facebook/jest/pull/8455/files#r314608524) this package has just been a thin facade over `v8` APIs, so it serves no real purpose.

I'll keep the source code until the Jest 28 stable release, at which point I'll deprecate that version (so people stuck on 27 or older do not see the warning. There's nothing _wrong_ with 27, it's just unneeded) and delete the source.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
