### PR TITLE
feat(babel-jest): export `createTransformer` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[babel-jest]` Export `createTransformer` function ([#12399](https://github.com/facebook/jest/pull/12399))
 - `[jest-config]` [**BREAKING**] Stop shipping `jest-environment-jsdom` by default ([#12354](https://github.com/facebook/jest/pull/12354))
 - `[jest-config]` [**BREAKING**] Stop shipping `jest-jasmine2` by default ([#12355](https://github.com/facebook/jest/pull/12355))
 - `[jest-config, @jest/types]` Add `ci` to `GlobalConfig` ([#12378](https://github.com/facebook/jest/pull/12378))

--- a/e2e/transform/babel-jest-manual/transformer.js
+++ b/e2e/transform/babel-jest-manual/transformer.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {createTransformer} = require('babel-jest').default;
+const {createTransformer} = require('babel-jest');
 
 module.exports = createTransformer({
   presets: ['@babel/preset-flow'],

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -149,7 +149,7 @@ async function loadBabelOptionsAsync(
   return addIstanbulInstrumentation(options, jestTransformOptions);
 }
 
-const createTransformer: CreateTransformer = userOptions => {
+export const createTransformer: CreateTransformer = userOptions => {
   const inputOptions = userOptions ?? {};
 
   const options = {
@@ -278,5 +278,3 @@ const transformer: SyncTransformer<TransformOptions> = {
 };
 
 export default transformer;
-
-export { createTransformer };

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -278,3 +278,5 @@ const transformer: SyncTransformer<TransformOptions> = {
 };
 
 export default transformer;
+
+export { createTransformer };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #11444 by adding a named export of `createTransformer` to the `babel-jest` package. This allows Jest users to do the following:

```ts
import { createTransformer } from 'babel-jest';

export default createTransformer({
  // ...
});
```