### PR TITLE
chore: use `this` in `expect.extend` example

### DIFF
--- a/examples/expect-extend/toBeWithinRange.ts
+++ b/examples/expect-extend/toBeWithinRange.ts
@@ -8,34 +8,39 @@
 import {expect} from '@jest/globals';
 import type {MatcherFunction} from 'expect';
 
-const toBeWithinRange: MatcherFunction<[floor: number, ceiling: number]> = (
-  actual: unknown,
-  floor: unknown,
-  ceiling: unknown,
-) => {
-  if (
-    typeof actual !== 'number' ||
-    typeof floor !== 'number' ||
-    typeof ceiling !== 'number'
-  ) {
-    throw new Error('These must be of type number!');
-  }
+const toBeWithinRange: MatcherFunction<[floor: number, ceiling: number]> =
+  function (actual: unknown, floor: unknown, ceiling: unknown) {
+    if (
+      typeof actual !== 'number' ||
+      typeof floor !== 'number' ||
+      typeof ceiling !== 'number'
+    ) {
+      throw new Error('These must be of type number!');
+    }
 
-  const pass = actual >= floor && actual <= ceiling;
-  if (pass) {
-    return {
-      message: () =>
-        `expected ${actual} not to be within range ${floor} - ${ceiling}`,
-      pass: true,
-    };
-  } else {
-    return {
-      message: () =>
-        `expected ${actual} to be within range ${floor} - ${ceiling}`,
-      pass: false,
-    };
-  }
-};
+    const pass = actual >= floor && actual <= ceiling;
+    if (pass) {
+      return {
+        message: () =>
+          `expected ${this.utils.printReceived(
+            actual,
+          )} not to be within range ${this.utils.printExpected(
+            `${floor} - ${ceiling}`,
+          )}`,
+        pass: true,
+      };
+    } else {
+      return {
+        message: () =>
+          `expected ${this.utils.printReceived(
+            actual,
+          )} to be within range ${this.utils.printExpected(
+            `${floor} - ${ceiling}`,
+          )}`,
+        pass: false,
+      };
+    }
+  };
 
 expect.extend({
   toBeWithinRange,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

@mrazauskas thoughts? `this` is inaccessible in arrow functions

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
