### PR TITLE
`jest-mock` Add `hasAnyMocks` method

### DIFF
--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -521,6 +521,8 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting all mocks', () => {
+        expect(moduleMocker.hasAnyMocks()).toEqual(false);
+
         const fn1 = moduleMocker.fn();
         fn1.mockImplementation(() => 'abcd');
         fn1(1, 2, 3);
@@ -531,7 +533,10 @@ describe('moduleMocker', () => {
         fn2('a', 'b', 'c');
         expect(fn2.mock.calls).toEqual([['a', 'b', 'c']]);
 
+        expect(moduleMocker.hasAnyMocks()).toEqual(true);
+
         moduleMocker.resetAllMocks();
+        expect(moduleMocker.hasAnyMocks()).toEqual(false);
         expect(fn1.mock.calls).toEqual([]);
         expect(fn2.mock.calls).toEqual([]);
         expect(fn1()).not.toEqual('abcd');

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1192,6 +1192,10 @@ export class ModuleMocker {
     this._mockState = new WeakMap();
   }
 
+  hasAnyMocks(): boolean {
+    return this._mockConfigRegistry.size > 0 || this._mockState.size > 0;
+  }
+
   restoreAllMocks(): void {
     this._spyState.forEach(restore => restore());
     this._spyState = new Set();


### PR DESCRIPTION
## Summary

It's nice to be able to see if any mocks have been set to be able to check if mocks are lingering in an `after` hook. Allows you to do things like:

```js
afterAll(() => {
   if(jest.hasAnyMocks()) {
       console.error("Hey it looks like you've mocked something and forgotten to reset it")
    }
  });
```

## Test plan

I think the tests speak for themselves.
