### PR TITLE
feat(jest-expect): re-export `Matchers` and `MatcherFunctionWithState` interface

### DIFF
--- a/examples/expect-extend/toBeWithinRange.ts
+++ b/examples/expect-extend/toBeWithinRange.ts
@@ -6,7 +6,7 @@
  */
 
 import {expect} from '@jest/globals';
-import type {MatcherFunction} from 'expect';
+import type {MatcherFunction} from '@jest/expect';
 
 const toBeWithinRange: MatcherFunction<[floor: number, ceiling: number]> =
   function (actual: unknown, floor: unknown, ceiling: unknown) {
@@ -46,11 +46,11 @@ expect.extend({
   toBeWithinRange,
 });
 
-declare module 'expect' {
+declare module '@jest/expect' {
   interface AsymmetricMatchers {
-    toBeWithinRange(a: number, b: number): void;
+    toBeWithinRange(floor: number, ceiling: number): void;
   }
   interface Matchers<R> {
-    toBeWithinRange(a: number, b: number): R;
+    toBeWithinRange(floor: number, ceiling: number): R;
   }
 }

--- a/examples/expect-extend/tsconfig.json
+++ b/examples/expect-extend/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["./**/*"]
+}

--- a/packages/jest-expect/src/index.ts
+++ b/packages/jest-expect/src/index.ts
@@ -15,7 +15,12 @@ import {
 } from 'jest-snapshot';
 import type {JestExpect} from './types';
 
-export type {AsymmetricMatchers, MatcherFunction, MatcherState} from 'expect';
+export type {
+  AsymmetricMatchers,
+  Matchers,
+  MatcherFunction,
+  MatcherState,
+} from 'expect';
 export type {JestExpect} from './types';
 
 function createJestExpect(): JestExpect {

--- a/packages/jest-expect/src/index.ts
+++ b/packages/jest-expect/src/index.ts
@@ -19,6 +19,7 @@ export type {
   AsymmetricMatchers,
   Matchers,
   MatcherFunction,
+  MatcherFunctionWithState,
   MatcherState,
 } from 'expect';
 export type {JestExpect} from './types';


### PR DESCRIPTION
## Summary

Perhaps `jest-expect` should re-export `Matchers` interface as well?

I was looking at the example again. Feels like Jest users should be recommended to extend interfaces from `'@jest/expect'` instead of `'expect'`. Right? In this case `Matchers` must be re-exported from `jest-expect`.

Also `MatcherFunctionWithState` is also useful. It is just the same as `MatcherFunction`, but takes two generic type arguments (state and matcher args) instead of one (only matcher args). I guess in most of the cases `MatcherFunction` will do the job, but for more advance usage `MatcherFunctionWithState` will be helpful too.

Other problem. Because of augmentation the example was pulling types from test type files. Ups.. I added minimal `tsconfig.json`, which helps to isolate the example.

## Test plan

Green CI.
