### PR TITLE
chore: fix `cleanE2e` script

### DIFF
--- a/scripts/cleanE2e.js
+++ b/scripts/cleanE2e.js
@@ -19,6 +19,7 @@ const excludedModules = [
   'e2e/presets/json/node_modules/',
   'e2e/presets/mjs/node_modules/',
   'e2e/resolve-conditions/node_modules/',
+  'e2e/retain-all-files/node_modules/',
 ].map(dir => normalize(dir));
 
 const e2eNodeModules = glob('e2e/*/node_modules/')


### PR DESCRIPTION
## Summary

Found accidentally. The `cleanE2e` script is discarding recently added [e2e/retain-all-files/node_modules/retainAllFiles.test.js](https://github.com/facebook/jest/blob/main/e2e/retain-all-files/node_modules/retainAllFiles.test.js), but it shouldn’t.

## Test plan

N/A
