### PR TITLE
docs: add note about line discrepancies and returning source maps in code transformers

### DIFF
--- a/docs/CodeTransformation.md
+++ b/docs/CodeTransformation.md
@@ -128,9 +128,9 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
-:::info
+:::tip
 
-Jest might not be able to report the coverage and error information accurately if a source map is not returned by the `process` or `processAsync` function.
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
 
 :::
 

--- a/docs/CodeTransformation.md
+++ b/docs/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::info
+
+Jest might not be able to report the coverage and error information accurately if a source map is not returned by the `process` or `processAsync` function.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking

--- a/website/versioned_docs/version-27.0/CodeTransformation.md
+++ b/website/versioned_docs/version-27.0/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::tip
+
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking

--- a/website/versioned_docs/version-27.1/CodeTransformation.md
+++ b/website/versioned_docs/version-27.1/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::tip
+
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking

--- a/website/versioned_docs/version-27.2/CodeTransformation.md
+++ b/website/versioned_docs/version-27.2/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::tip
+
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking

--- a/website/versioned_docs/version-27.4/CodeTransformation.md
+++ b/website/versioned_docs/version-27.4/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::tip
+
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking

--- a/website/versioned_docs/version-27.5/CodeTransformation.md
+++ b/website/versioned_docs/version-27.5/CodeTransformation.md
@@ -128,6 +128,12 @@ As can be seen, only `process` or `processAsync` is mandatory to implement, alth
 
 Note that [ECMAScript module](ECMAScriptModules.md) support is indicated by the passed in `supports*` options. Specifically `supportsDynamicImport: true` means the transformer can return `import()` expressions, which is supported by both ESM and CJS. If `supportsStaticESM: true` it means top level `import` statements are supported and the code will be interpreted as ESM and not CJS. See [Node's docs](https://nodejs.org/api/esm.html#esm_differences_between_es_modules_and_commonjs) for details on the differences.
 
+:::tip
+
+Make sure `TransformedSource` contains a source map, so it is possible to report line information accurately in code coverage and test errors. Inline source maps also work but are slower.
+
+:::
+
 ### Examples
 
 ### TypeScript with type checking


### PR DESCRIPTION
## Summary
Added a new note in the Code Transformation page about line discrepancies when source maps are not returned by the `process` or `processAsync` functions. Was just generally confusing why my errors were pointing to a different place.

## Test plan
Only docs are changed -> proofread

## Related Issue:
#10305 ?