### PR TITLE
feat!: create new `@jest/expect` package

### DIFF
--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -16,8 +16,7 @@ import {
 } from 'expect';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 
-type M = Matchers<void, unknown>;
-type N = Matchers<void>;
+type M = Matchers<void>;
 
 expectError(() => {
   type E = Matchers;

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -62,22 +62,20 @@ export function hasProperty(obj: object | null, property: string): boolean {
   return hasProperty(getPrototype(obj), property);
 }
 
-export abstract class AsymmetricMatcher<
-  T,
-  State extends MatcherState = MatcherState,
-> implements AsymmetricMatcherInterface
+export abstract class AsymmetricMatcher<T>
+  implements AsymmetricMatcherInterface
 {
   $$typeof = Symbol.for('jest.asymmetricMatcher');
 
   constructor(protected sample: T, protected inverse = false) {}
 
-  protected getMatcherContext(): State {
+  protected getMatcherContext(): MatcherState {
     return {
       ...getState(),
       equals,
       isNot: this.inverse,
       utils,
-    } as State;
+    };
   }
 
   abstract asymmetricMatch(other: unknown): boolean;

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -51,6 +51,7 @@ import type {
 
 export type {
   AsymmetricMatchers,
+  BaseExpect,
   Expect,
   MatcherFunction,
   MatcherFunctionWithState,
@@ -363,9 +364,8 @@ const makeThrowingMatcher = (
     }
   };
 
-expect.extend = <T extends MatcherState = MatcherState>(
-  matchers: MatchersObject<T>,
-) => setMatchers(matchers, false, expect);
+expect.extend = (matchers: MatchersObject) =>
+  setMatchers(matchers, false, expect);
 
 expect.anything = anything;
 expect.any = any;
@@ -431,7 +431,6 @@ setMatchers(matchers, true, expect);
 setMatchers(spyMatchers, true, expect);
 setMatchers(toThrowMatchers, true, expect);
 
-expect.addSnapshotSerializer = () => void 0;
 expect.assertions = assertions;
 expect.hasAssertions = hasAssertions;
 expect.getState = getState;

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -46,12 +46,11 @@ export const setState = <State extends MatcherState = MatcherState>(
   Object.assign((global as any)[JEST_MATCHERS_OBJECT].state, state);
 };
 
-export const getMatchers = <
-  State extends MatcherState = MatcherState,
->(): MatchersObject<State> => (global as any)[JEST_MATCHERS_OBJECT].matchers;
+export const getMatchers = (): MatchersObject =>
+  (global as any)[JEST_MATCHERS_OBJECT].matchers;
 
-export const setMatchers = <State extends MatcherState = MatcherState>(
-  matchers: MatchersObject<State>,
+export const setMatchers = (
+  matchers: MatchersObject,
   isInternal: boolean,
   expect: Expect,
 ): void => {
@@ -65,8 +64,7 @@ export const setMatchers = <State extends MatcherState = MatcherState>(
       // expect is defined
 
       class CustomMatcher extends AsymmetricMatcher<
-        [unknown, ...Array<unknown>],
-        State
+        [unknown, ...Array<unknown>]
       > {
         constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
           super(sample, inverse);

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -35,8 +35,8 @@ export type RawMatcherFn<State extends MatcherState = MatcherState> = {
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
-export type MatchersObject<T extends MatcherState = MatcherState> = {
-  [name: string]: RawMatcherFn<T>;
+export type MatchersObject = {
+  [name: string]: RawMatcherFn;
 };
 
 export type ThrowingMatcherFn = (actual: any) => void;
@@ -76,27 +76,28 @@ export type ExpectedAssertionsErrors = Array<{
   expected: string;
 }>;
 
-export type Expect<State extends MatcherState = MatcherState> = {
-  <T = unknown>(actual: T): Matchers<void, T> &
-    InverseMatchers<void, T> &
-    PromiseMatchers<T>;
-  // TODO: this is added by test runners, not `expect` itself
-  addSnapshotSerializer(serializer: unknown): void;
+export type BaseExpect = {
   assertions(numberOfAssertions: number): void;
-  // TODO: remove this `T extends` - should get from some interface merging
-  extend<T extends MatcherState = State>(matchers: MatchersObject<T>): void;
+  extend(matchers: MatchersObject): void;
   extractExpectedAssertionsErrors(): ExpectedAssertionsErrors;
-  getState(): State;
+  getState(): MatcherState;
   hasAssertions(): void;
-  setState(state: Partial<State>): void;
-} & AsymmetricMatchers &
-  InverseAsymmetricMatchers;
+  setState(state: Partial<MatcherState>): void;
+};
 
-type InverseAsymmetricMatchers = {
+export type Expect = {
+  <T = unknown>(actual: T): Matchers<void> &
+    Inverse<Matchers<void>> &
+    PromiseMatchers;
+} & BaseExpect &
+  AsymmetricMatchers &
+  Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
+
+type Inverse<Matchers> = {
   /**
    * Inverse next matcher. If you know how to test something, `.not` lets you test its opposite.
    */
-  not: Omit<AsymmetricMatchers, 'any' | 'anything'>;
+  not: Matchers;
 };
 
 export interface AsymmetricMatchers {
@@ -109,28 +110,21 @@ export interface AsymmetricMatchers {
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }
 
-type PromiseMatchers<T = unknown> = {
+type PromiseMatchers = {
   /**
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: Matchers<Promise<void>, T> & InverseMatchers<Promise<void>, T>;
+  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: Matchers<Promise<void>, T> & InverseMatchers<Promise<void>, T>;
-};
-
-type InverseMatchers<R extends void | Promise<void>, T = unknown> = {
-  /**
-   * Inverse next matcher. If you know how to test something, `.not` lets you test its opposite.
-   */
-  not: Matchers<R, T>;
+  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
 };
 
 // This is a copy from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/de6730f4463cba69904698035fafd906a72b9664/types/jest/index.d.ts#L570-L817
-export interface Matchers<R extends void | Promise<void>, T = unknown> {
+export interface Matchers<R extends void | Promise<void>> {
   /**
    * Ensures the last call to a mock function was provided specific args.
    */
@@ -340,44 +334,4 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
    * If you want to test that a specific error is thrown inside a function.
    */
   toThrowError(expected?: unknown): R;
-
-  /* TODO: START snapshot matchers are not from `expect`, the types should not be here */
-  /**
-   * This ensures that a value matches the most recent snapshot with property matchers.
-   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
-   */
-  toMatchSnapshot(hint?: string): R;
-  /**
-   * This ensures that a value matches the most recent snapshot.
-   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
-   */
-  toMatchSnapshot<U extends Record<keyof T, unknown>>(
-    propertyMatchers: Partial<U>,
-    hint?: string,
-  ): R;
-  /**
-   * This ensures that a value matches the most recent snapshot with property matchers.
-   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
-   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
-   */
-  toMatchInlineSnapshot(snapshot?: string): R;
-  /**
-   * This ensures that a value matches the most recent snapshot with property matchers.
-   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
-   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
-   */
-  toMatchInlineSnapshot<U extends Record<keyof T, unknown>>(
-    propertyMatchers: Partial<U>,
-    snapshot?: string,
-  ): R;
-  /**
-   * Used to test that a function throws a error matching the most recent snapshot when it is called.
-   */
-  toThrowErrorMatchingSnapshot(hint?: string): R;
-  /**
-   * Used to test that a function throws a error matching the most recent snapshot when it is called.
-   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
-   */
-  toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
-  /* TODO: END snapshot matchers are not from `expect`, the types should not be here */
 }

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@jest/environment": "^28.0.0-alpha.1",
+    "@jest/expect": "^28.0.0-alpha.1",
     "@jest/test-result": "^28.0.0-alpha.1",
     "@jest/types": "^28.0.0-alpha.1",
     "@types/node": "*",

--- a/packages/jest-circus/tsconfig.json
+++ b/packages/jest-circus/tsconfig.json
@@ -10,6 +10,7 @@
     {"path": "../expect"},
     {"path": "../jest-each"},
     {"path": "../jest-environment"},
+    {"path": "../jest-expect"},
     {"path": "../jest-matcher-utils"},
     {"path": "../jest-message-util"},
     {"path": "../jest-runtime"},

--- a/packages/jest-expect/.npmignore
+++ b/packages/jest-expect/.npmignore
@@ -1,0 +1,5 @@
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo
+api-extractor.json

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "@jest/globals",
+  "name": "@jest/expect",
   "version": "28.0.0-alpha.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",
-    "directory": "packages/jest-globals"
-  },
-  "engines": {
-    "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
+    "directory": "packages/jest-expect"
   },
   "license": "MIT",
   "main": "./build/index.js",
@@ -20,9 +17,12 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@jest/environment": "^28.0.0-alpha.1",
-    "@jest/expect": "^28.0.0-alpha.1",
-    "@jest/types": "^28.0.0-alpha.1"
+    "@jest/types": "^28.0.0-alpha.1",
+    "expect": "^28.0.0-alpha.1",
+    "jest-snapshot": "^28.0.0-alpha.1"
+  },
+  "engines": {
+    "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-expect/src/index.ts
+++ b/packages/jest-expect/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type {Config} from '@jest/types';
-import {Expect, expect} from 'expect';
+import {expect} from 'expect';
 import {
   addSerializer,
   toMatchInlineSnapshot,
@@ -14,19 +14,22 @@ import {
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
+import type {JestExpect} from './types';
 
-export default function jestExpect(
-  config: Pick<Config.GlobalConfig, 'expand'>,
-): Expect {
-  expect.setState({expand: config.expand});
-  expect.extend({
+export type {JestExpect} from './types';
+
+export function createJestExpect({expand}: Config.GlobalConfig): JestExpect {
+  const jestExpect = expect as JestExpect;
+
+  jestExpect.setState({expand});
+  jestExpect.extend({
     toMatchInlineSnapshot,
     toMatchSnapshot,
     toThrowErrorMatchingInlineSnapshot,
     toThrowErrorMatchingSnapshot,
   });
 
-  expect.addSnapshotSerializer = addSerializer;
+  jestExpect.addSnapshotSerializer = addSerializer;
 
-  return expect;
+  return jestExpect;
 }

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {AsymmetricMatchers, BaseExpect, Matchers} from 'expect';
+import type {SnapshotState, addSerializer} from 'jest-snapshot';
+
+export type JestExpect = {
+  <T = unknown>(actual: T): JestMatchers<void, T> &
+    Inverse<JestMatchers<void, T>> &
+    PromiseMatchers<T>;
+  addSnapshotSerializer: typeof addSerializer;
+} & BaseExpect &
+  AsymmetricMatchers &
+  Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
+
+type Inverse<Matchers> = {
+  /**
+   * Inverse next matcher. If you know how to test something, `.not` lets you test its opposite.
+   */
+  not: Matchers;
+};
+
+type JestMatchers<R extends void | Promise<void>, T> = Matchers<R> &
+  SnapshotMatchers<R, T>;
+
+type PromiseMatchers<T = unknown> = {
+  /**
+   * Unwraps the reason of a rejected promise so any other matcher can be chained.
+   * If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestMatchers<Promise<void>, T> &
+    Inverse<JestMatchers<Promise<void>, T>>;
+  /**
+   * Unwraps the value of a fulfilled promise so any other matcher can be chained.
+   * If the promise is rejected the assertion fails.
+   */
+  resolves: JestMatchers<Promise<void>, T> &
+    Inverse<JestMatchers<Promise<void>, T>>;
+};
+
+interface SnapshotMatchers<R extends void | Promise<void>, T> {
+  /**
+   * This ensures that a value matches the most recent snapshot with property matchers.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchSnapshot(hint?: string): R;
+  /**
+   * This ensures that a value matches the most recent snapshot.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchSnapshot<U extends Record<keyof T, unknown>>(
+    propertyMatchers: Partial<U>,
+    hint?: string,
+  ): R;
+  /**
+   * This ensures that a value matches the most recent snapshot with property matchers.
+   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchInlineSnapshot(snapshot?: string): R;
+  /**
+   * This ensures that a value matches the most recent snapshot with property matchers.
+   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+   * Check out [the Snapshot Testing guide](https://jestjs.io/docs/snapshot-testing) for more information.
+   */
+  toMatchInlineSnapshot<U extends Record<keyof T, unknown>>(
+    propertyMatchers: Partial<U>,
+    snapshot?: string,
+  ): R;
+  /**
+   * Used to test that a function throws a error matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(hint?: string): R;
+  /**
+   * Used to test that a function throws a error matching the most recent snapshot when it is called.
+   * Instead of writing the snapshot value to a .snap file, it will be written into the source code automatically.
+   */
+  toThrowErrorMatchingInlineSnapshot(snapshot?: string): R;
+}
+
+declare module 'expect' {
+  interface MatcherState {
+    snapshotState: SnapshotState;
+  }
+}

--- a/packages/jest-expect/tsconfig.json
+++ b/packages/jest-expect/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src"
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./**/__tests__/**/*"],
+  "references": [
+    {"path": "../expect"},
+    {"path": "../jest-snapshot"},
+    {"path": "../jest-types"}
+  ]
+}

--- a/packages/jest-globals/src/index.ts
+++ b/packages/jest-globals/src/index.ts
@@ -6,12 +6,12 @@
  */
 
 import type {Jest} from '@jest/environment';
+import type {JestExpect} from '@jest/expect';
 import type {Global} from '@jest/types';
-import type {Expect} from 'expect';
 
 export declare const jest: Jest;
 
-export declare const expect: Expect;
+export declare const expect: JestExpect;
 
 export declare const it: Global.GlobalAdditions['it'];
 export declare const test: Global.GlobalAdditions['test'];

--- a/packages/jest-globals/tsconfig.json
+++ b/packages/jest-globals/tsconfig.json
@@ -9,8 +9,8 @@
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
   "references": [
-    {"path": "../expect"},
     {"path": "../jest-environment"},
+    {"path": "../jest-expect"},
     {"path": "../jest-types"}
   ]
 }

--- a/packages/jest-jasmine2/src/jestExpect.ts
+++ b/packages/jest-jasmine2/src/jestExpect.ts
@@ -26,6 +26,7 @@ export default function jestExpect(config: {expand: boolean}): void {
     toThrowErrorMatchingInlineSnapshot,
     toThrowErrorMatchingSnapshot,
   });
+  // @ts-expect-error: TODO
   expect.addSnapshotSerializer = addSerializer;
 
   const jasmine = global.jasmine;

--- a/packages/jest-jasmine2/src/setup_jest_globals.ts
+++ b/packages/jest-jasmine2/src/setup_jest_globals.ts
@@ -111,7 +111,7 @@ export default async function setupJestGlobals({
     snapshotFormat,
     updateSnapshot,
   });
-  // @ts-expect-error: snapshotState is a jest extension of `expect`
+
   expect.setState({snapshotState, testPath});
   // Return it back to the outer scope (test runner outside the VM).
   return snapshotState;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2589,6 +2589,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jest/expect@^28.0.0-alpha.1, @jest/expect@workspace:packages/jest-expect":
+  version: 0.0.0-use.local
+  resolution: "@jest/expect@workspace:packages/jest-expect"
+  dependencies:
+    "@jest/types": ^28.0.0-alpha.1
+    expect: ^28.0.0-alpha.1
+    jest-snapshot: ^28.0.0-alpha.1
+  languageName: unknown
+  linkType: soft
+
 "@jest/fake-timers@^28.0.0-alpha.1, @jest/fake-timers@workspace:packages/jest-fake-timers":
   version: 0.0.0-use.local
   resolution: "@jest/fake-timers@workspace:packages/jest-fake-timers"
@@ -2608,6 +2618,7 @@ __metadata:
   resolution: "@jest/globals@workspace:packages/jest-globals"
   dependencies:
     "@jest/environment": ^28.0.0-alpha.1
+    "@jest/expect": ^28.0.0-alpha.1
     "@jest/types": ^28.0.0-alpha.1
     expect: ^28.0.0-alpha.1
   languageName: unknown
@@ -12854,6 +12865,7 @@ __metadata:
     "@babel/core": ^7.1.0
     "@babel/register": ^7.0.0
     "@jest/environment": ^28.0.0-alpha.1
+    "@jest/expect": ^28.0.0-alpha.1
     "@jest/test-result": ^28.0.0-alpha.1
     "@jest/types": ^28.0.0-alpha.1
     "@types/co": ^4.6.0


### PR DESCRIPTION
## Summary

@SimenB Hope this isn’t overlapping with anything you do, I just couldn’t stop myself from trying out adding `@jest/expect` package.

Seems like this is the cleanest way to separate snapshot matchers implementation from `expect`. Also most flexible, since it becomes very easy to use `@jest/expect` as stand alone package.

Alternatives: moving `expect` types to `@jest/types` (#12059); moving `jestExpect.ts` from `jest-circus` to `jest-runtime`. I was playing with both. That was rather complex and did not allow stand alone usage as `@jest/expect` does.

The implementation is slightly unfinished (`jasmine` should be rework), but seems like it does the right job.

## Test plan

Green CI.