### PR TITLE
chore: include `__typetests_` in `.npmignore` files of all packages

### DIFF
--- a/packages/babel-jest/.npmignore
+++ b/packages/babel-jest/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/babel-plugin-jest-hoist/.npmignore
+++ b/packages/babel-plugin-jest-hoist/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/babel-preset-jest/.npmignore
+++ b/packages/babel-preset-jest/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/diff-sequences/.npmignore
+++ b/packages/diff-sequences/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-changed-files/.npmignore
+++ b/packages/jest-changed-files/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-circus/.npmignore
+++ b/packages/jest-circus/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-cli/.npmignore
+++ b/packages/jest-cli/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-config/.npmignore
+++ b/packages/jest-config/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-console/.npmignore
+++ b/packages/jest-console/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-core/.npmignore
+++ b/packages/jest-core/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-create-cache-key-function/.npmignore
+++ b/packages/jest-create-cache-key-function/.npmignore
@@ -1,5 +1,7 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo
+api-extractor.json

--- a/packages/jest-diff/.npmignore
+++ b/packages/jest-diff/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-docblock/.npmignore
+++ b/packages/jest-docblock/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-each/.npmignore
+++ b/packages/jest-each/.npmignore
@@ -1,5 +1,6 @@
-**/__tests__/**
 **/__mocks__/**
+**/__tests__/**
+__typetests__
 src
 assets
 tsconfig.json

--- a/packages/jest-environment-jsdom/.npmignore
+++ b/packages/jest-environment-jsdom/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-environment-node/.npmignore
+++ b/packages/jest-environment-node/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-environment/.npmignore
+++ b/packages/jest-environment/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-expect/.npmignore
+++ b/packages/jest-expect/.npmignore
@@ -1,3 +1,4 @@
+**/__mocks__/**
 **/__tests__/**
 __typetests__
 src

--- a/packages/jest-expect/.npmignore
+++ b/packages/jest-expect/.npmignore
@@ -1,4 +1,5 @@
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-fake-timers/.npmignore
+++ b/packages/jest-fake-timers/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-get-type/.npmignore
+++ b/packages/jest-get-type/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-globals/.npmignore
+++ b/packages/jest-globals/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-haste-map/.npmignore
+++ b/packages/jest-haste-map/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-jasmine2/.npmignore
+++ b/packages/jest-jasmine2/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-leak-detector/.npmignore
+++ b/packages/jest-leak-detector/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-matcher-utils/.npmignore
+++ b/packages/jest-matcher-utils/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-message-util/.npmignore
+++ b/packages/jest-message-util/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-mock/.npmignore
+++ b/packages/jest-mock/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-phabricator/.npmignore
+++ b/packages/jest-phabricator/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+example
 __typetests__
 src
 tsconfig.json

--- a/packages/jest-phabricator/.npmignore
+++ b/packages/jest-phabricator/.npmignore
@@ -1,6 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
-example
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-regex-util/.npmignore
+++ b/packages/jest-regex-util/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-repl/.npmignore
+++ b/packages/jest-repl/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-reporters/.npmignore
+++ b/packages/jest-reporters/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-resolve-dependencies/.npmignore
+++ b/packages/jest-resolve-dependencies/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-resolve/.npmignore
+++ b/packages/jest-resolve/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-runner/.npmignore
+++ b/packages/jest-runner/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-runtime/.npmignore
+++ b/packages/jest-runtime/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-schemas/.npmignore
+++ b/packages/jest-schemas/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-serializer/.npmignore
+++ b/packages/jest-serializer/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-snapshot/.npmignore
+++ b/packages/jest-snapshot/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-source-map/.npmignore
+++ b/packages/jest-source-map/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-test-result/.npmignore
+++ b/packages/jest-test-result/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-test-sequencer/.npmignore
+++ b/packages/jest-test-sequencer/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-transform/.npmignore
+++ b/packages/jest-transform/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-util/.npmignore
+++ b/packages/jest-util/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-validate/.npmignore
+++ b/packages/jest-validate/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-watcher/.npmignore
+++ b/packages/jest-watcher/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest-worker/.npmignore
+++ b/packages/jest-worker/.npmignore
@@ -1,6 +1,7 @@
 **/__mocks__/**
 **/__tests__/**
 **/__performance_tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/jest/.npmignore
+++ b/packages/jest/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 tsconfig.json
 tsconfig.tsbuildinfo

--- a/packages/pretty-format/.npmignore
+++ b/packages/pretty-format/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
+__typetests__
 src
 perf
 tsconfig.json


### PR DESCRIPTION
## Summary

Seems like `__typetests__` directory got published. Ups.. Adding it to `.npmignore` list.

## Test plan

N/A
