### PR TITLE
refactor(@jest/core, jest-watcher)!: rework and clean up `PatternPrompt` and its derived classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[jest-runtime]` Calling `jest.resetModules` function will clear FS and transform cache ([#12531](https://github.com/facebook/jest/pull/12531))
 - `[@jest/schemas]` New module for JSON schemas for Jest's config ([#12384](https://github.com/facebook/jest/pull/12384))
 - `[jest-test-result]` Add duration property to JSON test output ([#12518](https://github.com/facebook/jest/pull/12518))
+- `[jest-watcher]` [**BREAKING**] Make `PatternPrompt` class to take `entityName` as third constructor parameter instead of `this._entityName` ([#12591](https://github.com/facebook/jest/pull/12591))
 - `[jest-worker]` [**BREAKING**] Allow only absolute `workerPath` ([#12343](https://github.com/facebook/jest/pull/12343))
 - `[pretty-format]` New `maxWidth` parameter ([#12402](https://github.com/facebook/jest/pull/12402))
 

--- a/packages/jest-core/src/TestNamePatternPrompt.ts
+++ b/packages/jest-core/src/TestNamePatternPrompt.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {TestResult} from '@jest/test-result';
 import {
   PatternPrompt,
   Prompt,
@@ -14,28 +13,19 @@ import {
   printRestoredPatternCaret,
 } from 'jest-watcher';
 
-// TODO: Make underscored props `private`
 export default class TestNamePatternPrompt extends PatternPrompt {
-  _cachedTestResults: Array<TestResult>;
-
   constructor(pipe: NodeJS.WritableStream, prompt: Prompt) {
-    super(pipe, prompt);
-    this._entityName = 'tests';
-    this._cachedTestResults = [];
+    super(pipe, prompt, 'tests');
   }
 
-  _onChange(pattern: string, options: ScrollOptions): void {
+  protected _onChange(pattern: string, options: ScrollOptions): void {
     super._onChange(pattern, options);
     this._printPrompt(pattern);
   }
 
-  _printPrompt(pattern: string): void {
+  private _printPrompt(pattern: string): void {
     const pipe = this._pipe;
     printPatternCaret(pattern, pipe);
     printRestoredPatternCaret(pattern, this._currentUsageRows, pipe);
-  }
-
-  updateCachedTestResults(testResults: Array<TestResult> = []): void {
-    this._cachedTestResults = testResults;
   }
 }

--- a/packages/jest-core/src/TestPathPatternPrompt.ts
+++ b/packages/jest-core/src/TestPathPatternPrompt.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Context} from 'jest-runtime';
 import {
   PatternPrompt,
   Prompt,
@@ -13,34 +12,20 @@ import {
   printPatternCaret,
   printRestoredPatternCaret,
 } from 'jest-watcher';
-import type SearchSource from './SearchSource';
 
-type SearchSources = Array<{
-  context: Context;
-  searchSource: SearchSource;
-}>;
-
-// TODO: Make underscored props `private`
 export default class TestPathPatternPrompt extends PatternPrompt {
-  _searchSources?: SearchSources;
-
   constructor(pipe: NodeJS.WritableStream, prompt: Prompt) {
-    super(pipe, prompt);
-    this._entityName = 'filenames';
+    super(pipe, prompt, 'filenames');
   }
 
-  _onChange(pattern: string, options: ScrollOptions): void {
+  protected _onChange(pattern: string, options: ScrollOptions): void {
     super._onChange(pattern, options);
     this._printPrompt(pattern);
   }
 
-  _printPrompt(pattern: string): void {
+  private _printPrompt(pattern: string): void {
     const pipe = this._pipe;
     printPatternCaret(pattern, pipe);
     printRestoredPatternCaret(pattern, this._currentUsageRows, pipe);
-  }
-
-  updateSearchSources(searchSources: SearchSources): void {
-    this._searchSources = searchSources;
   }
 }

--- a/packages/jest-watcher/src/PatternPrompt.ts
+++ b/packages/jest-watcher/src/PatternPrompt.ts
@@ -22,17 +22,14 @@ const usage = (entity: string) =>
 
 const usageRows = usage('').split('\n').length;
 
-export default class PatternPrompt {
-  protected _pipe: NodeJS.WritableStream;
-  protected _prompt: Prompt;
-  protected _entityName: string;
+export default abstract class PatternPrompt {
   protected _currentUsageRows: number;
 
-  constructor(pipe: NodeJS.WritableStream, prompt: Prompt) {
-    // TODO: Should come in the constructor
-    this._entityName = '';
-    this._pipe = pipe;
-    this._prompt = prompt;
+  constructor(
+    protected _pipe: NodeJS.WritableStream,
+    protected _prompt: Prompt,
+    protected _entityName = '',
+  ) {
     this._currentUsageRows = usageRows;
   }
 


### PR DESCRIPTION
## Summary

Just a few simple TODOs:

- `entityName` became a parameter of the constructor of the `PatternPrompt` class of `jest-watcher`;
- underscored methods were marked `private` / `protected` in the derived classes;
- some unused code removed (might be I misunderstood, the lines look unused internally).

## Test plan

Green CI.