### PR TITLE
feat: ESM data uri import and mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-environment-node]` [**BREAKING**] Add default `node` and `node-addon` conditions to `exportConditions` for `node` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[@jest/expect-utils]` New module exporting utils for `expect` ([#12323](https://github.com/facebook/jest/pull/12323))
 - `[jest-resolver]` [**BREAKING**] Add support for `package.json` `exports` ([11961](https://github.com/facebook/jest/pull/11961))
+- `[jest-resolve, jest-runtime]` Add support for `data:` URI import and mock ([#12392](https://github.com/facebook/jest/pull/12392))
 - `[@jes/schemas]` New module for JSON schemas for Jest's config ([#12384](https://github.com/facebook/jest/pull/12384))
 - `[jest-worker]` [**BREAKING**] Allow only absolute `workerPath` ([#12343](https://github.com/facebook/jest/pull/12343))
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:568:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:572:17)
       at Object.require (index.js:10:1)"
 `;
 
@@ -70,6 +70,6 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:568:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:572:17)
       at Object.require (index.js:10:1)"
 `;

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`on node >=12.16.0 runs test with native ESM 1`] = `
 "Test Suites: 1 passed, 1 total
-Tests:       21 passed, 21 total
+Tests:       25 passed, 25 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /native-esm.test.js/i."

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`on node >=12.16.0 runs test with native ESM 1`] = `
 "Test Suites: 1 passed, 1 total
-Tests:       25 passed, 25 total
+Tests:       32 passed, 32 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /native-esm.test.js/i."

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -247,17 +247,17 @@ test('imports from "data:text/javascript" URI with invalid data fail', async () 
 test('imports from "data:application/wasm" URI not supported', async () => {
   await expect(
     async () => await import('data:application/wasm,96cafe00babe'),
-  ).rejects.toThrow('Unsupported MIME type');
+  ).rejects.toThrow('WASM is currently not supported');
 });
 
 test('supports imports from "data:application/json" URI', async () => {
-  const data = await import('data:application/json,{foo: "bar"}');
-  expect(data.default).toStrictEqual({foo: 'bar'});
+  const data = await import('data:application/json,{"foo": "bar"}');
+  expect(data.default).toEqual({foo: 'bar'});
 });
 
 test('supports static "data:" URI import', async () => {
   const module = await import('../staticDataImport.js');
-  expect(module.value()).toStrictEqual({bar: {obj: 456}, foo: '123'});
+  expect(module.value()).toEqual({bar: {obj: 456}, foo: '123'});
 });
 
 test('imports from "data:" URI is properly cached', async () => {

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -5,23 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {jest as jestObject} from '@jest/globals'
-import dns from 'dns'
+import dns from 'dns';
 // the point here is that it's the node core module
 // eslint-disable-next-line no-restricted-imports
-import {readFileSync} from 'fs'
-import {createRequire} from 'module'
-import prefixDns from 'node:dns'
-import {dirname, resolve} from 'path'
-import {fileURLToPath} from 'url'
-import staticImportedStatefulFromCjs from '../fromCjs.mjs'
-import {double} from '../index'
-import defaultFromCjs, {half, namedFunction} from '../namedExport.cjs'
-import {bag} from '../namespaceExport.js'
+import {readFileSync} from 'fs';
+import {createRequire} from 'module';
+import prefixDns from 'node:dns';
+import {dirname, resolve} from 'path';
+import {fileURLToPath} from 'url';
+import {jest as jestObject} from '@jest/globals';
+import staticImportedStatefulFromCjs from '../fromCjs.mjs';
+import {double} from '../index';
+import defaultFromCjs, {half, namedFunction} from '../namedExport.cjs';
+import {bag} from '../namespaceExport.js';
 /* eslint-disable import/no-duplicates */
-import staticImportedStateful from '../stateful.mjs'
-import staticImportedStatefulWithQuery from '../stateful.mjs?query=1'
-import staticImportedStatefulWithAnotherQuery from '../stateful.mjs?query=2'
+import staticImportedStateful from '../stateful.mjs';
+import staticImportedStatefulWithQuery from '../stateful.mjs?query=1';
+import staticImportedStatefulWithAnotherQuery from '../stateful.mjs?query=2';
 /* eslint-enable import/no-duplicates */
 
 test('should have correct import.meta', () => {
@@ -207,7 +207,7 @@ test('supports imports from "data:text/javascript;charset=utf-8" URI', async () 
 test('supports imports from "data:text/javascript;base64" URI', async () => {
   const code = 'export const something = "some value"';
   const importedBase64 = await import(
-    `data:text/javascript;base64,${btoa(code)}`
+    `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
   );
   expect(importedBase64.something).toBe('some value');
 });
@@ -221,7 +221,9 @@ test('imports from "data:" URI is properly cached', async () => {
   expect(data1.wrapper.value).toBe(123);
   data1.set(234);
   expect(data1.wrapper.value).toBe(234);
-  const data2 = await import(`data:text/javascript;base64,${btoa(code)}`);
+  const data2 = await import(
+    `data:text/javascript;base64,${Buffer.from(code).toString('base64')}`
+  );
   expect(data2.wrapper.value).toBe(123);
   const data3 = await import(
     `data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`
@@ -231,7 +233,9 @@ test('imports from "data:" URI is properly cached', async () => {
 
 test('can mock "data:" URI module', async () => {
   const code = 'export const something = "some value"';
-  const dataModule = `data:text/javascript;base64,${btoa(code)}`;
+  const dataModule = `data:text/javascript;base64,${Buffer.from(code).toString(
+    'base64',
+  )}`;
   jestObject.unstable_mockModule(dataModule, () => ({foo: 'bar'}), {
     virtual: true,
   });

--- a/e2e/native-esm/staticDataImport.js
+++ b/e2e/native-esm/staticDataImport.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import bar from 'data:application/json,{obj: 456}';
+import {foo} from 'data:text/javascript,export const foo = "123"';
+
+export function value() {
+  return {bar, foo};
+}

--- a/e2e/native-esm/staticDataImport.js
+++ b/e2e/native-esm/staticDataImport.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import bar from 'data:application/json,{obj: 456}';
+import bar from 'data:application/json,{"obj": 456}';
 import {foo} from 'data:text/javascript,export const foo = "123"';
 
 export function value() {

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -370,6 +370,9 @@ export default class Resolver {
     if (this.isCoreModule(moduleName)) {
       return moduleName;
     }
+    if (moduleName.startsWith('data:')) {
+      return moduleName;
+    }
     return this._isModuleResolved(from, moduleName)
       ? this.getModule(moduleName)
       : this._getVirtualMockPath(virtualMocks, from, moduleName, options);

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -554,6 +554,17 @@ export default class Runtime {
     }
 
     if (specifier.startsWith('data:')) {
+      if (
+        this._shouldMock(
+          referencingIdentifier,
+          specifier,
+          this._explicitShouldMockModule,
+          {conditions: this.esmConditions},
+        )
+      ) {
+        return this.importMock(referencingIdentifier, specifier, context);
+      }
+
       const fromCache = this._esmoduleRegistry.get(specifier);
 
       if (fromCache) {
@@ -573,6 +584,8 @@ export default class Runtime {
         code = atob(code);
       } else if (match[1] === 'charset=utf-8') {
         code = decodeURIComponent(code);
+      } else {
+        throw new Error('Invalid data URI encoding');
       }
 
       const module = new SourceTextModule(code, {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -581,7 +581,7 @@ export default class Runtime {
 
       const mime = match.groups.mime;
       if (mime === 'application/wasm') {
-        throw new Error('Unsupported MIME type');
+        throw new Error('WASM is currently not supported');
       }
 
       const encoding = match.groups.encoding;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -63,6 +63,8 @@ export type {Context} from './types';
 
 const esmIsAvailable = typeof SourceTextModule === 'function';
 
+const dataURIregex = /^data:(?<mime>text\/javascript|application\/json|application\/wasm)(?:;(?<encoding>charset=utf-8|base64))?,(?<code>.*)$/;
+
 interface JestGlobals extends Global.TestFrameworkGlobals {
   expect: typeof JestGlobals.expect;
 }
@@ -571,9 +573,7 @@ export default class Runtime {
         return fromCache;
       }
 
-      const match = specifier.match(
-        /^data:(?<mime>text\/javascript|application\/json|application\/wasm)(?:;(?<encoding>charset=utf-8|base64))?,(?<code>.*)$/,
-      );
+      const match = specifier.match(dataURIregex);
 
       if (!match || !match.groups) {
         throw new Error('Invalid data URI');

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -591,7 +591,7 @@ export default class Runtime {
       } else if (encoding === 'base64') {
         code = Buffer.from(code, 'base64').toString();
       } else {
-        throw new Error('Invalid data URI encoding');
+        throw new Error(`Invalid data URI encoding: ${encoding}`);
       }
 
       if (mime === 'application/json') {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -581,7 +581,7 @@ export default class Runtime {
 
       let code = match[2];
       if (match[1] === 'base64') {
-        code = atob(code);
+        code = Buffer.from(code, 'base64').toString();
       } else if (match[1] === 'charset=utf-8') {
         code = decodeURIComponent(code);
       } else {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -572,17 +572,18 @@ export default class Runtime {
       }
 
       const match = specifier.match(
-        /^data:text\/javascript;(charset=utf-8|base64),(.*)$/,
+        /^data:text\/javascript;(?<encoding>charset=utf-8|base64),(?<code>.*)$/,
       );
 
-      if (!match) {
+      if (!match || !match.groups) {
         throw new Error('Invalid data URI');
       }
 
-      let code = match[2];
-      if (match[1] === 'base64') {
+      const encoding = match.groups.encoding;
+      let code = match.groups.code;
+      if (encoding === 'base64') {
         code = Buffer.from(code, 'base64').toString();
-      } else if (match[1] === 'charset=utf-8') {
+      } else if (encoding === 'charset=utf-8') {
         code = decodeURIComponent(code);
       } else {
         throw new Error('Invalid data URI encoding');

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -63,7 +63,8 @@ export type {Context} from './types';
 
 const esmIsAvailable = typeof SourceTextModule === 'function';
 
-const dataURIregex = /^data:(?<mime>text\/javascript|application\/json|application\/wasm)(?:;(?<encoding>charset=utf-8|base64))?,(?<code>.*)$/;
+const dataURIregex =
+  /^data:(?<mime>text\/javascript|application\/json|application\/wasm)(?:;(?<encoding>charset=utf-8|base64))?,(?<code>.*)$/;
 
 interface JestGlobals extends Global.TestFrameworkGlobals {
   expect: typeof JestGlobals.expect;


### PR DESCRIPTION
## Summary

This change should close #12370 
Allows dynamic import (and mock) from `data:` URI as it works on node.js:
```js
const code = 'export const foo = 123'
const imported = await import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
// OR
const imported = await import(`data:text/javascript;base64,${btoa(code)}`)
// imported.foo === 123
```

## Test plan

Added e2e tests in native-esm.test.js to check:

- import when code is URI component encoded;
- import when code is Base64 encoded;
- further imports of the same data URI are cached;
- data URI can be mocked with `jest.unstable_mockModule()`.
