### PR TITLE
chore: fix v8 coverage test

### DIFF
--- a/e2e/__tests__/coverageProviderV8.test.ts
+++ b/e2e/__tests__/coverageProviderV8.test.ts
@@ -11,13 +11,17 @@ import runJest from '../runJest';
 
 const DIR = path.resolve(__dirname, '../coverage-provider-v8');
 
+// https://github.com/nodejs/node/issues/42638
+const nodeOptions =
+  typeof fetch === 'undefined' ? '' : '--no-experimental-fetch';
+
 test('prints coverage with missing sourcemaps', () => {
   const sourcemapDir = path.join(DIR, 'no-sourcemap');
 
   const {stdout, exitCode} = runJest(
     sourcemapDir,
     ['--coverage', '--coverage-provider', 'v8'],
-    {stripAnsi: true},
+    {nodeOptions, stripAnsi: true},
   );
 
   expect(exitCode).toBe(0);
@@ -30,7 +34,7 @@ test('prints coverage with empty sourcemaps', () => {
   const {stdout, exitCode} = runJest(
     sourcemapDir,
     ['--coverage', '--coverage-provider', 'v8'],
-    {stripAnsi: true},
+    {nodeOptions, stripAnsi: true},
   );
 
   expect(exitCode).toBe(0);
@@ -43,7 +47,7 @@ test('prints correct coverage report, if a CJS module is put under test without 
   const {stdout, exitCode} = runJest(
     sourcemapDir,
     ['--coverage', '--coverage-provider', 'v8', '--no-cache'],
-    {stripAnsi: true},
+    {nodeOptions, stripAnsi: true},
   );
 
   expect(exitCode).toBe(0);
@@ -56,7 +60,7 @@ test('prints correct coverage report, if a TS module is transpiled by Babel to C
   const {stdout, exitCode} = runJest(
     sourcemapDir,
     ['--coverage', '--coverage-provider', 'v8', '--no-cache'],
-    {stripAnsi: true},
+    {nodeOptions, stripAnsi: true},
   );
 
   expect(exitCode).toBe(0);
@@ -72,7 +76,7 @@ onNodeVersions('>=12.16.0', () => {
       sourcemapDir,
       ['--coverage', '--coverage-provider', 'v8', '--no-cache'],
       {
-        nodeOptions: '--experimental-vm-modules --no-warnings',
+        nodeOptions: `${nodeOptions} --experimental-vm-modules --no-warnings`,
         stripAnsi: true,
       },
     );
@@ -88,7 +92,7 @@ onNodeVersions('>=12.16.0', () => {
       sourcemapDir,
       ['--coverage', '--coverage-provider', 'v8', '--no-cache'],
       {
-        nodeOptions: '--experimental-vm-modules --no-warnings',
+        nodeOptions: `${nodeOptions} --experimental-vm-modules --no-warnings`,
         stripAnsi: true,
       },
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Global `fetch` breaks `source-map`, see https://github.com/nodejs/node/issues/42638. This disables `fetch` in our coverage tests as suggested there.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI (although we don't run against node nightly, but local verification shows this works)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
