### PR TITLE
fix: Expected signature to be an Uint8Array

### DIFF
--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -68,6 +68,8 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
 
     // TODO: remove this ASAP, but it currently causes tests to run really slow
     global.Buffer = Buffer;
+    
+    global.Uint8Array = Uint8Array;
 
     // Report uncaught errors.
     this.errorEventListener = event => {


### PR DESCRIPTION
Parsing lightning network payment requests currently fail within a jsdom test environment.
(using libs such as: https://github.com/bitcoinjs/bolt11 or https://github.com/alexbosworth/invoices within your front-end)

In similar issues it has been adviced to set the testenvironment to node `testEnvironment: node`, but we need to render react components in our test.