### PR TITLE
chore(lint): turn the ESLint rule `no-useless-call` on as an error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -467,7 +467,7 @@ module.exports = {
     'no-unused-expressions': 'off',
     'no-unused-vars': ['error', {argsIgnorePattern: '^_'}],
     'no-use-before-define': 'off',
-    'no-useless-call': 'warn',
+    'no-useless-call': 'error',
     'no-useless-computed-key': 'error',
     'no-useless-concat': 'error',
     'no-var': 'error',

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -442,9 +442,9 @@ describe('moduleMocker', () => {
         expect(fn.mock.contexts[2]).toBe(ctx2);
 
         // null context
-        fn.apply(null, []);
+        fn.apply(null, []); // eslint-disable-line no-useless-call
         expect(fn.mock.contexts[3]).toBe(null);
-        fn.call(null);
+        fn.call(null); // eslint-disable-line no-useless-call
         expect(fn.mock.contexts[4]).toBe(null);
         fn.bind(null)();
         expect(fn.mock.contexts[5]).toBe(null);


### PR DESCRIPTION
Following up #12601

## Summary

After the mentioned PR got merged, ESLint is printing two warnings regarding the `no-useless-call` rule. To avoid this, I added `// eslint-disable-line` comments.

Perhaps it is worth to set the rule to `'error'` instead of `'warn'` for the future?

## Test plan

Green CI.