### PR TITLE
chore(type-tests): do not include `@types` definitions in type tests

### DIFF
--- a/packages/expect/__typetests__/tsconfig.json
+++ b/packages/expect/__typetests__/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "types": []
   },
   "include": ["./**/*"]
 }

--- a/packages/jest-expect/__typetests__/tsconfig.json
+++ b/packages/jest-expect/__typetests__/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "types": []
   },
   "include": ["./**/*"]
 }

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -7,7 +7,7 @@
 
 import {expectError, expectType} from 'tsd-lite';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
-import {expect} from '@jest/globals';
+import {expect, jest} from '@jest/globals';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 
 // asymmetric matchers

--- a/packages/jest-types/__typetests__/tsconfig.json
+++ b/packages/jest-types/__typetests__/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+
+    "types": []
   },
   "include": ["./**/*"]
 }


### PR DESCRIPTION
## Summary

Currently `@types` definitions are included in type tests. For instance `@types/jest` managed to sneak into `expect` test. Perhaps it is good idea to exclude all `@types` definitions for type testing?

## Test plan

Green CI
