### PR TITLE
docs(ES6ClassMocks): add clarity for module factory limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[*]` Bundle all `.d.ts` files into a single `index.d.ts` per module ([#12345](https://github.com/facebook/jest/pull/12345))
 - `[docs]` Add note about not mixing `done()` with Promises ([#11077](https://github.com/facebook/jest/pull/11077))
 - `[docs, examples]` Update React examples to match with the new React guidelines for code examples ([#12217](https://github.com/facebook/jest/pull/12217))
+- `[docs]` Add clarity for module factory hoisting limitations ([#12453](https://github.com/facebook/jest/pull/12453))
 - `[expect]` [**BREAKING**] Remove support for importing `build/utils` ([#12323](https://github.com/facebook/jest/pull/12323))
 - `[expect]` [**BREAKING**] Migrate to ESM ([#12344](https://github.com/facebook/jest/pull/12344))
 - `[expect]` [**BREAKING**] Snapshot matcher types are moved to `@jest/expect` ([#12404](https://github.com/facebook/jest/pull/12404))
@@ -53,7 +54,6 @@
 - `[jest-transform]` Update `write-file-atomic` to v4 ([#12357](https://github.com/facebook/jest/pull/12357))
 - `[jest-types]` [**BREAKING**] Remove `Config.Glob` and `Config.Path` ([#12406](https://github.com/facebook/jest/pull/12406))
 - `[jest]` Use `index.ts` instead of `jest.ts` as main export ([#12329](https://github.com/facebook/jest/pull/12329))
-- `[docs, website]` Add clarity for module factory limitations ([#12453](https://github.com/facebook/jest/pull/12453))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - `[jest-transform]` Update `write-file-atomic` to v4 ([#12357](https://github.com/facebook/jest/pull/12357))
 - `[jest-types]` [**BREAKING**] Remove `Config.Glob` and `Config.Path` ([#12406](https://github.com/facebook/jest/pull/12406))
 - `[jest]` Use `index.ts` instead of `jest.ts` as main export ([#12329](https://github.com/facebook/jest/pull/12329))
+- `[docs, website]` Add clarity for module factory limitations ([#12453](https://github.com/facebook/jest/pull/12453))
 
 ### Performance
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-27.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.0/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-27.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.1/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-27.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.2/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-27.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.4/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -140,7 +140,11 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
+
+For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 
 ```javascript
 // Note: this will fail
@@ -150,6 +154,19 @@ jest.mock('./sound-player', () => {
   return jest.fn().mockImplementation(() => {
     return {playSoundFile: fakePlaySoundFile};
   });
+});
+```
+
+The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+
+```javascript
+import SoundPlayer from './sound-player';
+const mockSoundPlayer = jest.fn().mockImplementation(() => {
+  return {playSoundFile: mockPlaySoundFile};
+});
+// results in a ReferenceError
+jest.mock('./sound-player', () => {
+  return mockSoundPlayer;
 });
 ```
 

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -140,6 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
+<!-- prettier-ignore -->
 :::caution
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -141,7 +141,7 @@ jest.mock('./sound-player', () => {
 ```
 
 :::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word 'mock'. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
@@ -157,7 +157,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-The following will throw a ReferenceError despite using 'mock' in the variable declaration, as the mockSoundPlayer is not wrapped in an arrow function and thus accessed before initialization after hoisting.
+The following will throw a `ReferenceError` despite using `mock` in the variable declaration, as the `mockSoundPlayer` is not wrapped in an arrow function and thus accessed before initialization after hoisting.
 
 ```javascript
 import SoundPlayer from './sound-player';

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -140,9 +140,10 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-<!-- prettier-ignore -->
 :::caution
+
 Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+
 :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -140,7 +140,9 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
+:::caution
+Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
+:::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -146,7 +146,7 @@ Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents a
 
 :::
 
-For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
+For example, the following will throw an out-of-scope error due to the use of `fake` instead of `mock` in the variable declaration.
 
 ```javascript
 // Note: this will fail

--- a/website/versioned_docs/version-27.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.5/Es6ClassMocks.md
@@ -140,9 +140,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-:::caution
-Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz).
-:::
+:::caution Since calls to `jest.mock()` are hoisted to the top of the file, Jest prevents access to out-of-scope variables. By default, you cannot first define a variable and then use it in the factory. Jest will disable this check for variables that start with the word `mock`. However, it is still up to you to guarantee that they will be initialized on time. Be aware of [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz). :::
 
 For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration.
 


### PR DESCRIPTION
- close #11862
- related to #11455

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Modify verbiage and include another code example to make it clear that there is a language-level limitation outside of Jest when using the module factory pattern.
