### PR TITLE
docs: add README for jest-create-cache-key-function package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - `[expect]` [**BREAKING**] Snapshot matcher types are moved to `@jest/expect` ([#12404](https://github.com/facebook/jest/pull/12404))
 - `[jest-cli]` Update `yargs` to v17 ([#12357](https://github.com/facebook/jest/pull/12357))
 - `[jest-config]` [**BREAKING**] Remove `getTestEnvironment` export ([#12353](https://github.com/facebook/jest/pull/12353))
+- `[jest-create-cache-key-function]` Added README.md file with basic usage instructions ([#12492](https://github.com/facebook/jest/pull/12492))
 - `[@jest/core]` Use `index.ts` instead of `jest.ts` as main export ([#12329](https://github.com/facebook/jest/pull/12329))
 - `[jest-environment-jsdom]` [**BREAKING**] Migrate to ESM ([#12340](https://github.com/facebook/jest/pull/12340))
 - `[jest-environment-node]` [**BREAKING**] Migrate to ESM ([#12340](https://github.com/facebook/jest/pull/12340))

--- a/packages/jest-create-cache-key-function/README.md
+++ b/packages/jest-create-cache-key-function/README.md
@@ -1,0 +1,48 @@
+# jest-create-cache-key-function
+
+This module creates a function which is used for generating cache keys used by code transformers in Jest.
+
+## Install
+
+```sh
+$ npm install --save-dev @jest/create-cache-key-function
+```
+
+## API
+
+### `createCacheKey(files?: Array<string>, values?: Array<String>): GetCacheKeyFunction`
+
+Get a function that can generate cache keys using source code, provided files and provided values.
+
+#### Parameters
+
+- `files`: [Optional] Array of absolute paths to files whose code should be accounted for when generating cache key
+- `values`: [Optional] Array of string values that should be accounted for when generating cache key
+
+**Note:**
+
+The source code for your test is already taken into account when generating the cache key. 
+The `files` array should be used to provide files that are not directly related to your code such as external configuration files.
+
+## Usage
+
+Here is some sample usage code while creating a new transformer for Jest
+
+```javascript
+const createCacheKeyFunction = require('@jest/create-cache-key-function').default;
+
+const filesToAccountFor = [
+  __filename,
+  require.resolve('some-package-name/package.json'),
+];
+
+const valuesToAccountFor = [
+  process.env.SOME_LOCAL_ENV,
+  "Some_Other_Value"
+]
+
+module.exports = {
+  process(src, filename, config, options) {},
+  getCacheKey: createCacheKeyFunction(filesToAccountFor, valuesToAccountFor),
+};
+```

--- a/packages/jest-create-cache-key-function/README.md
+++ b/packages/jest-create-cache-key-function/README.md
@@ -21,25 +21,22 @@ Get a function that can generate cache keys using source code, provided files an
 
 **Note:**
 
-The source code for your test is already taken into account when generating the cache key. 
-The `files` array should be used to provide files that are not directly related to your code such as external configuration files.
+The source code for your test is already taken into account when generating the cache key. The `files` array should be used to provide files that are not directly related to your code such as external configuration files.
 
 ## Usage
 
 Here is some sample usage code while creating a new transformer for Jest
 
 ```javascript
-const createCacheKeyFunction = require('@jest/create-cache-key-function').default;
+const createCacheKeyFunction =
+  require('@jest/create-cache-key-function').default;
 
 const filesToAccountFor = [
   __filename,
   require.resolve('some-package-name/package.json'),
 ];
 
-const valuesToAccountFor = [
-  process.env.SOME_LOCAL_ENV,
-  "Some_Other_Value"
-]
+const valuesToAccountFor = [process.env.SOME_LOCAL_ENV, 'Some_Other_Value'];
 
 module.exports = {
   process(src, filename, config, options) {},


### PR DESCRIPTION
## Summary

Added basic usage documentation for the `jest-create-cache-key-function` package. Using this package is recommended in the main [Code Transformation](https://jestjs.io/docs/code-transformation) page but has no further instructions on how to use it. Related to issue number #12004

## Test plan

Just added a `README.md` file, only proof reading needed
