### PR TITLE
fix(jest-circus, @jest/types): disallow undefined `TestContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[expect]` Throw useful error if `expect.extend` is called with invalid matchers ([#12488](https://github.com/facebook/jest/pull/12488))
 - `[expect]` Fix `iterableEquality` ignores other properties ([#8359](https://github.com/facebook/jest/pull/8359))
+- `[jest-circus, @jest/types]` Disallow undefined value in `TestContext` type ([#12507](https://github.com/facebook/jest/pull/12507))
 - `[jest-config]` Correctly detect CI environment and update snapshots accordingly ([#12378](https://github.com/facebook/jest/pull/12378))
 - `[jest-config]` Pass `moduleTypes` to `ts-node` to enforce CJS when transpiling ([#12397](https://github.com/facebook/jest/pull/12397))
 - `[jest-config, jest-haste-map]` Allow searching for tests in `node_modules` by exposing `retainAllFiles` ([#11084](https://github.com/facebook/jest/pull/11084))

--- a/e2e/__tests__/__snapshots__/callDoneTwice.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/callDoneTwice.test.ts.snap
@@ -70,7 +70,7 @@ exports[`\`done()\` should not be called more than once 1`] = `
       50 |
       51 |   it('should fail', () => {
 
-      at done (__tests__/index.test.js:48:5)
+      at Object.done (__tests__/index.test.js:48:5)
 
 
   ● Test suite failed to run
@@ -85,5 +85,5 @@ exports[`\`done()\` should not be called more than once 1`] = `
       61 |
       62 |   it('should fail', () => {
 
-      at done (__tests__/index.test.js:59:5)"
+      at Object.done (__tests__/index.test.js:59:5)"
 `;

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -142,7 +142,7 @@ const _callCircusHook = async ({
   hook,
   test,
   describeBlock,
-  testContext,
+  testContext = {},
 }: {
   hook: Circus.Hook;
   describeBlock?: Circus.DescribeBlock;

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -170,7 +170,7 @@ function checkIsError(error: unknown): error is Error {
 
 export const callAsyncCircusFn = (
   testOrHook: Circus.TestEntry | Circus.Hook,
-  testContext: Circus.TestContext | undefined,
+  testContext: Circus.TestContext,
   {isHook, timeout}: {isHook: boolean; timeout: number},
 ): Promise<unknown> => {
   let timeoutID: NodeJS.Timeout;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -15,16 +15,14 @@ export type TestReturnValue = ValidTestReturnValues | TestReturnValuePromise;
 export type TestContext = Record<string, unknown>;
 
 export type DoneFn = (reason?: string | Error) => void;
-// these should not be undefined
+
 export type DoneTakingTestFn = (
-  this: TestContext | undefined,
+  this: TestContext,
   done: DoneFn,
 ) => ValidTestReturnValues;
-export type PromiseReturningTestFn = (
-  this: TestContext | undefined,
-) => TestReturnValue;
+export type PromiseReturningTestFn = (this: TestContext) => TestReturnValue;
 export type GeneratorReturningTestFn = (
-  this: TestContext | undefined,
+  this: TestContext,
 ) => TestReturnValueGenerator;
 
 // eslint-disable-next-line @typescript-eslint/ban-types


### PR DESCRIPTION
## Summary

Another tiny todo. As a comment in `@jest/types` states, the `TestContext` type shouldn’t allow `undefined` value. Let’s fix this.

## Test plan

Green CI.
