### PR TITLE
refactor(jest-runtime): do not import from `@jest/globals`

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@jest/environment": "^28.0.0-alpha.2",
+    "@jest/expect": "^28.0.0-alpha.2",
     "@jest/fake-timers": "^28.0.0-alpha.2",
-    "@jest/globals": "^28.0.0-alpha.2",
     "@jest/source-map": "^28.0.0-alpha.0",
     "@jest/test-result": "^28.0.0-alpha.2",
     "@jest/transform": "^28.0.0-alpha.2",

--- a/packages/jest-runtime/tsconfig.json
+++ b/packages/jest-runtime/tsconfig.json
@@ -9,8 +9,8 @@
   "references": [
     {"path": "../jest-environment"},
     {"path": "../jest-environment-node"},
+    {"path": "../jest-expect"},
     {"path": "../jest-fake-timers"},
-    {"path": "../jest-globals"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-message-util"},
     {"path": "../jest-mock"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,7 +2614,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jest/globals@^28.0.0-alpha.2, @jest/globals@workspace:*, @jest/globals@workspace:packages/jest-globals":
+"@jest/globals@workspace:*, @jest/globals@workspace:packages/jest-globals":
   version: 0.0.0-use.local
   resolution: "@jest/globals@workspace:packages/jest-globals"
   dependencies:
@@ -13355,8 +13355,8 @@ __metadata:
   resolution: "jest-runtime@workspace:packages/jest-runtime"
   dependencies:
     "@jest/environment": ^28.0.0-alpha.2
+    "@jest/expect": ^28.0.0-alpha.2
     "@jest/fake-timers": ^28.0.0-alpha.2
-    "@jest/globals": ^28.0.0-alpha.2
     "@jest/source-map": ^28.0.0-alpha.0
     "@jest/test-result": ^28.0.0-alpha.2
     "@jest/test-utils": ^28.0.0-alpha.2


### PR DESCRIPTION
## Summary

Currently `jest-runtime` is importing types from `@jest/globals`, seems like there is no need for that. All necessary types can be imported directly.

The only change – `@jest/globals` is removed from `jest-runtime` dependency graph.

---

Semi-related idea. If this change is accepted, none of the packages in the repo will depend on `@jest/globals`. What if the code of `@jest/globals` would be moved into `jest`? Just wondering, if the guide for typed testing could look like this:

1. Install Jest: `yarn add -D jest`
2. Import Jest: `import {expect, jest, test} from 'jest';`
3. Happy typed testing!

## Test plan

Green CI