### PR TITLE
docs: add section about installing `ts-jest`

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -150,8 +150,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
-```bash
-yarn add --dev ts-jest
+```bash npm2yarn
+npm install --save-dev jest
 ```
 
 #### Type definitions

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -150,6 +150,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -151,7 +151,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
 ```bash npm2yarn
-npm install --save-dev jest
+npm install --save-dev ts-jest
 ```
 
 #### Type definitions

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 ### Using TypeScript: type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-27.0/GettingStarted.md
+++ b/website/versioned_docs/version-27.0/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-27.1/GettingStarted.md
+++ b/website/versioned_docs/version-27.1/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-27.2/GettingStarted.md
+++ b/website/versioned_docs/version-27.2/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-27.4/GettingStarted.md
+++ b/website/versioned_docs/version-27.4/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 ### Using TypeScript: type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-27.5/GettingStarted.md
+++ b/website/versioned_docs/version-27.5/GettingStarted.md
@@ -158,6 +158,10 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.
 
+```bash
+yarn add --dev ts-jest
+```
+
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
 
 > For `@types/*` modules it's recommended to try to match the version of the associated module. For example, if you are using `26.4.0` of `jest` then using `26.4.x` of `@types/jest` is ideal. In general, try to match the major (`26`) and minor (`4`) version as closely as possible.


### PR DESCRIPTION
Adding the command to install `ts-jest` since it is an implied install here and may lead to the end user only running the `@types/jest` command which will not allow the tests to run.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
