### PR TITLE
chore: make code base and type tests TS 4.2 compatible

### DIFF
--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -8,10 +8,10 @@
 import {expectAssignable, expectError, expectType} from 'tsd-lite';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
 import {
-  type MatcherFunction,
-  type MatcherFunctionWithState,
-  type MatcherState,
-  type Matchers,
+  MatcherFunction,
+  MatcherFunctionWithState,
+  MatcherState,
+  Matchers,
   expect,
 } from 'expect';
 import type * as jestMatcherUtils from 'jest-matcher-utils';

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -7,7 +7,7 @@
 
 import throat from 'throat';
 import type {JestEnvironment} from '@jest/environment';
-import {type JestExpect, jestExpect} from '@jest/expect';
+import {JestExpect, jestExpect} from '@jest/expect';
 import {
   AssertionResult,
   Status,


### PR DESCRIPTION
## Summary

From https://github.com/facebook/jest/issues/12444#issuecomment-1046871687

This PR is fixing couple of places where I recently introduced `type` modifiers. The `type` modifier is TS 4.5 feature. Jest is aiming to support TS 4.2, so I think these modifiers should be removed.

## Test plan

I was installing TS v4.2 locally, build and type tests fail pointing at these lines. The rest works. There is obvious need for infrastructure proposed in #12444