### PR TITLE
chore: use esmodule in partial mock example

### DIFF
--- a/examples/module-mock/__tests__/partial_mock.js
+++ b/examples/module-mock/__tests__/partial_mock.js
@@ -9,11 +9,10 @@ import defaultExport, {apple, strawberry} from '../fruit';
 
 jest.mock('../fruit', () => {
   const originalModule = jest.requireActual('../fruit');
-  const mockedModule = jest.createMockFromModule('../fruit');
 
   //Mock the default export and named export 'apple'.
   return {
-    ...mockedModule,
+    __esModule: true,
     ...originalModule,
     apple: 'mocked apple',
     default: jest.fn(() => 'mocked fruit'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I got a bit sidetracked whilst reading this example because I was curious why `createMockFromModule` is needed.

It looks like the only purpose it serves is to add `__esModule: true` to the object.

I'm guessing it would make a clearer example to replace `jest.createMockFromModule` with `__esModule: true`.

## Test plan
No testing required to modify documents
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
