### PR TITLE
docs(pretty-format): fix typos in README

### DIFF
--- a/packages/pretty-format/README.md
+++ b/packages/pretty-format/README.md
@@ -218,8 +218,8 @@ Write `serialize` to return a string, given the arguments:
 | `min`               | `boolean` | minimize added space: no indentation nor line breaks    |
 | `plugins`           | `array`   | plugins to serialize application-specific data types    |
 | `printFunctionName` | `boolean` | include or omit the name of a function                  |
-| `spacingInner`      | `strong`  | spacing to separate items in a list                     |
-| `spacingOuter`      | `strong`  | spacing to enclose a list of items                      |
+| `spacingInner`      | `string`  | spacing to separate items in a list                     |
+| `spacingOuter`      | `string`  | spacing to enclose a list of items                      |
 
 Each property of `colors` in `config` corresponds to a property of `theme` in `options`:
 


### PR DESCRIPTION
## Summary

The documentation for the pretty-format package mistakenly refers to the types of the `spacingInner` and `spacingOuter` properties of the serialize config as "strong"s rather than "string"s.

## Test plan

Not applicable.
