### PR TITLE
Make @types/node a dev dependency

### DIFF
--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -17,11 +17,11 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@types/node": "*",
     "merge-stream": "^2.0.0",
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
+    "@types/node": "*",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",
     "get-stream": "^6.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

npm requiring the jest-worker package is requiring `@types/node` within your project which causes TypeScript to include @types/node for non-node projects.

This is a problem because a number of things are different between the DOM and npm. Namely in a browser setTimeout returns a number instead of a handle.

## Test plan

No code changes