### PR TITLE
feat(jest-runner): improve typings by exposing `TestRunner` abstract classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - `[jest-resolve, jest-runtime]` Add support for async resolver ([#11540](https://github.com/facebook/jest/pull/11540))
 - `[jest-runner]` Allow `setupFiles` module to export an async function ([#12042](https://github.com/facebook/jest/pull/12042))
 - `[jest-runner]` Allow passing `testEnvironmentOptions` via docblocks ([#12470](https://github.com/facebook/jest/pull/12470))
+- `[jest-runner]` Exposing `CallbackTestRunner`, `EmittingTestRunner` abstract classes to help typing third party runners ([#12646](https://github.com/facebook/jest/pull/12646))
 - `[jest-runtime]` [**BREAKING**] `Runtime.createHasteMap` now returns a promise ([#12008](https://github.com/facebook/jest/pull/12008))
 - `[jest-runtime]` Calling `jest.resetModules` function will clear FS and transform cache ([#12531](https://github.com/facebook/jest/pull/12531))
 - `[@jest/schemas]` New module for JSON schemas for Jest's config ([#12384](https://github.com/facebook/jest/pull/12384))

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {UnsubscribeFn} from 'emittery';
+import {expectType} from 'tsd-lite';
+import type {Test, TestEvents} from '@jest/test-result';
+import type {Config} from '@jest/types';
+import {CallbackTestRunner, EmittingTestRunner} from 'jest-runner';
+import type {
+  OnTestFailure,
+  OnTestStart,
+  OnTestSuccess,
+  TestRunnerContext,
+  TestRunnerOptions,
+  TestWatcher,
+} from 'jest-runner';
+
+const globalConfig = {} as Config.GlobalConfig;
+const runnerContext = {} as TestRunnerContext;
+
+class CallbackRunner extends CallbackTestRunner {
+  override async runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    onStart: OnTestStart,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
+    options: TestRunnerOptions,
+  ): Promise<void> {
+    return;
+  }
+}
+
+const callbackRunner = new CallbackRunner(globalConfig, runnerContext);
+
+expectType<boolean | undefined>(callbackRunner.isSerial);
+expectType<false>(callbackRunner.supportsEventEmitters);
+
+class EmittingRunner extends EmittingTestRunner {
+  override on<Name extends keyof TestEvents>(
+    eventName: string,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn {
+    return () => {};
+  }
+
+  override async runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void> {
+    return;
+  }
+}
+
+const emittingRunner = new EmittingRunner(globalConfig, runnerContext);
+
+expectType<boolean | undefined>(emittingRunner.isSerial);
+expectType<true>(emittingRunner.supportsEventEmitters);

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -31,6 +31,9 @@ class CallbackRunner extends CallbackTestRunner {
     onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
+    expectType<Config.GlobalConfig>(this._globalConfig);
+    expectType<TestRunnerContext>(this._context);
+
     return;
   }
 }
@@ -41,19 +44,22 @@ expectType<boolean | undefined>(callbackRunner.isSerial);
 expectType<false>(callbackRunner.supportsEventEmitters);
 
 class EmittingRunner extends EmittingTestRunner {
-  on<Name extends keyof TestEvents>(
-    eventName: string,
-    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
-  ): UnsubscribeFn {
-    return () => {};
-  }
-
   async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
+    expectType<Config.GlobalConfig>(this._globalConfig);
+    expectType<TestRunnerContext>(this._context);
+
     return;
+  }
+
+  on<Name extends keyof TestEvents>(
+    eventName: string,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn {
+    return () => {};
   }
 }
 

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {UnsubscribeFn} from 'emittery';
 import {expectType} from 'tsd-lite';
 import type {Test, TestEvents} from '@jest/test-result';
 import type {Config} from '@jest/types';
@@ -17,6 +16,7 @@ import type {
   TestRunnerContext,
   TestRunnerOptions,
   TestWatcher,
+  UnsubscribeFn,
 } from 'jest-runner';
 
 const globalConfig = {} as Config.GlobalConfig;

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -22,6 +22,8 @@ import type {
 const globalConfig = {} as Config.GlobalConfig;
 const runnerContext = {} as TestRunnerContext;
 
+// CallbackRunner
+
 class CallbackRunner extends CallbackTestRunner {
   async runTests(
     tests: Array<Test>,
@@ -42,6 +44,8 @@ const callbackRunner = new CallbackRunner(globalConfig, runnerContext);
 
 expectType<boolean | undefined>(callbackRunner.isSerial);
 expectType<false>(callbackRunner.supportsEventEmitters);
+
+// EmittingRunner
 
 class EmittingRunner extends EmittingTestRunner {
   async runTests(

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -23,7 +23,7 @@ const globalConfig = {} as Config.GlobalConfig;
 const runnerContext = {} as TestRunnerContext;
 
 class CallbackRunner extends CallbackTestRunner {
-  override async runTests(
+  async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
     onStart: OnTestStart,
@@ -41,14 +41,14 @@ expectType<boolean | undefined>(callbackRunner.isSerial);
 expectType<false>(callbackRunner.supportsEventEmitters);
 
 class EmittingRunner extends EmittingTestRunner {
-  override on<Name extends keyof TestEvents>(
+  on<Name extends keyof TestEvents>(
     eventName: string,
     listener: (eventData: TestEvents[Name]) => void | Promise<void>,
   ): UnsubscribeFn {
     return () => {};
   }
 
-  override async runTests(
+  async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
     options: TestRunnerOptions,

--- a/packages/jest-runner/__typetests__/tsconfig.json
+++ b/packages/jest-runner/__typetests__/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+
+    "types": []
+  },
+  "include": ["./**/*"]
+}

--- a/packages/jest-runner/__typetests__/tsconfig.json
+++ b/packages/jest-runner/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "noImplicitOverride": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-runner/__typetests__/tsconfig.json
+++ b/packages/jest-runner/__typetests__/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "noImplicitOverride": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -43,6 +43,7 @@
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.2",
     "@types/source-map-support": "^0.5.0",
+    "jest-jasmine2": "^28.0.0-alpha.8",
     "tsd-lite": "^0.5.1"
   },
   "engines": {

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -39,10 +39,11 @@
     "throat": "^6.0.1"
   },
   "devDependencies": {
+    "@tsd/typescript": "~4.6.2",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.2",
     "@types/source-map-support": "^0.5.0",
-    "jest-jasmine2": "^28.0.0-alpha.8"
+    "tsd-lite": "^0.5.1"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.13.0 || >=17.0.0"

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -25,8 +25,6 @@ jest.mock('jest-worker', () => ({
   ),
 }));
 
-jest.mock('../testWorker', () => {});
-
 test('injects the serializable module map into each worker in watch mode', async () => {
   const globalConfig = makeGlobalConfig({maxWorkers: 2, watch: true});
   const config = makeProjectConfig({rootDir: '/path/'});

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -34,7 +34,7 @@ test('injects the serializable module map into each worker in watch mode', async
     moduleMap: {toJSON: jest.fn()},
   } as unknown as TestContext;
 
-  await new TestRunner(globalConfig, {}).runTests(
+  await new TestRunner(globalConfig, runContext).runTests(
     [
       {context: mockTestContext, path: './file.test.js'},
       {context: mockTestContext, path: './file2.test.js'},
@@ -45,24 +45,21 @@ test('injects the serializable module map into each worker in watch mode', async
 
   expect(mockTestContext.moduleMap.toJSON).toBeCalledTimes(1);
 
-  expect(mockWorkerFarm.worker.mock.calls).toEqual([
-    [
-      {
-        config,
-        context: runContext,
-        globalConfig,
-        path: './file.test.js',
-      },
-    ],
-    [
-      {
-        config,
-        context: runContext,
-        globalConfig,
-        path: './file2.test.js',
-      },
-    ],
-  ]);
+  expect(mockWorkerFarm.worker).toBeCalledTimes(2);
+
+  expect(mockWorkerFarm.worker).nthCalledWith(1, {
+    config,
+    context: runContext,
+    globalConfig,
+    path: './file.test.js',
+  });
+
+  expect(mockWorkerFarm.worker).nthCalledWith(2, {
+    config,
+    context: runContext,
+    globalConfig,
+    path: './file2.test.js',
+  });
 });
 
 test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', async () => {

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -31,19 +31,21 @@ test('injects the serializable module map into each worker in watch mode', async
   const globalConfig = makeGlobalConfig({maxWorkers: 2, watch: true});
   const config = makeProjectConfig({rootDir: '/path/'});
   const runContext = {};
-  const context = {
+  const mockTestContext = {
     config,
     moduleMap: {toJSON: jest.fn()},
   } as unknown as TestContext;
 
   await new TestRunner(globalConfig, {}).runTests(
     [
-      {context, path: './file.test.js'},
-      {context, path: './file2.test.js'},
+      {context: mockTestContext, path: './file.test.js'},
+      {context: mockTestContext, path: './file2.test.js'},
     ],
     new TestWatcher({isWatchMode: globalConfig.watch}),
     {serial: false},
   );
+
+  expect(mockTestContext.moduleMap.toJSON).toBeCalledTimes(1);
 
   expect(mockWorkerFarm.worker.mock.calls).toEqual([
     [

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {TestWatcher} from '@jest/core';
+import type {TestContext} from '@jest/test-result';
 import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import TestRunner from '../index';
 
@@ -29,12 +30,11 @@ jest.mock('../testWorker', () => {});
 test('injects the serializable module map into each worker in watch mode', async () => {
   const globalConfig = makeGlobalConfig({maxWorkers: 2, watch: true});
   const config = makeProjectConfig({rootDir: '/path/'});
-  const serializableModuleMap = jest.fn();
   const runContext = {};
   const context = {
     config,
-    moduleMap: {toJSON: () => serializableModuleMap},
-  };
+    moduleMap: {toJSON: jest.fn()},
+  } as unknown as TestContext;
 
   await new TestRunner(globalConfig, {}).runTests(
     [
@@ -68,7 +68,7 @@ test('injects the serializable module map into each worker in watch mode', async
 test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', async () => {
   const globalConfig = makeGlobalConfig({maxWorkers: 1, watch: false});
   const config = makeProjectConfig({rootDir: '/path/'});
-  const context = {config};
+  const context = {config} as TestContext;
 
   await new TestRunner(globalConfig, {}).runTests(
     [{context, path: './file.test.js'}],

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -42,9 +42,6 @@ test('injects the serializable module map into each worker in watch mode', async
       {context, path: './file2.test.js'},
     ],
     new TestWatcher({isWatchMode: globalConfig.watch}),
-    undefined,
-    undefined,
-    undefined,
     {serial: false},
   );
 
@@ -76,9 +73,6 @@ test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', async () =>
   await new TestRunner(globalConfig, {}).runTests(
     [{context, path: './file.test.js'}],
     new TestWatcher({isWatchMode: globalConfig.watch}),
-    undefined,
-    undefined,
-    undefined,
     {serial: true},
   );
 

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -25,6 +25,8 @@ jest.mock('jest-worker', () => ({
   ),
 }));
 
+jest.mock('../testWorker', () => {});
+
 test('injects the serializable module map into each worker in watch mode', async () => {
   const globalConfig = makeGlobalConfig({maxWorkers: 2, watch: true});
   const config = makeProjectConfig({rootDir: '/path/'});
@@ -42,8 +44,6 @@ test('injects the serializable module map into each worker in watch mode', async
     new TestWatcher({isWatchMode: globalConfig.watch}),
     {serial: false},
   );
-
-  expect(mockTestContext.moduleMap.toJSON).toBeCalledTimes(1);
 
   expect(mockWorkerFarm.worker).toBeCalledTimes(2);
 

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -18,7 +18,12 @@ import {deepCyclicCopy} from 'jest-util';
 import {PromiseWithCustomMessage, Worker} from 'jest-worker';
 import runTest from './runTest';
 import type {SerializableResolver, worker} from './testWorker';
-import {EmittingTestRunner, TestRunnerOptions, TestWatcher} from './types';
+import {
+  EmittingTestRunner,
+  TestRunnerOptions,
+  TestWatcher,
+  UnsubscribeFn,
+} from './types';
 
 const TEST_WORKER_PATH = require.resolve('./testWorker');
 
@@ -35,6 +40,7 @@ export type {
   TestRunnerContext,
   TestRunnerOptions,
   JestTestRunner,
+  UnsubscribeFn,
 } from './types';
 
 export default class TestRunner extends EmittingTestRunner {
@@ -188,7 +194,7 @@ export default class TestRunner extends EmittingTestRunner {
   on<Name extends keyof TestEvents>(
     eventName: Name,
     listener: (eventData: TestEvents[Name]) => void | Promise<void>,
-  ): Emittery.UnsubscribeFn {
+  ): UnsubscribeFn {
     return this.#eventEmitter.on(eventName, listener);
   }
 }

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -26,6 +26,7 @@ interface WorkerInterface extends Worker {
   worker: typeof worker;
 }
 
+export {CallbackTestRunner, EmittingTestRunner} from './types';
 export type {
   OnTestFailure,
   OnTestStart,
@@ -33,9 +34,7 @@ export type {
   TestWatcher,
   TestRunnerContext,
   TestRunnerOptions,
-  EmittingTestRunner,
   JestTestRunner,
-  TestRunner,
 } from './types';
 
 export default class TestRunner extends EmittingTestRunner {

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -40,7 +40,7 @@ export type {
 export default class TestRunner extends EmittingTestRunner {
   readonly #eventEmitter = new Emittery<TestEvents>();
 
-  override async runTests(
+  async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
     options: TestRunnerOptions,

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -40,7 +40,7 @@ export type {
 export default class TestRunner extends EmittingTestRunner {
   readonly #eventEmitter = new Emittery<TestEvents>();
 
-  async runTests(
+  override async runTests(
     tests: Array<Test>,
     watcher: TestWatcher,
     options: TestRunnerOptions,

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -74,7 +74,7 @@ abstract class BaseTestRunner {
   ) {}
 }
 
-export abstract class TestRunner extends BaseTestRunner {
+export abstract class CallbackTestRunner extends BaseTestRunner {
   readonly supportsEventEmitters = false;
 
   abstract runTests(
@@ -102,4 +102,4 @@ export abstract class EmittingTestRunner extends BaseTestRunner {
   ): Emittery.UnsubscribeFn;
 }
 
-export type JestTestRunner = TestRunner | EmittingTestRunner;
+export type JestTestRunner = CallbackTestRunner | EmittingTestRunner;

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -55,14 +55,7 @@ export type TestRunnerSerializedContext = {
   sourcesRelatedToTestsInChangedFiles?: Array<string>;
 };
 
-// TODO: Should live in `@jest/core` or `jest-watcher`
-type WatcherState = {interrupted: boolean};
-export interface TestWatcher extends Emittery<{change: WatcherState}> {
-  state: WatcherState;
-  setState(state: WatcherState): void;
-  isInterrupted(): boolean;
-  isWatchMode(): boolean;
-}
+export type UnsubscribeFn = () => void;
 
 abstract class BaseTestRunner {
   readonly isSerial?: boolean;
@@ -99,7 +92,16 @@ export abstract class EmittingTestRunner extends BaseTestRunner {
   abstract on<Name extends keyof TestEvents>(
     eventName: Name,
     listener: (eventData: TestEvents[Name]) => void | Promise<void>,
-  ): Emittery.UnsubscribeFn;
+  ): UnsubscribeFn;
 }
 
 export type JestTestRunner = CallbackTestRunner | EmittingTestRunner;
+
+// TODO: Should live in `@jest/core` or `jest-watcher`
+type WatcherState = {interrupted: boolean};
+export interface TestWatcher extends Emittery<{change: WatcherState}> {
+  state: WatcherState;
+  setState(state: WatcherState): void;
+  isInterrupted(): boolean;
+  isWatchMode(): boolean;
+}

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -25,6 +25,7 @@ export type {
   Status,
   Suite,
   Test,
+  TestContext,
   TestEvents,
   TestFileEvent,
   TestResult,

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -183,12 +183,12 @@ export type SnapshotSummary = {
 };
 
 export type Test = {
-  context: Context;
+  context: TestContext;
   duration?: number;
   path: string;
 };
 
-type Context = {
+export type TestContext = {
   config: Config.ProjectConfig;
   hasteFS: HasteFS;
   moduleMap: ModuleMap;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13309,7 +13309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-jasmine2@workspace:packages/jest-jasmine2":
+"jest-jasmine2@^28.0.0-alpha.8, jest-jasmine2@workspace:packages/jest-jasmine2":
   version: 0.0.0-use.local
   resolution: "jest-jasmine2@workspace:packages/jest-jasmine2"
   dependencies:
@@ -13553,6 +13553,7 @@ __metadata:
     jest-docblock: ^28.0.0-alpha.6
     jest-environment-node: ^28.0.0-alpha.8
     jest-haste-map: ^28.0.0-alpha.8
+    jest-jasmine2: ^28.0.0-alpha.8
     jest-leak-detector: ^28.0.0-alpha.8
     jest-message-util: ^28.0.0-alpha.8
     jest-resolve: ^28.0.0-alpha.8

--- a/yarn.lock
+++ b/yarn.lock
@@ -13309,7 +13309,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-jasmine2@^28.0.0-alpha.8, jest-jasmine2@workspace:packages/jest-jasmine2":
+"jest-jasmine2@workspace:packages/jest-jasmine2":
   version: 0.0.0-use.local
   resolution: "jest-jasmine2@workspace:packages/jest-jasmine2"
   dependencies:
@@ -13542,6 +13542,7 @@ __metadata:
     "@jest/test-result": ^28.0.0-alpha.8
     "@jest/transform": ^28.0.0-alpha.8
     "@jest/types": ^28.0.0-alpha.8
+    "@tsd/typescript": ~4.6.2
     "@types/exit": ^0.1.30
     "@types/graceful-fs": ^4.1.2
     "@types/node": "*"
@@ -13552,7 +13553,6 @@ __metadata:
     jest-docblock: ^28.0.0-alpha.6
     jest-environment-node: ^28.0.0-alpha.8
     jest-haste-map: ^28.0.0-alpha.8
-    jest-jasmine2: ^28.0.0-alpha.8
     jest-leak-detector: ^28.0.0-alpha.8
     jest-message-util: ^28.0.0-alpha.8
     jest-resolve: ^28.0.0-alpha.8
@@ -13561,6 +13561,7 @@ __metadata:
     jest-worker: ^28.0.0-alpha.8
     source-map-support: ^0.5.6
     throat: ^6.0.1
+    tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Following up #12641

## Summary

`jest-core` supports two kinds of test runner. What if `jest-runner` would expose two abstract classes, which would help to implement either kind of the runner?

For instance `create-jest-runner` could use these types [here](https://github.com/jest-community/create-jest-runner/blob/35b66e1b5e6fa220b3b39fae74d7d4101e884217/lib/types.ts#L23-L42). Not to say that I would like to have this for my test runner ;D

Todo:

- [x] add type tests to prove all works as expected
- [ ] documentation would be nice too

## Test plan

Green CI.