### PR TITLE
chore: run type tests using old version of TS

### DIFF
--- a/scripts/verifyOldTs.js
+++ b/scripts/verifyOldTs.js
@@ -70,4 +70,153 @@ function smoketest() {
   }
 }
 
+function typeTests() {
+  const cwd = path.resolve(__dirname, '../');
+  const rootPackageJson = require('../package.json');
+
+  const currentTsdTypescriptVersion =
+    rootPackageJson.devDependencies['@tsd/typescript'];
+  const currentTypescriptVersion =
+    rootPackageJson.devDependencies['typescript'];
+  const apiExtractorTypescriptVersion =
+    require('@microsoft/api-extractor/package.json').dependencies['typescript'];
+
+  try {
+    const {stdout: statusStdout} = execa.sync(
+      'git',
+      ['status', '--porcelain'],
+      {cwd},
+    );
+
+    if (statusStdout.length > 0) {
+      throw new Error(
+        'Repo is not clean - cannot run type tests with old typescript version',
+      );
+    }
+
+    execa.sync(
+      'yarn',
+      [
+        'set',
+        'resolution',
+        `@tsd/typescript@npm:${currentTsdTypescriptVersion}`,
+        tsVersion,
+      ],
+      {cwd},
+    );
+
+    verifyInstalledTsdTypescript();
+
+    execa.sync(
+      'yarn',
+      [
+        'set',
+        'resolution',
+        `typescript@npm:${currentTypescriptVersion}`,
+        tsVersion,
+      ],
+      {cwd},
+    );
+    execa.sync(
+      'yarn',
+      [
+        'set',
+        'resolution',
+        `typescript@npm:${apiExtractorTypescriptVersion}`,
+        tsVersion,
+      ],
+      {cwd},
+    );
+    execa.sync('yarn', ['set', 'resolution', 'typescript@npm:*', tsVersion], {
+      cwd,
+    });
+
+    verifyInstalledTypescript();
+
+    execa.sync('yarn', ['test-types'], {cwd, stdio: 'inherit'});
+  } finally {
+    execa.sync('git', ['checkout', 'yarn.lock'], {cwd});
+  }
+
+  function verifyInstalledTsdTypescript() {
+    const tsdEntries = listInstalledVersion('@tsd/typescript');
+
+    if (tsdEntries.length !== 1) {
+      throw new Error(
+        `More than one version of @tsd/typescript found: ${tsdEntries.join(
+          ', ',
+        )}`,
+      );
+    }
+
+    const tsdVersion = tsdEntries[0].match(/@npm:(\d+\.\d+)\.\d+/);
+
+    if (!tsdVersion) {
+      throw new Error('Unable to verify installed version of @tsd/typescript');
+    }
+
+    if (tsdVersion[1] !== tsVersion) {
+      throw new Error(
+        `Installed TSD version is not ${tsVersion}, is ${tsdVersion[1]}`,
+      );
+    }
+  }
+
+  function verifyInstalledTypescript() {
+    const typescriptEntries = listInstalledVersion('typescript');
+
+    if (typescriptEntries.length !== 1) {
+      throw new Error(
+        `More than one version of typescript found: ${typescriptEntries.join(
+          ', ',
+        )}`,
+      );
+    }
+
+    const tsdVersion = typescriptEntries[0].match(/@npm%3A(\d+\.\d+)\.\d+/);
+
+    if (!tsdVersion) {
+      throw new Error('Unable to verify installed version of typescript');
+    }
+
+    if (tsdVersion[1] !== tsVersion) {
+      throw new Error(
+        `Installed TSD version is not ${tsVersion}, is ${tsdVersion[1]}`,
+      );
+    }
+  }
+
+  function listInstalledVersion(module) {
+    const {stdout: tsdWhyOutput} = execa.sync(
+      'yarn',
+      ['why', module, '--json'],
+      {cwd},
+    );
+
+    const locators = tsdWhyOutput
+      .split('\n')
+      .map(JSON.parse)
+      .map(entry => {
+        const entries = Object.entries(entry.children);
+        if (entries.length !== 1) {
+          throw new Error(
+            `More than one entry found in ${JSON.stringify(entry, null, 2)}`,
+          );
+        }
+
+        return entries[0][1].locator;
+      });
+
+    return Array.from(new Set(locators));
+  }
+}
+
+console.log(chalk.inverse(` Running smoketest using TypeScript@${tsVersion} `));
 smoketest();
+console.log(chalk.inverse.green(' Successfully ran smoketest '));
+
+console.log(
+  chalk.inverse(` Running type tests using TypeScript@${tsVersion} `),
+);
+typeTests();
+console.log(chalk.inverse.green(' Successfully ran type tests '));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This currently fails, /cc @mrazauskas 

```
 FAIL   types  packages/expect/__typetests__/expect.test.ts
  ● Test suite failed to run

    SyntaxError: ',' expected.

      at packages/expect/__typetests__/expect.test.ts:11:8

 PASS   types  packages/jest-types/__typetests__/config.test.ts
 PASS   types  packages/jest-expect/__typetests__/jest-expect.test.ts
 PASS   types  packages/jest-types/__typetests__/globals.test.ts
 PASS   types  packages/jest-types/__typetests__/expect.test.ts
 FAIL   types  packages/jest-types/__typetests__/jest.test.ts
  ● tsd typecheck

    Argument of type '((a: string, b: number) => boolean) & Mock<unknown, unknown[]>' is not assignable to parameter of type 'Mock<boolean, [a: string, b: number]>'.

    > 130 |   expectType<Mock<boolean, [a: string, b: number]>>(maybeMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:130:3

    Parameter type 'Mock<boolean, [a: string, b: number]>' is declared too wide for argument type 'Mock<boolean, [a: string, b: number]> & Mock<unknown, unknown[]>'.

    > 143 |   expectType<Mock<boolean, [a: string, b: number]>>(surelyMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:143:3

    Argument of type 'Mock<boolean, [a: string, b: number]>' is not assignable to parameter of type 'never'.

    > 150 |   expectType<never>(surelyMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:150:3

    Parameter type 'string & Mock<unknown, unknown[]>' is not identical to argument type 'string & Mock<unknown, unknown[]>'.

    > 160 |   expectType<string & Mock<unknown, Array<unknown>>>(stringMaybeMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:160:3

    Parameter type 'Mock<unknown, unknown[]>' is not identical to argument type 'Mock<unknown, unknown[]>'.

    > 170 |   expectType<Mock<unknown, Array<unknown>>>(anyMaybeMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:170:3

    Parameter type 'Mock<unknown, unknown[]>' is not identical to argument type 'Mock<unknown, unknown[]>'.

    > 180 |   expectType<Mock<unknown, Array<unknown>>>(unknownMaybeMock);
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:180:3

    Argument of type 'SpyInstance<string, []>' is not assignable to parameter of type 'SpyInstance<Date, [value: string | number | Date]>'.

    > 271 | expectType<SpyInstance<Date, [value: string | number | Date]>>(
          | ^

      at packages/jest-types/__typetests__/jest.test.ts:271:1

    Argument of type 'string' is not assignable to parameter of type '(...args: any[]) => unknown'.

    > 155 | if (!jest.isMockFunction(stringMaybeMock)) {
          |                          ^

      at packages/jest-types/__typetests__/jest.test.ts:155:26

    Argument of type 'string' is not assignable to parameter of type '(...args: any[]) => unknown'.

    > 159 | if (jest.isMockFunction(stringMaybeMock)) {
          |                         ^

      at packages/jest-types/__typetests__/jest.test.ts:159:25

    Argument of type 'unknown' is not assignable to parameter of type '(...args: any[]) => unknown'.

    > 175 | if (!jest.isMockFunction(unknownMaybeMock)) {
          |                          ^

      at packages/jest-types/__typetests__/jest.test.ts:175:26

    Argument of type 'unknown' is not assignable to parameter of type '(...args: any[]) => unknown'.

    > 179 | if (jest.isMockFunction(unknownMaybeMock)) {
          |                         ^

      at packages/jest-types/__typetests__/jest.test.ts:179:25

    Expected an error, but found none.

    > 133 |   expectError(maybeMock.mockReturnValueOnce(123));
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:133:3

    Expected an error, but found none.

    > 146 |   expectError(surelyMock.mockReturnValueOnce(123));
          |   ^

      at packages/jest-types/__typetests__/jest.test.ts:146:3

    Expected an error, but found none.

    > 255 | expectError(jest.spyOn('abc', 'methodA'));
          | ^

      at packages/jest-types/__typetests__/jest.test.ts:255:1

Test Suites: 2 failed, 4 passed, 6 total
Tests:       14 failed, 447 passed, 461 total
Snapshots:   0 total
Time:        2.958 s
```

Closes #12444

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
