### PR TITLE
chore: add type tests for Mock Function

### DIFF
--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -15,6 +15,22 @@ import {Mock, SpyInstance, fn, spyOn} from 'jest-mock';
 
 // jest.fn()
 
+expectType<Mock<Promise<string>, []>>(
+  fn(async () => 'value')
+    .mockClear()
+    .mockReset()
+    .mockImplementation(fn())
+    .mockImplementationOnce(fn())
+    .mockName('mock')
+    .mockReturnThis()
+    .mockReturnValue(Promise.resolve('value'))
+    .mockReturnValueOnce(Promise.resolve('value'))
+    .mockResolvedValue('value')
+    .mockResolvedValueOnce('value')
+    .mockRejectedValue('error')
+    .mockRejectedValue('error'),
+);
+
 expectAssignable<Function>(fn()); // eslint-disable-line @typescript-eslint/ban-types
 
 expectType<Mock<unknown>>(fn());
@@ -50,8 +66,12 @@ expectType<{
   connect(): Mock<unknown, Array<unknown>>;
   disconnect(): void;
 }>(new MockObject('credentials'));
-
 expectError(new MockObject());
+
+expectType<((a: string, b?: number | undefined) => boolean) | undefined>(
+  mockFn.getMockImplementation(),
+);
+expectError(mockFn.getMockImplementation('some-mock'));
 
 expectType<string>(mockFn.getMockName());
 expectError(mockFn.getMockName('some-mock'));

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  expectAssignable,
+  expectError,
+  expectNotAssignable,
+  expectType,
+} from 'tsd-lite';
+import {Mock, SpyInstance, fn, spyOn} from 'jest-mock';
+
+// jest.fn()
+
+expectAssignable<Function>(fn()); // eslint-disable-line @typescript-eslint/ban-types
+
+expectType<Mock<unknown>>(fn());
+expectType<Mock<void, []>>(fn(() => {}));
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  fn((a: string, b?: number) => true),
+);
+expectType<Mock<never, [e: any]>>(
+  fn((e: any) => {
+    throw new Error();
+  }),
+);
+expectError(fn('moduleName'));
+
+const mockFn = fn((a: string, b?: number) => true);
+const mockAsyncFn = fn(async (p: boolean) => 'value');
+
+expectType<boolean>(mockFn('one', 2));
+expectType<Promise<string>>(mockAsyncFn(false));
+expectError(mockFn());
+expectError(mockAsyncFn());
+
+const MockObject = fn((credentials: string) => ({
+  connect() {
+    return fn();
+  },
+  disconnect() {
+    return;
+  },
+}));
+
+expectType<{
+  connect(): Mock<unknown, Array<unknown>>;
+  disconnect(): void;
+}>(new MockObject('credentials'));
+
+expectError(new MockObject());
+
+expectType<string>(mockFn.getMockName());
+expectError(mockFn.getMockName('some-mock'));
+
+expectType<number>(mockFn.mock.calls.length);
+
+expectType<string>(mockFn.mock.calls[0][0]);
+expectType<number | undefined>(mockFn.mock.calls[0][1]);
+
+expectType<string>(mockFn.mock.calls[1][0]);
+expectType<number | undefined>(mockFn.mock.calls[1][1]);
+
+expectType<[a: string, b?: number | undefined] | undefined>(
+  mockFn.mock.lastCall,
+);
+
+expectType<Array<number>>(mockFn.mock.invocationCallOrder);
+
+expectType<
+  Array<{
+    connect(): Mock<unknown, Array<unknown>>;
+    disconnect(): void;
+  }>
+>(MockObject.mock.instances);
+
+const returnValue = mockFn.mock.results[0];
+
+expectType<'incomplete' | 'return' | 'throw'>(returnValue.type);
+expectType<unknown>(returnValue.value);
+
+if (returnValue.type === 'incomplete') {
+  expectType<undefined>(returnValue.value);
+}
+
+if (returnValue.type === 'return') {
+  expectType<boolean>(returnValue.value);
+}
+
+if (returnValue.type === 'throw') {
+  expectType<unknown>(returnValue.value);
+}
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockClear(),
+);
+expectError(mockFn.mockClear('some-mock'));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockReset(),
+);
+expectError(mockFn.mockClear('some-mock'));
+
+expectType<void>(mockFn.mockRestore());
+expectError(mockFn.mockClear('some-mock'));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockImplementation((a, b) => {
+    expectType<string>(a);
+    expectType<number | undefined>(b);
+    return false;
+  }),
+);
+expectError(mockFn.mockImplementation((a: number) => false));
+expectError(mockFn.mockImplementation(a => 'false'));
+expectError(mockFn.mockImplementation());
+
+expectType<Mock<Promise<string>, [p: boolean]>>(
+  mockAsyncFn.mockImplementation(async a => {
+    expectType<boolean>(a);
+    return 'mock value';
+  }),
+);
+expectError(mockAsyncFn.mockImplementation(a => 'mock value'));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockImplementationOnce((a, b) => {
+    expectType<string>(a);
+    expectType<number | undefined>(b);
+    return false;
+  }),
+);
+expectError(mockFn.mockImplementationOnce((a: number) => false));
+expectError(mockFn.mockImplementationOnce(a => 'false'));
+expectError(mockFn.mockImplementationOnce());
+
+expectType<Mock<Promise<string>, [p: boolean]>>(
+  mockAsyncFn.mockImplementationOnce(async a => {
+    expectType<boolean>(a);
+    return 'mock value';
+  }),
+);
+expectError(mockAsyncFn.mockImplementationOnce(a => 'mock value'));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockName('mockedFunction'),
+);
+expectError(mockFn.mockName(123));
+expectError(mockFn.mockName());
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockReturnThis(),
+);
+expectError(mockFn.mockReturnThis('this'));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockReturnValue(false),
+);
+expectError(mockFn.mockReturnValue('true'));
+expectError(mockFn.mockReturnValue());
+
+expectType<Mock<Promise<string>, [p: boolean]>>(
+  mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
+);
+expectError(mockAsyncFn.mockReturnValue(Promise.resolve(true)));
+
+expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+  mockFn.mockReturnValueOnce(false),
+);
+expectError(mockFn.mockReturnValueOnce('true'));
+expectError(mockFn.mockReturnValueOnce());
+
+expectType<Mock<Promise<string>, [p: boolean]>>(
+  mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
+);
+expectError(mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)));
+
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockResolvedValue('Mock value'),
+);
+expectError(fn(() => Promise.resolve('')).mockResolvedValue(123));
+expectError(fn(() => Promise.resolve('')).mockResolvedValue());
+
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockResolvedValueOnce('Mock value'),
+);
+expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce(123));
+expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce());
+
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockRejectedValue(new Error('Mock error')),
+);
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockRejectedValue('Mock error'),
+);
+expectError(fn(() => Promise.resolve('')).mockRejectedValue());
+
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockRejectedValueOnce(new Error('Mock error')),
+);
+expectType<Mock<Promise<string>, []>>(
+  fn(() => Promise.resolve('')).mockRejectedValueOnce('Mock error'),
+);
+expectError(fn(() => Promise.resolve('')).mockRejectedValueOnce());
+
+// jest.spyOn()
+
+const spiedArray = ['a', 'b'];
+
+const spiedFunction = () => {};
+
+const spiedObject = {
+  _propertyB: false,
+
+  methodA() {
+    return true;
+  },
+  methodB(a: string, b: number) {
+    return;
+  },
+  methodC(e: any) {
+    throw new Error();
+  },
+
+  propertyA: 'abc',
+
+  set propertyB(value) {
+    this._propertyB = value;
+  },
+  get propertyB() {
+    return this._propertyB;
+  },
+};
+
+const spy = spyOn(spiedObject, 'methodA');
+
+expectNotAssignable<Function>(spy); // eslint-disable-line @typescript-eslint/ban-types
+expectError(spy());
+expectError(new spy());
+
+expectType<SpyInstance<boolean, []>>(spyOn(spiedObject, 'methodA'));
+expectType<SpyInstance<void, [a: string, b: number]>>(
+  spyOn(spiedObject, 'methodB'),
+);
+expectType<SpyInstance<never, [e: any]>>(spyOn(spiedObject, 'methodC'));
+
+expectType<SpyInstance<boolean, []>>(spyOn(spiedObject, 'propertyB', 'get'));
+expectType<SpyInstance<void, [boolean]>>(
+  spyOn(spiedObject, 'propertyB', 'set'),
+);
+expectError(spyOn(spiedObject, 'propertyB'));
+expectError(spyOn(spiedObject, 'methodB', 'get'));
+expectError(spyOn(spiedObject, 'methodB', 'set'));
+
+expectType<SpyInstance<string, []>>(spyOn(spiedObject, 'propertyA', 'get'));
+expectType<SpyInstance<void, [string]>>(spyOn(spiedObject, 'propertyA', 'set'));
+expectError(spyOn(spiedObject, 'propertyA'));
+
+expectError(spyOn(spiedObject, 'notThere'));
+expectError(spyOn('abc', 'methodA'));
+expectError(spyOn(123, 'methodA'));
+expectError(spyOn(true, 'methodA'));
+expectError(spyOn(spiedObject));
+expectError(spyOn());
+
+expectType<SpyInstance<boolean, [arg: any]>>(
+  spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
+);
+expectError(spyOn(spiedArray, 'isArray'));
+
+expectType<SpyInstance<string, []>>(
+  spyOn(spiedFunction as unknown as Function, 'toString'), // eslint-disable-line @typescript-eslint/ban-types
+);
+expectError(spyOn(spiedFunction, 'toString'));
+
+expectType<SpyInstance<Date, [value: string | number | Date]>>(
+  spyOn(globalThis, 'Date'),
+);
+expectType<SpyInstance<number, []>>(spyOn(Date, 'now'));

--- a/packages/jest-mock/__typetests__/tsconfig.json
+++ b/packages/jest-mock/__typetests__/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+
+    "types": []
+  },
+  "include": ["./**/*"]
+}

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -6,13 +6,6 @@
     "url": "https://github.com/facebook/jest.git",
     "directory": "packages/jest-mock"
   },
-  "engines": {
-    "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
-  },
-  "dependencies": {
-    "@jest/types": "^28.0.0-alpha.4",
-    "@types/node": "*"
-  },
   "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
@@ -22,6 +15,17 @@
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"
+  },
+  "dependencies": {
+    "@jest/types": "^28.0.0-alpha.3",
+    "@types/node": "*"
+  },
+  "devDependencies": {
+    "@tsd/typescript": "~4.5.5",
+    "tsd-lite": "^0.5.1"
+  },
+  "engines": {
+    "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -17,7 +17,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@jest/types": "^28.0.0-alpha.3",
+    "@jest/types": "^28.0.0-alpha.4",
     "@types/node": "*"
   },
   "devDependencies": {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -115,8 +115,8 @@ export interface SpyInstance<T, Y extends Array<unknown>>
 export interface MockInstance<T, Y extends Array<unknown>> {
   _isMockFunction: true;
   _protoImpl: Function;
+  getMockImplementation(): ((...args: Y) => T) | undefined;
   getMockName(): string;
-  getMockImplementation(): Function | undefined;
   mock: MockFunctionState<T, Y>;
   mockClear(): this;
   mockReset(): this;
@@ -716,7 +716,8 @@ export class ModuleMocker {
         mockConstructor,
       ) as unknown as Mock<T, Y>;
       f._isMockFunction = true;
-      f.getMockImplementation = () => this._ensureMockConfig(f).mockImpl;
+      f.getMockImplementation = () =>
+        this._ensureMockConfig(f).mockImpl as unknown as (...args: Y) => T;
 
       if (typeof restore === 'function') {
         this._spyState.add(restore);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -122,8 +122,10 @@ export interface MockInstance<T, Y extends Array<unknown>> {
   mockReset(): this;
   mockRestore(): void;
   mockImplementation(fn: (...args: Y) => T): this;
+  /** @internal */
   mockImplementation(fn: () => Promise<T>): this;
   mockImplementationOnce(fn: (...args: Y) => T): this;
+  /** @internal */
   mockImplementationOnce(fn: () => Promise<T>): this;
   mockName(name: string): this;
   mockReturnThis(): this;
@@ -137,43 +139,58 @@ export interface MockInstance<T, Y extends Array<unknown>> {
 
 type Unpromisify<T> = T extends Promise<infer R> ? R : never;
 
-/**
- * Possible types of a MockFunctionResult.
- * 'return': The call completed by returning normally.
- * 'throw': The call completed by throwing a value.
- * 'incomplete': The call has not completed yet. This is possible if you read
- *               the  mock function result from within the mock function itself
- *               (or a function called by the mock function).
- */
-type MockFunctionResultType = 'return' | 'throw' | 'incomplete';
-
-/**
- * Represents the result of a single call to a mock function.
- */
-type MockFunctionResult = {
+type MockFunctionResultIncomplete = {
+  type: 'incomplete';
   /**
-   * Indicates how the call completed.
+   * Result of a single call to a mock function that has not yet completed.
+   * This occurs if you test the result from within the mock function itself,
+   * or from within a function that was called by the mock.
    */
-  type: MockFunctionResultType;
+  value: undefined;
+};
+type MockFunctionResultReturn<T> = {
+  type: 'return';
   /**
-   * The value that was either thrown or returned by the function.
-   * Undefined when type === 'incomplete'.
+   * Result of a single call to a mock function that returned.
+   */
+  value: T;
+};
+type MockFunctionResultThrow = {
+  type: 'throw';
+  /**
+   * Result of a single call to a mock function that threw.
    */
   value: unknown;
 };
 
+type MockFunctionResult<T> =
+  | MockFunctionResultIncomplete
+  | MockFunctionResultReturn<T>
+  | MockFunctionResultThrow;
+
 type MockFunctionState<T, Y extends Array<unknown>> = {
+  /**
+   * List of the call arguments of all calls that have been made to the mock.
+   */
   calls: Array<Y>;
+  /**
+   * List of all the object instances that have been instantiated from the mock.
+   */
   instances: Array<T>;
+  /**
+   * List of the call order indexes of the mock. Jest is indexing the order of
+   * invocations of all mocks in a test file. The index is starting with `1`.
+   */
   invocationCallOrder: Array<number>;
   /**
-   * Getter for retrieving the last call arguments
+   * List of the call arguments of the last call that was made to the mock.
+   * If the function was not called, it will return `undefined`.
    */
   lastCall?: Y;
   /**
-   * List of results of calls to the mock function.
+   * List of the results of all calls that have been made to the mock.
    */
-  results: Array<MockFunctionResult>;
+  results: Array<MockFunctionResult<T>>;
 };
 
 type MockFunctionConfig = {
@@ -615,7 +632,7 @@ export class ModuleMocker {
         // calling rather than waiting for the mock to return. This avoids
         // issues caused by recursion where results can be recorded in the
         // wrong order.
-        const mockResult: MockFunctionResult = {
+        const mockResult: MockFunctionResult<unknown> = {
           type: 'incomplete',
           value: undefined,
         };
@@ -686,6 +703,7 @@ export class ModuleMocker {
           // NOTE: Intentionally NOT pushing/indexing into the array of mock
           //       results here to avoid corrupting results data if mockClear()
           //       is called during the execution of the mock.
+          // @ts-expect-error reassigning 'incomplete'
           mockResult.type = callDidThrowError ? 'throw' : 'return';
           mockResult.value = callDidThrowError ? thrownError : finalReturnValue;
         }
@@ -993,11 +1011,17 @@ export class ModuleMocker {
   }
 
   isMockFunction<T, Y extends Array<unknown> = Array<unknown>>(
+    fn: Mock<T, Y>,
+  ): fn is Mock<T, Y>;
+  isMockFunction<T, Y extends Array<unknown> = Array<unknown>>(
+    fn: SpyInstance<T, Y>,
+  ): fn is SpyInstance<T, Y>;
+  isMockFunction<T, Y extends Array<unknown> = Array<unknown>>(
     fn: (...args: Y) => T,
   ): fn is Mock<T, Y>;
   isMockFunction(fn: unknown): fn is Mock<unknown>;
   isMockFunction<T>(fn: unknown): fn is Mock<T> {
-    return !!fn && (fn as any)._isMockFunction === true;
+    return !!fn && (fn as Mock<unknown>)._isMockFunction === true;
   }
 
   fn<T, Y extends Array<unknown>>(
@@ -1023,7 +1047,7 @@ export class ModuleMocker {
     accessType: 'set',
   ): SpyInstance<void, [T[M]]>;
 
-  spyOn<T extends object, M extends ConstructorPropertyNames<Required<T>>>(
+  spyOn<T extends object, M extends ConstructorPropertyNames<T>>(
     object: T,
     methodName: M,
   ): T[M] extends new (...args: Array<any>) => any

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -7,7 +7,7 @@
 
 import {expectError, expectType} from 'tsd-lite';
 import {jest} from '@jest/globals';
-import type {Mock, SpyInstance} from 'jest-mock';
+import type {Mock, ModuleMocker, SpyInstance, fn, spyOn} from 'jest-mock';
 
 expectType<typeof jest>(
   jest
@@ -121,6 +121,12 @@ expectError(jest.unmock());
 expectType<typeof jest>(jest.clearAllMocks());
 expectError(jest.clearAllMocks('moduleName'));
 
+expectType<typeof jest>(jest.resetAllMocks());
+expectError(jest.resetAllMocks(true));
+
+expectType<typeof jest>(jest.restoreAllMocks());
+expectError(jest.restoreAllMocks(false));
+
 expectType<boolean>(jest.isMockFunction(() => {}));
 expectError(jest.isMockFunction());
 
@@ -150,128 +156,58 @@ if (!jest.isMockFunction(surelyMock)) {
   expectType<never>(surelyMock);
 }
 
-declare const stringMaybeMock: string;
+const spiedObject = {
+  methodA(a: number, b: string) {
+    return true;
+  },
+};
 
-if (!jest.isMockFunction(stringMaybeMock)) {
-  expectType<string>(stringMaybeMock);
+const surelySpy = jest.spyOn(spiedObject, 'methodA');
+
+if (jest.isMockFunction(surelySpy)) {
+  expectType<SpyInstance<boolean, [a: number, b: string]>>(surelySpy);
+
+  surelySpy.mockReturnValueOnce(false);
+  expectError(surelyMock.mockReturnValueOnce(123));
 }
+
+if (!jest.isMockFunction(surelySpy)) {
+  expectType<never>(surelySpy);
+}
+
+declare const stringMaybeMock: string;
 
 if (jest.isMockFunction(stringMaybeMock)) {
   expectType<string & Mock<unknown, Array<unknown>>>(stringMaybeMock);
 }
 
-declare const anyMaybeMock: any;
-
-if (!jest.isMockFunction(anyMaybeMock)) {
-  expectType<any>(anyMaybeMock);
+if (!jest.isMockFunction(stringMaybeMock)) {
+  expectType<string>(stringMaybeMock);
 }
+
+declare const anyMaybeMock: any;
 
 if (jest.isMockFunction(anyMaybeMock)) {
   expectType<Mock<unknown, Array<unknown>>>(anyMaybeMock);
 }
 
-declare const unknownMaybeMock: unknown;
-
-if (!jest.isMockFunction(unknownMaybeMock)) {
-  expectType<unknown>(unknownMaybeMock);
+if (!jest.isMockFunction(anyMaybeMock)) {
+  expectType<any>(anyMaybeMock);
 }
+
+declare const unknownMaybeMock: unknown;
 
 if (jest.isMockFunction(unknownMaybeMock)) {
   expectType<Mock<unknown, Array<unknown>>>(unknownMaybeMock);
 }
 
-expectType<Mock<unknown>>(jest.fn());
-expectType<Mock<void, []>>(jest.fn(() => {}));
-expectType<Mock<boolean, [a: string, b: number]>>(
-  jest.fn((a: string, b: number) => true),
-);
-expectType<Mock<never, [e: any]>>(
-  jest.fn((e: any) => {
-    throw new Error();
-  }),
-);
-expectError(jest.fn('moduleName'));
+if (!jest.isMockFunction(unknownMaybeMock)) {
+  expectType<unknown>(unknownMaybeMock);
+}
 
-expectType<typeof jest>(jest.resetAllMocks());
-expectError(jest.resetAllMocks(true));
+expectType<ModuleMocker['fn']>(jest.fn);
 
-expectType<typeof jest>(jest.restoreAllMocks());
-expectError(jest.restoreAllMocks(false));
-
-const spiedArray = ['a', 'b'];
-
-const spiedFunction = () => {};
-
-spiedFunction.toString();
-
-const spiedObject = {
-  _propertyB: false,
-
-  methodA() {
-    return true;
-  },
-  methodB(a: string, b: number) {
-    return;
-  },
-  methodC(e: any) {
-    throw new Error();
-  },
-
-  propertyA: 'abc',
-
-  set propertyB(value) {
-    this._propertyB = value;
-  },
-  get propertyB() {
-    return this._propertyB;
-  },
-};
-
-expectType<SpyInstance<boolean, []>>(jest.spyOn(spiedObject, 'methodA'));
-expectType<SpyInstance<void, [a: string, b: number]>>(
-  jest.spyOn(spiedObject, 'methodB'),
-);
-expectType<SpyInstance<never, [e: any]>>(jest.spyOn(spiedObject, 'methodC'));
-
-expectType<SpyInstance<boolean, []>>(
-  jest.spyOn(spiedObject, 'propertyB', 'get'),
-);
-expectType<SpyInstance<void, [boolean]>>(
-  jest.spyOn(spiedObject, 'propertyB', 'set'),
-);
-expectError(jest.spyOn(spiedObject, 'propertyB'));
-expectError(jest.spyOn(spiedObject, 'methodB', 'get'));
-expectError(jest.spyOn(spiedObject, 'methodB', 'set'));
-
-expectType<SpyInstance<string, []>>(
-  jest.spyOn(spiedObject, 'propertyA', 'get'),
-);
-expectType<SpyInstance<void, [string]>>(
-  jest.spyOn(spiedObject, 'propertyA', 'set'),
-);
-expectError(jest.spyOn(spiedObject, 'propertyA'));
-
-expectError(jest.spyOn(spiedObject, 'notThere'));
-expectError(jest.spyOn('abc', 'methodA'));
-expectError(jest.spyOn(123, 'methodA'));
-expectError(jest.spyOn(true, 'methodA'));
-expectError(jest.spyOn(spiedObject));
-expectError(jest.spyOn());
-
-expectType<SpyInstance<boolean, [arg: any]>>(
-  jest.spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
-);
-expectError(jest.spyOn(spiedArray, 'isArray'));
-
-expectType<SpyInstance<string, []>>(
-  jest.spyOn(spiedFunction as unknown as Function, 'toString'), // eslint-disable-line @typescript-eslint/ban-types
-);
-expectError(jest.spyOn(spiedFunction, 'toString'));
-
-expectType<SpyInstance<Date, [value: string | number | Date]>>(
-  jest.spyOn(globalThis, 'Date'),
-);
-expectType<SpyInstance<number, []>>(jest.spyOn(Date, 'now'));
+expectType<ModuleMocker['spyOn']>(jest.spyOn);
 
 // Mock Timers
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,7 +2858,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jest/types@^28.0.0-alpha.3, @jest/types@^28.0.0-alpha.4, @jest/types@workspace:packages/jest-types":
+"@jest/types@^28.0.0-alpha.4, @jest/types@workspace:packages/jest-types":
   version: 0.0.0-use.local
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
@@ -13210,7 +13210,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
-    "@jest/types": ^28.0.0-alpha.3
+    "@jest/types": ^28.0.0-alpha.4
     "@tsd/typescript": ~4.5.5
     "@types/node": "*"
     tsd-lite: ^0.5.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,7 +2858,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jest/types@^28.0.0-alpha.4, @jest/types@workspace:packages/jest-types":
+"@jest/types@^28.0.0-alpha.3, @jest/types@^28.0.0-alpha.4, @jest/types@workspace:packages/jest-types":
   version: 0.0.0-use.local
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
@@ -13210,8 +13210,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
-    "@jest/types": ^28.0.0-alpha.4
+    "@jest/types": ^28.0.0-alpha.3
+    "@tsd/typescript": ~4.5.5
     "@types/node": "*"
+    tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

As agreed https://github.com/facebook/jest/pull/12442#discussion_r810883683, I moved `jest.fn` and `jest.spyOn` type tests to `jest-mock`. Also added tests for all Mock Function methods and props. Took some time to understand some details. To make it all work I had to refactor `MockFunctionResult` type.

## Test plan

Current tests and new tests should pass.