### PR TITLE
[expect] Protect against undefined `matcher` when extending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[jest-jasmine2, jest-types]` [**BREAKING**] Move all `jasmine` specific types from `@jest/types` to its own package ([#12125](https://github.com/facebook/jest/pull/12125))
 - `[jest-matcher-utils]` Pass maxWidth to `pretty-format` to avoid printing every element in arrays by default ([#12402](https://github.com/facebook/jest/pull/12402))
 - `[jest-mock]` Fix function overloads for `spyOn` to allow more correct type inference in complex object ([#12442](https://github.com/facebook/jest/pull/12442))
+- `[expect]` Protect against undefined `matcher` when extending ([#12481](https://github.com/facebook/jest/pull/12481))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/extend.test.ts
+++ b/packages/expect/src/__tests__/extend.test.ts
@@ -184,3 +184,11 @@ it('allows overriding existing extension', () => {
 
   jestExpect('foo').toAllowOverridingExistingMatcher();
 });
+
+it('does not explode if matcher is undefined', () => {
+  expect(() =>
+    jestExpect.extend({
+      default: undefined,
+    }),
+  ).not.toThrow();
+});

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -56,6 +56,9 @@ export const setMatchers = (
 ): void => {
   Object.keys(matchers).forEach(key => {
     const matcher = matchers[key];
+
+    if (!matcher) return;
+
     Object.defineProperty(matcher, INTERNAL_MATCHER_FLAG, {
       value: isInternal,
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes an issue when `import * as matchers from 'my-matchers';` includes a `default` import whose value is `undefined`, as is happening in https://github.com/storybookjs/jest/issues/15.  It just adds a bit of safety to be sure that the matcher is defined, before trying to add it.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
 
I added a unit test which fails without this change.