### PR TITLE
fix: `TestRunnerContext` is not optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - `[jest-phabricator]` [**BREAKING**] Migrate to ESM ([#12341](https://github.com/facebook/jest/pull/12341))
 - `[jest-resolve]` [**BREAKING**] Make `requireResolveFunction` argument mandatory ([#12353](https://github.com/facebook/jest/pull/12353))
 - `[jest-runner]` [**BREAKING**] Remove some type exports from `@jest/test-result` ([#12353](https://github.com/facebook/jest/pull/12353))
+- `[jest-runner]` [**BREAKING**] Second argument to constructor (`Context`) is not optional ([#12640](https://github.com/facebook/jest/pull/12640))
 - `[jest-serializer]` [**BREAKING**] Deprecate package in favour of using `v8` APIs directly ([#12391](https://github.com/facebook/jest/pull/12391))
 - `[jest-snapshot]` [**BREAKING**] Migrate to ESM ([#12342](https://github.com/facebook/jest/pull/12342))
 - `[jest-transform]` Update `write-file-atomic` to v4 ([#12357](https://github.com/facebook/jest/pull/12357))

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -216,9 +216,9 @@ class TestScheduler {
           const Runner: typeof TestRunner =
             await transformer.requireAndTranspileModule(config.runner);
           const runner = new Runner(this._globalConfig, {
-            changedFiles: this._context?.changedFiles,
+            changedFiles: this._context.changedFiles,
             sourcesRelatedToTestsInChangedFiles:
-              this._context?.sourcesRelatedToTestsInChangedFiles,
+              this._context.sourcesRelatedToTestsInChangedFiles,
           });
           testRunners[config.runner] = runner;
           contextsByTestRunner.set(runner, context);

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -7,7 +7,7 @@
  */
 
 import {SummaryReporter} from '@jest/reporters';
-import {makeProjectConfig} from '@jest/test-utils';
+import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import {createTestScheduler} from '../TestScheduler';
 import * as testSchedulerHelper from '../testSchedulerHelper';
 
@@ -37,18 +37,20 @@ beforeEach(() => {
 
 test('config for reporters supports `default`', async () => {
   const undefinedReportersScheduler = await createTestScheduler(
-    {
+    makeGlobalConfig({
       reporters: undefined,
-    },
+    }),
+    {},
     {},
   );
   const numberOfReporters =
     undefinedReportersScheduler._dispatcher._reporters.length;
 
   const stringDefaultReportersScheduler = await createTestScheduler(
-    {
+    makeGlobalConfig({
       reporters: ['default'],
-    },
+    }),
+    {},
     {},
   );
   expect(stringDefaultReportersScheduler._dispatcher._reporters.length).toBe(
@@ -56,9 +58,10 @@ test('config for reporters supports `default`', async () => {
   );
 
   const defaultReportersScheduler = await createTestScheduler(
-    {
+    makeGlobalConfig({
       reporters: [['default', {}]],
-    },
+    }),
+    {},
     {},
   );
   expect(defaultReportersScheduler._dispatcher._reporters.length).toBe(
@@ -66,16 +69,17 @@ test('config for reporters supports `default`', async () => {
   );
 
   const emptyReportersScheduler = await createTestScheduler(
-    {
+    makeGlobalConfig({
       reporters: [],
-    },
+    }),
+    {},
     {},
   );
   expect(emptyReportersScheduler._dispatcher._reporters.length).toBe(0);
 });
 
 test('.addReporter() .removeReporter()', async () => {
-  const scheduler = await createTestScheduler({}, {});
+  const scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
   const reporter = new SummaryReporter();
   scheduler.addReporter(reporter);
   expect(scheduler._dispatcher._reporters).toContain(reporter);
@@ -84,7 +88,7 @@ test('.addReporter() .removeReporter()', async () => {
 });
 
 test('schedule tests run in parallel per default', async () => {
-  const scheduler = await createTestScheduler({}, {});
+  const scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
   const test = {
     context: {
       config: makeProjectConfig({
@@ -107,7 +111,7 @@ test('schedule tests run in parallel per default', async () => {
 });
 
 test('schedule tests run in serial if the runner flags them', async () => {
-  const scheduler = await createTestScheduler({}, {});
+  const scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
   const test = {
     context: {
       config: makeProjectConfig({
@@ -130,7 +134,11 @@ test('schedule tests run in serial if the runner flags them', async () => {
 });
 
 test('should bail after `n` failures', async () => {
-  const scheduler = await createTestScheduler({bail: 2}, {});
+  const scheduler = await createTestScheduler(
+    makeGlobalConfig({bail: 2}),
+    {},
+    {},
+  );
   const test = {
     context: {
       config: makeProjectConfig({
@@ -162,7 +170,11 @@ test('should bail after `n` failures', async () => {
 });
 
 test('should not bail if less than `n` failures', async () => {
-  const scheduler = await createTestScheduler({bail: 2}, {});
+  const scheduler = await createTestScheduler(
+    makeGlobalConfig({bail: 2}),
+    {},
+    {},
+  );
   const test = {
     context: {
       config: makeProjectConfig({
@@ -194,7 +206,7 @@ test('should not bail if less than `n` failures', async () => {
 });
 
 test('should set runInBand to run in serial', async () => {
-  const scheduler = await createTestScheduler({}, {});
+  const scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
   const test = {
     context: {
       config: makeProjectConfig({
@@ -220,7 +232,7 @@ test('should set runInBand to run in serial', async () => {
 });
 
 test('should set runInBand to not run in serial', async () => {
-  const scheduler = await createTestScheduler({}, {});
+  const scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
   const test = {
     context: {
       config: makeProjectConfig({

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {TestWatcher} from '@jest/core';
+import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import TestRunner from '../index';
 
 let mockWorkerFarm;
@@ -26,8 +27,8 @@ jest.mock('jest-worker', () => ({
 jest.mock('../testWorker', () => {});
 
 test('injects the serializable module map into each worker in watch mode', async () => {
-  const globalConfig = {maxWorkers: 2, watch: true};
-  const config = {rootDir: '/path/'};
+  const globalConfig = makeGlobalConfig({maxWorkers: 2, watch: true});
+  const config = makeProjectConfig({rootDir: '/path/'});
   const serializableModuleMap = jest.fn();
   const runContext = {};
   const context = {
@@ -35,7 +36,7 @@ test('injects the serializable module map into each worker in watch mode', async
     moduleMap: {toJSON: () => serializableModuleMap},
   };
 
-  await new TestRunner(globalConfig).runTests(
+  await new TestRunner(globalConfig, {}).runTests(
     [
       {context, path: './file.test.js'},
       {context, path: './file2.test.js'},
@@ -68,11 +69,11 @@ test('injects the serializable module map into each worker in watch mode', async
 });
 
 test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', async () => {
-  const globalConfig = {maxWorkers: 1, watch: false};
-  const config = {rootDir: '/path/'};
+  const globalConfig = makeGlobalConfig({maxWorkers: 1, watch: false});
+  const config = makeProjectConfig({rootDir: '/path/'});
   const context = {config};
 
-  await new TestRunner(globalConfig).runTests(
+  await new TestRunner(globalConfig, {}).runTests(
     [{context, path: './file.test.js'}],
     new TestWatcher({isWatchMode: globalConfig.watch}),
     undefined,

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -51,9 +51,9 @@ export default class TestRunner {
 
   readonly isSerial?: boolean;
 
-  constructor(globalConfig: Config.GlobalConfig, context?: TestRunnerContext) {
+  constructor(globalConfig: Config.GlobalConfig, context: TestRunnerContext) {
     this._globalConfig = globalConfig;
-    this._context = context || {};
+    this._context = context;
   }
 
   async runTests(

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -79,7 +79,7 @@ async function runTestInternal(
   globalConfig: Config.GlobalConfig,
   projectConfig: Config.ProjectConfig,
   resolver: Resolver,
-  context?: TestRunnerContext,
+  context: TestRunnerContext,
   sendMessageToJest?: TestFileEvent,
 ): Promise<RunTestInternalResult> {
   const testSource = fs.readFileSync(path, 'utf8');
@@ -188,13 +188,13 @@ async function runTestInternal(
     transformer,
     cacheFS,
     {
-      changedFiles: context?.changedFiles,
+      changedFiles: context.changedFiles,
       collectCoverage: globalConfig.collectCoverage,
       collectCoverageFrom: globalConfig.collectCoverageFrom,
       collectCoverageOnlyFrom: globalConfig.collectCoverageOnlyFrom,
       coverageProvider: globalConfig.coverageProvider,
       sourcesRelatedToTestsInChangedFiles:
-        context?.sourcesRelatedToTestsInChangedFiles,
+        context.sourcesRelatedToTestsInChangedFiles,
     },
     path,
   );
@@ -363,7 +363,7 @@ export default async function runTest(
   globalConfig: Config.GlobalConfig,
   config: Config.ProjectConfig,
   resolver: Resolver,
-  context?: TestRunnerContext,
+  context: TestRunnerContext,
   sendMessageToJest?: TestFileEvent,
 ): Promise<TestResult> {
   const {leakDetector, result} = await runTestInternal(

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -30,7 +30,7 @@ type WorkerData = {
   config: Config.ProjectConfig;
   globalConfig: Config.GlobalConfig;
   path: string;
-  context?: TestRunnerSerializedContext;
+  context: TestRunnerSerializedContext;
 };
 
 // Make sure uncaught errors are logged before we exit.
@@ -97,7 +97,7 @@ export async function worker({
       globalConfig,
       config,
       getResolver(config),
-      context && {
+      {
         ...context,
         changedFiles: context.changedFiles && new Set(context.changedFiles),
         sourcesRelatedToTestsInChangedFiles:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Since it defaulted the `?.` chain was useless anyways. But it is always passed, so no reason to handle it missing.

https://github.com/facebook/jest/blob/777e32687775b9287650c85ade4f9fdda1405fe1/packages/jest-core/src/TestScheduler.ts#L218-L222

(looking at that snippet, we can remove more optional chaining 😅)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
