### PR TITLE
chore: re-export `AsymmetricMatcher` from `@jest/expect`

### DIFF
--- a/packages/jest-expect/README.md
+++ b/packages/jest-expect/README.md
@@ -1,5 +1,5 @@
 # @jest/expect
 
-This package extends `expect` library with `jest-snapshot` matchers. It export `jestExpect` object, which can be used as standalone replacement of `expect`, and `createJestExpect` factory function, which returns an instance of `jestExpect`.
+This package extends `expect` library with `jest-snapshot` matchers. It exports `jestExpect` object, which can be used as standalone replacement of `expect`.
 
 The `jestExpect` function used in [Jest](https://jestjs.io/). You can find its documentation [on Jest's website](https://jestjs.io/docs/expect).

--- a/packages/jest-expect/src/index.ts
+++ b/packages/jest-expect/src/index.ts
@@ -15,9 +15,10 @@ import {
 } from 'jest-snapshot';
 import type {JestExpect} from './types';
 
+export type {AsymmetricMatchers, MatcherFunction, MatcherState} from 'expect';
 export type {JestExpect} from './types';
 
-export function createJestExpect(): JestExpect {
+function createJestExpect(): JestExpect {
   expect.extend({
     toMatchInlineSnapshot,
     toMatchSnapshot,

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type {AssertionError} from 'assert';
-import type {JestExpect} from '@jest/expect';
+import type {AsymmetricMatchers, JestExpect} from '@jest/expect';
 import type CallTracker from './jasmine/CallTracker';
 import type Env from './jasmine/Env';
 import type JsApiReporter from './jasmine/JsApiReporter';
@@ -69,7 +69,7 @@ export type Jasmine = {
   version: string;
   testPath: string;
   addMatchers: (matchers: JasmineMatchersObject) => void;
-} & JestExpect &
+} & AsymmetricMatchers &
   typeof globalThis;
 
 declare global {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

There might be other types we wanna export as well but at least exporting stuff people might import from `expect` seems reasonable.

/cc @mrazauskas 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
