### PR TITLE
refactor(jest-mock)!: simplify usage of `jest.fn` generic type arguments

### DIFF
--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -15,12 +15,12 @@ import {Mock, SpyInstance, fn, spyOn} from 'jest-mock';
 
 // jest.fn()
 
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(async () => 'value')
     .mockClear()
     .mockReset()
-    .mockImplementation(fn())
-    .mockImplementationOnce(fn())
+    .mockImplementation(async () => 'value')
+    .mockImplementationOnce(async () => 'value')
     .mockName('mock')
     .mockReturnThis()
     .mockReturnValue(Promise.resolve('value'))
@@ -33,12 +33,12 @@ expectType<Mock<Promise<string>, []>>(
 
 expectAssignable<Function>(fn()); // eslint-disable-line @typescript-eslint/ban-types
 
-expectType<Mock<unknown>>(fn());
-expectType<Mock<void, []>>(fn(() => {}));
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(...args: Array<unknown>) => unknown>>(fn());
+expectType<Mock<() => void>>(fn(() => {}));
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   fn((a: string, b?: number) => true),
 );
-expectType<Mock<never, [e: any]>>(
+expectType<Mock<(e: any) => never>>(
   fn((e: any) => {
     throw new Error();
   }),
@@ -63,7 +63,7 @@ const MockObject = fn((credentials: string) => ({
 }));
 
 expectType<{
-  connect(): Mock<unknown, Array<unknown>>;
+  connect(): Mock<(...args: Array<unknown>) => unknown>;
   disconnect(): void;
 }>(new MockObject('credentials'));
 expectError(new MockObject());
@@ -92,7 +92,7 @@ expectType<Array<number>>(mockFn.mock.invocationCallOrder);
 
 expectType<
   Array<{
-    connect(): Mock<unknown, Array<unknown>>;
+    connect(): Mock<(...args: Array<unknown>) => unknown>;
     disconnect(): void;
   }>
 >(MockObject.mock.instances);
@@ -114,12 +114,12 @@ if (returnValue.type === 'throw') {
   expectType<unknown>(returnValue.value);
 }
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockClear(),
 );
 expectError(mockFn.mockClear('some-mock'));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockReset(),
 );
 expectError(mockFn.mockClear('some-mock'));
@@ -127,7 +127,7 @@ expectError(mockFn.mockClear('some-mock'));
 expectType<void>(mockFn.mockRestore());
 expectError(mockFn.mockClear('some-mock'));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockImplementation((a, b) => {
     expectType<string>(a);
     expectType<number | undefined>(b);
@@ -138,7 +138,7 @@ expectError(mockFn.mockImplementation((a: number) => false));
 expectError(mockFn.mockImplementation(a => 'false'));
 expectError(mockFn.mockImplementation());
 
-expectType<Mock<Promise<string>, [p: boolean]>>(
+expectType<Mock<(p: boolean) => Promise<string>>>(
   mockAsyncFn.mockImplementation(async a => {
     expectType<boolean>(a);
     return 'mock value';
@@ -146,7 +146,7 @@ expectType<Mock<Promise<string>, [p: boolean]>>(
 );
 expectError(mockAsyncFn.mockImplementation(a => 'mock value'));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockImplementationOnce((a, b) => {
     expectType<string>(a);
     expectType<number | undefined>(b);
@@ -157,7 +157,7 @@ expectError(mockFn.mockImplementationOnce((a: number) => false));
 expectError(mockFn.mockImplementationOnce(a => 'false'));
 expectError(mockFn.mockImplementationOnce());
 
-expectType<Mock<Promise<string>, [p: boolean]>>(
+expectType<Mock<(p: boolean) => Promise<string>>>(
   mockAsyncFn.mockImplementationOnce(async a => {
     expectType<boolean>(a);
     return 'mock value';
@@ -165,63 +165,63 @@ expectType<Mock<Promise<string>, [p: boolean]>>(
 );
 expectError(mockAsyncFn.mockImplementationOnce(a => 'mock value'));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockName('mockedFunction'),
 );
 expectError(mockFn.mockName(123));
 expectError(mockFn.mockName());
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockReturnThis(),
 );
 expectError(mockFn.mockReturnThis('this'));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockReturnValue(false),
 );
 expectError(mockFn.mockReturnValue('true'));
 expectError(mockFn.mockReturnValue());
 
-expectType<Mock<Promise<string>, [p: boolean]>>(
+expectType<Mock<(p: boolean) => Promise<string>>>(
   mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
 );
 expectError(mockAsyncFn.mockReturnValue(Promise.resolve(true)));
 
-expectType<Mock<boolean, [a: string, b?: number | undefined]>>(
+expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
   mockFn.mockReturnValueOnce(false),
 );
 expectError(mockFn.mockReturnValueOnce('true'));
 expectError(mockFn.mockReturnValueOnce());
 
-expectType<Mock<Promise<string>, [p: boolean]>>(
+expectType<Mock<(p: boolean) => Promise<string>>>(
   mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
 );
 expectError(mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)));
 
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockResolvedValue('Mock value'),
 );
 expectError(fn(() => Promise.resolve('')).mockResolvedValue(123));
 expectError(fn(() => Promise.resolve('')).mockResolvedValue());
 
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockResolvedValueOnce('Mock value'),
 );
 expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce(123));
 expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce());
 
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockRejectedValue(new Error('Mock error')),
 );
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockRejectedValue('Mock error'),
 );
 expectError(fn(() => Promise.resolve('')).mockRejectedValue());
 
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockRejectedValueOnce(new Error('Mock error')),
 );
-expectType<Mock<Promise<string>, []>>(
+expectType<Mock<() => Promise<string>>>(
   fn(() => Promise.resolve('')).mockRejectedValueOnce('Mock error'),
 );
 expectError(fn(() => Promise.resolve('')).mockRejectedValueOnce());
@@ -261,22 +261,28 @@ expectNotAssignable<Function>(spy); // eslint-disable-line @typescript-eslint/ba
 expectError(spy());
 expectError(new spy());
 
-expectType<SpyInstance<boolean, []>>(spyOn(spiedObject, 'methodA'));
-expectType<SpyInstance<void, [a: string, b: number]>>(
+expectType<SpyInstance<typeof spiedObject.methodA>>(
+  spyOn(spiedObject, 'methodA'),
+);
+expectType<SpyInstance<typeof spiedObject.methodB>>(
   spyOn(spiedObject, 'methodB'),
 );
-expectType<SpyInstance<never, [e: any]>>(spyOn(spiedObject, 'methodC'));
+expectType<SpyInstance<typeof spiedObject.methodC>>(
+  spyOn(spiedObject, 'methodC'),
+);
 
-expectType<SpyInstance<boolean, []>>(spyOn(spiedObject, 'propertyB', 'get'));
-expectType<SpyInstance<void, [boolean]>>(
+expectType<SpyInstance<() => boolean>>(spyOn(spiedObject, 'propertyB', 'get'));
+expectType<SpyInstance<(value: boolean) => void>>(
   spyOn(spiedObject, 'propertyB', 'set'),
 );
 expectError(spyOn(spiedObject, 'propertyB'));
 expectError(spyOn(spiedObject, 'methodB', 'get'));
 expectError(spyOn(spiedObject, 'methodB', 'set'));
 
-expectType<SpyInstance<string, []>>(spyOn(spiedObject, 'propertyA', 'get'));
-expectType<SpyInstance<void, [string]>>(spyOn(spiedObject, 'propertyA', 'set'));
+expectType<SpyInstance<() => string>>(spyOn(spiedObject, 'propertyA', 'get'));
+expectType<SpyInstance<(value: string) => void>>(
+  spyOn(spiedObject, 'propertyA', 'set'),
+);
 expectError(spyOn(spiedObject, 'propertyA'));
 
 expectError(spyOn(spiedObject, 'notThere'));
@@ -286,17 +292,17 @@ expectError(spyOn(true, 'methodA'));
 expectError(spyOn(spiedObject));
 expectError(spyOn());
 
-expectType<SpyInstance<boolean, [arg: any]>>(
+expectType<SpyInstance<(arg: any) => boolean>>(
   spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
 );
 expectError(spyOn(spiedArray, 'isArray'));
 
-expectType<SpyInstance<string, []>>(
+expectType<SpyInstance<() => string>>(
   spyOn(spiedFunction as unknown as Function, 'toString'), // eslint-disable-line @typescript-eslint/ban-types
 );
 expectError(spyOn(spiedFunction, 'toString'));
 
-expectType<SpyInstance<Date, [value: string | number | Date]>>(
+expectType<SpyInstance<(value: string | number | Date) => Date>>(
   spyOn(globalThis, 'Date'),
 );
-expectType<SpyInstance<number, []>>(spyOn(Date, 'now'));
+expectType<SpyInstance<() => number>>(spyOn(Date, 'now'));

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -193,10 +193,7 @@ export default class Runtime {
   private _isCurrentlyExecutingManualMock: string | null;
   private _mainModule: Module | null;
   private readonly _mockFactories: Map<string, () => unknown>;
-  private readonly _mockMetaDataCache: Map<
-    string,
-    MockFunctionMetadata<unknown, Array<unknown>>
-  >;
+  private readonly _mockMetaDataCache: Map<string, MockFunctionMetadata>;
   private _mockRegistry: Map<string, any>;
   private _isolatedMockRegistry: Map<string, any> | null;
   private _moduleMockRegistry: Map<string, VMModule>;

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -133,7 +133,7 @@ expectError(jest.isMockFunction());
 const maybeMock = (a: string, b: number) => true;
 
 if (jest.isMockFunction(maybeMock)) {
-  expectType<Mock<boolean, [a: string, b: number]>>(maybeMock);
+  expectType<Mock<(a: string, b: number) => boolean>>(maybeMock);
 
   maybeMock.mockReturnValueOnce(false);
   expectError(maybeMock.mockReturnValueOnce(123));
@@ -146,7 +146,7 @@ if (!jest.isMockFunction(maybeMock)) {
 const surelyMock = jest.fn((a: string, b: number) => true);
 
 if (jest.isMockFunction(surelyMock)) {
-  expectType<Mock<boolean, [a: string, b: number]>>(surelyMock);
+  expectType<Mock<(a: string, b: number) => boolean>>(surelyMock);
 
   surelyMock.mockReturnValueOnce(false);
   expectError(surelyMock.mockReturnValueOnce(123));
@@ -165,7 +165,7 @@ const spiedObject = {
 const surelySpy = jest.spyOn(spiedObject, 'methodA');
 
 if (jest.isMockFunction(surelySpy)) {
-  expectType<SpyInstance<boolean, [a: number, b: string]>>(surelySpy);
+  expectType<SpyInstance<(a: number, b: string) => boolean>>(surelySpy);
 
   surelySpy.mockReturnValueOnce(false);
   expectError(surelyMock.mockReturnValueOnce(123));
@@ -178,7 +178,9 @@ if (!jest.isMockFunction(surelySpy)) {
 declare const stringMaybeMock: string;
 
 if (jest.isMockFunction(stringMaybeMock)) {
-  expectType<string & Mock<unknown, Array<unknown>>>(stringMaybeMock);
+  expectType<string & Mock<(...args: Array<unknown>) => unknown>>(
+    stringMaybeMock,
+  );
 }
 
 if (!jest.isMockFunction(stringMaybeMock)) {
@@ -188,7 +190,7 @@ if (!jest.isMockFunction(stringMaybeMock)) {
 declare const anyMaybeMock: any;
 
 if (jest.isMockFunction(anyMaybeMock)) {
-  expectType<Mock<unknown, Array<unknown>>>(anyMaybeMock);
+  expectType<Mock<(...args: Array<unknown>) => unknown>>(anyMaybeMock);
 }
 
 if (!jest.isMockFunction(anyMaybeMock)) {
@@ -198,7 +200,7 @@ if (!jest.isMockFunction(anyMaybeMock)) {
 declare const unknownMaybeMock: unknown;
 
 if (jest.isMockFunction(unknownMaybeMock)) {
-  expectType<Mock<unknown, Array<unknown>>>(unknownMaybeMock);
+  expectType<Mock<(...args: Array<unknown>) => unknown>>(unknownMaybeMock);
 }
 
 if (!jest.isMockFunction(unknownMaybeMock)) {


### PR DESCRIPTION
Closes #12479

## Summary

`jest.fn` and `jest.spyOn` depend on `Mock` and `MockInstance` types. These take two generic type arguments: the returned value, parameters type. That works just fine internally, but makes usage hard for on the user side. For instance, here is a line from Jest docs:

```ts
const mockAdd = jest.fn() as jest.MockedFunction<typeof add>;
```

All looks fine at first glance, but the thing is that type returned by `jest.fn` is `Mock` and it is slightly different from `MockedFunction`. As it was pointed out in the link issue, to have the right type currently user should do something like this:

```ts
const mockAdd = jest.fn<ReturnType<typeof add>, Parameters<typeof add>>();
```

This PR makes it possible to type `jest.fn` in much more simple way (which is also more precise than type casting using `MockedFunction`):

```ts
const mockAdd = jest.fn<typeof add>();
```

Looks like I made it work as expected. Have to take a second look tomorrow at a couple of `any`s here and there. Seems like internally they are necessary. On user side, everything should default to `unknown`.

## Test plan

It was priceless to have type tests in place! All should pass.