### PR TITLE
chore: improve Jest Object’s TSDoc comments

### DIFF
--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -46,8 +46,15 @@ export type Module = NodeModule;
 // TODO: Move to some separate package
 export interface Jest {
   /**
-   * Advances all timers by the needed milliseconds so that only the next timeouts/intervals will run.
-   * Optionally, you can provide steps, so it will run steps amount of next timeouts/intervals.
+   * Advances all timers by `msToRun` milliseconds. All pending "macro-tasks"
+   * that have been queued via `setTimeout()` or `setInterval()`, and would be
+   * executed within this time frame will be executed.
+   */
+  advanceTimersByTime(msToRun: number): void;
+  /**
+   * Advances all timers by the needed milliseconds so that only the next
+   * timeouts/intervals will run. Optionally, you can provide steps, so it will
+   * run steps amount of next timeouts/intervals.
    */
   advanceTimersToNextTimer(steps?: number): void;
   /**
@@ -59,8 +66,8 @@ export interface Jest {
    */
   autoMockOn(): Jest;
   /**
-   * Clears the mock.calls and mock.instances properties of all mocks.
-   * Equivalent to calling .mockClear() on every mocked function.
+   * Clears the `mock.calls`, `mock.instances` and `mock.results` properties of
+   * all mocks. Equivalent to calling `.mockClear()` on every mocked function.
    */
   clearAllMocks(): Jest;
   /**
@@ -70,9 +77,16 @@ export interface Jest {
    */
   clearAllTimers(): void;
   /**
-   * Indicates that the module system should never return a mocked version
-   * of the specified module, including all of the specified module's
-   * dependencies.
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   *
+   * This is useful when you want to create a manual mock that extends the
+   * automatic mock's behavior.
+   */
+  createMockFromModule(moduleName: string): unknown;
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module and its dependencies.
    */
   deepUnmock(moduleName: string): Jest;
   /**
@@ -83,9 +97,9 @@ export interface Jest {
    */
   disableAutomock(): Jest;
   /**
-   * When using `babel-jest`, calls to mock will automatically be hoisted to
-   * the top of the code block. Use this method if you want to explicitly avoid
-   * this behavior.
+   * When using `babel-jest`, calls to `jest.mock()` will automatically be hoisted
+   * to the top of the code block. Use this method if you want to explicitly
+   * avoid this behavior.
    */
   doMock(
     moduleName: string,
@@ -93,9 +107,9 @@ export interface Jest {
     options?: {virtual?: boolean},
   ): Jest;
   /**
-   * Indicates that the module system should never return a mocked version
-   * of the specified module from require() (e.g. that it should always return
-   * the real module).
+   * When using `babel-jest`, calls to `jest.unmock()` will automatically be hoisted
+   * to the top of the code block. Use this method if you want to explicitly
+   * avoid this behavior.
    */
   dontMock(moduleName: string): Jest;
   /**
@@ -117,17 +131,28 @@ export interface Jest {
    */
   genMockFromModule(moduleName: string): unknown;
   /**
-   * Given the name of a module, use the automatic mocking system to generate a
-   * mocked version of the module for you.
+   * When mocking time, `Date.now()` will also be mocked. If you for some reason
+   * need access to the real current time, you can invoke this function.
    *
-   * This is useful when you want to create a manual mock that extends the
-   * automatic mock's behavior.
+   * @remarks
+   * Only available when using 'modern' fake timers implementation.
    */
-  createMockFromModule(moduleName: string): unknown;
+  getRealSystemTime(): number;
+  /**
+   * Returns the number of fake timers still left to run.
+   */
+  getTimerCount(): number;
   /**
    * Determines if the given function is a mocked function.
    */
   isMockFunction: ModuleMocker['isMockFunction'];
+  /**
+   * `jest.isolateModules()` goes a step further than `jest.resetModules()` and
+   * creates a sandbox registry for the modules that are loaded inside the callback
+   * function. This is useful to isolate specific modules for every test so that
+   * local module state doesn't conflict between tests.
+   */
+  isolateModules(fn: () => void): Jest;
   /**
    * Mocks a module with an auto-mocked version when it is being required.
    */
@@ -139,32 +164,33 @@ export interface Jest {
   /**
    * Mocks a module with the provided module factory when it is being imported.
    */
-  unstable_mockModule<T = unknown>(
+  unstable_mockModule(
     moduleName: string,
-    moduleFactory: () => Promise<T> | T,
+    moduleFactory: () => Promise<unknown> | unknown,
     options?: {virtual?: boolean},
   ): Jest;
   /**
-   * Returns the actual module instead of a mock, bypassing all checks on
-   * whether the module should receive a mock implementation or not.
-   *
-   * @example
-   ```
-    jest.mock('../myModule', () => {
-    // Require the original module to not be mocked...
-    const originalModule = jest.requireActual(moduleName);
-      return {
-        __esModule: true, // Use it when dealing with esModules
-        ...originalModule,
-        getRandom: jest.fn().mockReturnValue(10),
-      };
-    });
+    * Returns the actual module instead of a mock, bypassing all checks on
+    * whether the module should receive a mock implementation or not.
+    *
+    * @example
+    ```js
+     jest.mock('../myModule', () => {
+     // Require the original module to not be mocked...
+     const originalModule = jest.requireActual('../myModule');
 
-    const getRandom = require('../myModule').getRandom;
+       return {
+         __esModule: true, // Use it when dealing with esModules
+         ...originalModule,
+         getRandom: jest.fn().mockReturnValue(10),
+       };
+     });
 
-    getRandom(); // Always returns 10
-    ```
-   */
+     const getRandom = require('../myModule').getRandom;
+
+     getRandom(); // Always returns 10
+     ```
+    */
   requireActual: (moduleName: string) => unknown;
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
@@ -172,8 +198,8 @@ export interface Jest {
    */
   requireMock: (moduleName: string) => unknown;
   /**
-   * Resets the state of all mocks.
-   * Equivalent to calling .mockReset() on every mocked function.
+   * Resets the state of all mocks. Equivalent to calling `.mockReset()` on
+   * every mocked function.
    */
   resetAllMocks(): Jest;
   /**
@@ -183,79 +209,90 @@ export interface Jest {
   resetModules(): Jest;
   /**
    * Restores all mocks back to their original value. Equivalent to calling
-   * `.mockRestore` on every mocked function.
+   * `.mockRestore()` on every mocked function.
    *
-   * Beware that jest.restoreAllMocks() only works when the mock was created with
-   * jest.spyOn; other mocks will require you to manually restore them.
+   * Beware that `jest.restoreAllMocks()` only works when the mock was created
+   * with `jest.spyOn()`; other mocks will require you to manually restore them.
    */
   restoreAllMocks(): Jest;
+  /**
+   * Wraps an object or a module with mock type definitions.
+   */
   mocked: ModuleMocker['mocked'];
   /**
    * Runs failed tests n-times until they pass or until the max number of
-   * retries is exhausted. This only works with `jest-circus`!
+   * retries is exhausted.
+   *
+   * @remarks
+   * Only available with `jest-circus` runner.
    */
   retryTimes(numRetries: number): Jest;
   /**
-   * Exhausts tasks queued by setImmediate().
+   * Exhausts tasks queued by `setImmediate()`.
    *
-   * > Note: This function is not available when using Lolex as fake timers implementation
+   * @remarks
+   * Not available when using 'modern' timers implementation.
    */
   runAllImmediates(): void;
   /**
    * Exhausts the micro-task queue (usually interfaced in node via
-   * process.nextTick).
+   * `process.nextTick()`).
    */
   runAllTicks(): void;
   /**
-   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout()
-   * and setInterval()).
+   * Exhausts the macro-task queue (i.e., all tasks queued by `setTimeout()`
+   * and `setInterval()`).
    */
   runAllTimers(): void;
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
-   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * tasks that have been queued by `setTimeout()` or `setInterval()` up to this
    * point). If any of the currently pending macro-tasks schedule new
    * macro-tasks, those new tasks will not be executed by this call.
    */
   runOnlyPendingTimers(): void;
   /**
-   * Advances all timers by msToRun milliseconds. All pending "macro-tasks"
-   * that have been queued via setTimeout() or setInterval(), and would be
-   * executed within this timeframe will be executed.
-   */
-  advanceTimersByTime(msToRun: number): void;
-  /**
-   * Returns the number of fake timers still left to run.
-   */
-  getTimerCount(): number;
-  /**
    * Explicitly supplies the mock object that the module system should return
    * for the specified module.
    *
-   * Note It is recommended to use `jest.mock()` instead. The `jest.mock`
-   * API's second argument is a module factory instead of the expected
-   * exported module object.
+   * @remarks
+   * It is recommended to use `jest.mock()` instead. The `jest.mock()` API's second
+   * argument is a module factory instead of the expected exported module object.
    */
   setMock(moduleName: string, moduleExports: unknown): Jest;
+  /**
+   * Set the current system time used by fake timers. Simulates a user changing
+   * the system clock while your program is running. It affects the current time,
+   * but it does not in itself cause e.g. timers to fire; they will fire exactly
+   * as they would have done without the call to `jest.setSystemTime()`.
+   *
+   * @remarks
+   * Only available when using 'modern' fake timers implementation.
+   */
+  setSystemTime(now?: number | Date): void;
   /**
    * Set the default timeout interval for tests and before/after hooks in
    * milliseconds.
    *
-   * Note: The default timeout interval is 5 seconds if this method is not
-   * called.
+   * @remarks
+   * The default timeout interval is 5 seconds if this method is not called.
    */
   setTimeout(timeout: number): Jest;
   /**
-   * Creates a mock function similar to `jest.fn` but also tracks calls to
+   * Creates a mock function similar to `jest.fn()` but also tracks calls to
    * `object[methodName]`.
    *
-   * Note: By default, jest.spyOn also calls the spied method. This is
-   * different behavior from most other test libraries.
+   * Optional third argument of `accessType` can be either 'get' or 'set', which
+   * proves to be useful when you want to spy on a getter or a setter, respectively.
+   *
+   * @remarks
+   * By default, `jest.spyOn()` also calls the spied method. This is different
+   * behavior from most other test libraries.
    */
   spyOn: ModuleMocker['spyOn'];
   /**
    * Indicates that the module system should never return a mocked version of
-   * the specified module from require() (e.g. that it should always return the
+   * the specified module from `require()` (e.g. that it should always return the
    * real module).
    */
   unmock(moduleName: string): Jest;
@@ -267,25 +304,4 @@ export interface Jest {
    * Instructs Jest to use the real versions of the standard timer functions.
    */
   useRealTimers(): Jest;
-  /**
-   * `jest.isolateModules(fn)` goes a step further than `jest.resetModules()`
-   * and creates a sandbox registry for the modules that are loaded inside
-   * the callback function. This is useful to isolate specific modules for
-   * every test so that local module state doesn't conflict between tests.
-   */
-  isolateModules(fn: () => void): Jest;
-
-  /**
-   * When mocking time, `Date.now()` will also be mocked. If you for some reason need access to the real current time, you can invoke this function.
-   *
-   * > Note: This function is only available when using Lolex as fake timers implementation
-   */
-  getRealSystemTime(): number;
-
-  /**
-   *  Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
-   *
-   *  > Note: This function is only available when using Lolex as fake timers implementation
-   */
-  setSystemTime(now?: number | Date): void;
 }

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -164,9 +164,9 @@ export interface Jest {
   /**
    * Mocks a module with the provided module factory when it is being imported.
    */
-  unstable_mockModule(
+  unstable_mockModule<T = unknown>(
     moduleName: string,
-    moduleFactory: () => Promise<unknown> | unknown,
+    moduleFactory: () => Promise<T> | T,
     options?: {virtual?: boolean},
   ): Jest;
   /**


### PR DESCRIPTION
## Summary

Few refactors / improvements in Jest Object’s type declaration and TSDoc comments:

- alphabetic order of all members
- style (e.g. back ticks around methods and props, methods of the Jest Object always prefixed with `jest`)
- `@remarks` tags for additional notes
- few minor changes in text

## Test plan

Green CI.