### PR TITLE
feat(jest-reporters)!: pass `reporterContext` to custom reporter constructors as third argument

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -101,8 +101,6 @@ module.exports = {
         'packages/expect/src/print.ts',
         'packages/expect/src/toThrowMatchers.ts',
         'packages/expect-utils/src/utils.ts',
-        'packages/jest-core/src/ReporterDispatcher.ts',
-        'packages/jest-core/src/TestScheduler.ts',
         'packages/jest-core/src/collectHandles.ts',
         'packages/jest-core/src/plugins/UpdateSnapshotsInteractive.ts',
         'packages/jest-haste-map/src/index.ts',

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -822,73 +822,62 @@ When using multi-project runner, it's recommended to add a `displayName` for eac
 
 Default: `undefined`
 
-Use this configuration option to add custom reporters to Jest. A custom reporter is a class that implements `onRunStart`, `onTestStart`, `onTestResult`, `onRunComplete` methods that will be called when any of those events occurs.
-
-If custom reporters are specified, the default Jest reporters will be overridden. To keep default reporters, `default` can be passed as a module name.
-
-This will override default reporters:
-
-```json
-{
-  "reporters": ["<rootDir>/my-custom-reporter.js"]
-}
-```
-
-This will use custom reporter in addition to default reporters that Jest provides:
-
-```json
-{
-  "reporters": ["default", "<rootDir>/my-custom-reporter.js"]
-}
-```
-
-Additionally, custom reporters can be configured by passing an `options` object as a second argument:
+Use this configuration option to add reporters to Jest. Optionally, a reporter can be configured by passing options object as a second argument of a tuple:
 
 ```json
 {
   "reporters": [
     "default",
-    ["<rootDir>/my-custom-reporter.js", {"banana": "yes", "pineapple": "no"}]
+    ["<rootDir>/custom-reporter.js", {"banana": "yes", "pineapple": "no"}]
   ]
 }
 ```
 
-Custom reporter modules must define a class that takes a `GlobalConfig` and reporter options as constructor arguments:
+:::tip
 
-Example reporter:
+Take a look at a list of [awesome reporters](https://github.com/jest-community/awesome-jest#reporters) from Awesome Jest.
 
-```js title="my-custom-reporter.js"
-class MyCustomReporter {
-  constructor(globalConfig, options) {
+If custom reporters are specified, the default Jest reporters will be overridden. If you wish to keep them, `'default'` can be passed as a module name:
+
+```json
+{
+  "reporters": [
+    "default",
+    ["jest-junit", {"outputName": "junit-report.xml", "suiteName": "some-name"}]
+  ]
+}
+```
+
+:::
+
+Custom reporter module must export a class that takes `globalConfig`, `reporterConfig` and `reporterContext` as constructor arguments and implements at least `onRunComplete()` method (for the full list of methods and argument types see `Reporter` interface in [packages/jest-reporters/src/types.ts](https://github.com/facebook/jest/blob/main/packages/jest-reporters/src/types.ts)):
+
+```js title="custom-reporter.js"
+class CustomReporter {
+  constructor(globalConfig, reporterOptions, reporterContext) {
     this._globalConfig = globalConfig;
-    this._options = options;
+    this._options = reporterOptions;
+    this._context = reporterContext;
   }
 
-  onRunComplete(contexts, results) {
+  onRunComplete(testContexts, results) {
     console.log('Custom reporter output:');
     console.log('GlobalConfig: ', this._globalConfig);
     console.log('Options: ', this._options);
+    console.log('Context: ', this._context);
   }
-}
 
-module.exports = MyCustomReporter;
-// or export default MyCustomReporter;
-```
-
-Custom reporters can also force Jest to exit with non-0 code by returning an Error from `getLastError()` methods
-
-```js
-class MyCustomReporter {
-  // ...
+  // Optionally, reporters can force Jest to exit with non zero code by returning
+  // an `Error` from `getLastError()` method.
   getLastError() {
     if (this._shouldFail) {
-      return new Error('my-custom-reporter.js reported an error');
+      return new Error('Custom error reported!');
     }
   }
 }
-```
 
-For the full list of methods and argument types see `Reporter` interface in [packages/jest-reporters/src/types.ts](https://github.com/facebook/jest/blob/main/packages/jest-reporters/src/types.ts)
+module.exports = CustomReporter;
+```
 
 ### `resetMocks` \[boolean]
 

--- a/e2e/__tests__/__snapshots__/customReporters.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/customReporters.test.ts.snap
@@ -27,7 +27,11 @@ Object {
     "called": true,
     "path": false,
   },
-  "options": Object {
+  "reporterContext": Object {
+    "firstRun": true,
+    "previousSuccess": true,
+  },
+  "reporterOptions": Object {
     "christoph": "pojer",
     "dmitrii": "abramov",
     "hello": "world",
@@ -55,7 +59,11 @@ Object {
     "called": true,
     "path": false,
   },
-  "options": Object {
+  "reporterContext": Object {
+    "firstRun": true,
+    "previousSuccess": true,
+  },
+  "reporterOptions": Object {
     "christoph": "pojer",
     "dmitrii": "abramov",
     "hello": "world",
@@ -97,7 +105,11 @@ Object {
     "called": true,
     "path": false,
   },
-  "options": Object {},
+  "reporterContext": Object {
+    "firstRun": true,
+    "previousSuccess": true,
+  },
+  "reporterOptions": Object {},
 }
 `;
 
@@ -146,7 +158,11 @@ exports[`Custom Reporters Integration valid array format for adding reporters 1`
         "called": true,
         "path": false
     },
-    "options": {
+    "reporterContext": {
+        "firstRun": true,
+        "previousSuccess": true
+    },
+    "reporterOptions": {
         "Aaron Abramov": "Awesome"
     }
 }"

--- a/e2e/custom-reporters/reporters/IncompleteReporter.js
+++ b/e2e/custom-reporters/reporters/IncompleteReporter.js
@@ -15,7 +15,7 @@
  * This only implements one method onRunComplete which should be called
  */
 class IncompleteReporter {
-  onRunComplete(contexts, results) {
+  onRunComplete(testContexts, results) {
     console.log('onRunComplete is called');
     console.log(`Passed Tests: ${results.numPassedTests}`);
     console.log(`Failed Tests: ${results.numFailedTests}`);

--- a/e2e/custom-reporters/reporters/TestReporter.js
+++ b/e2e/custom-reporters/reporters/TestReporter.js
@@ -15,8 +15,9 @@
  * to get the output.
  */
 class TestReporter {
-  constructor(globalConfig, options) {
-    this._options = options;
+  constructor(globalConfig, reporterOptions, reporterContext) {
+    this._context = reporterContext;
+    this._options = reporterOptions;
 
     /**
      * statsCollected property
@@ -30,7 +31,8 @@ class TestReporter {
       onRunStart: {},
       onTestResult: {times: 0},
       onTestStart: {},
-      options,
+      reporterContext,
+      reporterOptions,
     };
   }
 
@@ -66,7 +68,7 @@ class TestReporter {
     onRunStart.options = typeof options;
   }
 
-  onRunComplete(contexts, results) {
+  onRunComplete(testContexts, results) {
     const onRunComplete = this._statsCollected.onRunComplete;
 
     onRunComplete.called = true;
@@ -75,9 +77,9 @@ class TestReporter {
     onRunComplete.numFailedTests = results.numFailedTests;
     onRunComplete.numTotalTests = results.numTotalTests;
 
-    if (this._statsCollected.options.maxWorkers) {
+    if (this._statsCollected.reporterOptions.maxWorkers) {
       // Since it's a different number on different machines.
-      this._statsCollected.options.maxWorkers = '<<REPLACED>>';
+      this._statsCollected.reporterOptions.maxWorkers = '<<REPLACED>>';
     }
     // The Final Call
     process.stdout.write(JSON.stringify(this._statsCollected, null, 4));

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -5,16 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable local/ban-types-eventually */
-
 import type {Reporter, ReporterOnStartOptions} from '@jest/reporters';
 import type {
   AggregatedResult,
   Test,
   TestCaseResult,
+  TestContext,
   TestResult,
 } from '@jest/test-result';
-import type {Context} from 'jest-runtime';
+import type {ReporterConstructor} from './TestScheduler';
 
 export default class ReporterDispatcher {
   private _reporters: Array<Reporter>;
@@ -27,9 +26,9 @@ export default class ReporterDispatcher {
     this._reporters.push(reporter);
   }
 
-  unregister(ReporterClass: Function): void {
+  unregister(reporterConstructor: ReporterConstructor): void {
     this._reporters = this._reporters.filter(
-      reporter => !(reporter instanceof ReporterClass),
+      reporter => !(reporter instanceof reporterConstructor),
     );
   }
 
@@ -82,12 +81,12 @@ export default class ReporterDispatcher {
   }
 
   async onRunComplete(
-    contexts: Set<Context>,
+    testContexts: Set<TestContext>,
     results: AggregatedResult,
   ): Promise<void> {
     for (const reporter of this._reporters) {
       if (reporter.onRunComplete) {
-        await reporter.onRunComplete(contexts, results);
+        await reporter.onRunComplete(testContexts, results);
       }
     }
   }

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -23,8 +23,7 @@ import type {ChangedFiles, ChangedFilesPromise} from 'jest-changed-files';
 import Resolver from 'jest-resolve';
 import type {Context} from 'jest-runtime';
 import {requireOrImportModule, tryRealpath} from 'jest-util';
-import {JestHook, JestHookEmitter} from 'jest-watcher';
-import type {TestWatcher} from 'jest-watcher';
+import {JestHook, JestHookEmitter, TestWatcher} from 'jest-watcher';
 import type FailedTestsCache from './FailedTestsCache';
 import SearchSource from './SearchSource';
 import {TestSchedulerContext, createTestScheduler} from './TestScheduler';
@@ -280,11 +279,10 @@ export default async function runJest({
     }
   }
 
-  const scheduler = await createTestScheduler(
-    globalConfig,
-    {startRun},
-    testSchedulerContext,
-  );
+  const scheduler = await createTestScheduler(globalConfig, {
+    startRun,
+    ...testSchedulerContext,
+  });
 
   const results = await scheduler.scheduleTests(allTests, testWatcher);
 

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -28,8 +28,6 @@
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
     "istanbul-reports": "^3.1.3",
-    "jest-haste-map": "^28.0.0-alpha.8",
-    "jest-resolve": "^28.0.0-alpha.8",
     "jest-util": "^28.0.0-alpha.8",
     "jest-worker": "^28.0.0-alpha.8",
     "slash": "^3.0.0",
@@ -49,6 +47,7 @@
     "@types/istanbul-lib-source-maps": "^4.0.0",
     "@types/istanbul-reports": "^3.0.0",
     "@types/node-notifier": "^8.0.0",
+    "jest-resolve": "^28.0.0-alpha.8",
     "mock-fs": "^5.1.2",
     "strip-ansi": "^6.0.0"
   },

--- a/packages/jest-reporters/src/BaseReporter.ts
+++ b/packages/jest-reporters/src/BaseReporter.ts
@@ -7,11 +7,13 @@
 
 import type {
   AggregatedResult,
+  Test,
   TestCaseResult,
+  TestContext,
   TestResult,
 } from '@jest/test-result';
 import {preRunMessage} from 'jest-util';
-import type {Context, Reporter, ReporterOnStartOptions, Test} from './types';
+import type {Reporter, ReporterOnStartOptions} from './types';
 
 const {remove: preRunMessageRemove} = preRunMessage;
 
@@ -40,7 +42,7 @@ export default class BaseReporter implements Reporter {
   onTestStart(_test?: Test): void {}
 
   onRunComplete(
-    _contexts?: Set<Context>,
+    _testContexts?: Set<TestContext>,
     _aggregatedResults?: AggregatedResult,
   ): Promise<void> | void {}
 

--- a/packages/jest-reporters/src/CoverageWorker.ts
+++ b/packages/jest-reporters/src/CoverageWorker.ts
@@ -11,16 +11,14 @@ import type {Config} from '@jest/types';
 import generateEmptyCoverage, {
   CoverageWorkerResult,
 } from './generateEmptyCoverage';
-import type {CoverageReporterSerializedOptions} from './types';
+import type {ReporterContextSerialized} from './types';
 
 export type CoverageWorkerData = {
-  globalConfig: Config.GlobalConfig;
   config: Config.ProjectConfig;
+  context: ReporterContextSerialized;
+  globalConfig: Config.GlobalConfig;
   path: string;
-  options?: CoverageReporterSerializedOptions;
 };
-
-export type {CoverageWorkerResult};
 
 // Make sure uncaught errors are logged before we exit.
 process.on('uncaughtException', err => {
@@ -32,15 +30,15 @@ export function worker({
   config,
   globalConfig,
   path,
-  options,
+  context,
 }: CoverageWorkerData): Promise<CoverageWorkerResult | null> {
   return generateEmptyCoverage(
     fs.readFileSync(path, 'utf8'),
     path,
     globalConfig,
     config,
-    options?.changedFiles && new Set(options.changedFiles),
-    options?.sourcesRelatedToTestsInChangedFiles &&
-      new Set(options.sourcesRelatedToTestsInChangedFiles),
+    context.changedFiles && new Set(context.changedFiles),
+    context.sourcesRelatedToTestsInChangedFiles &&
+      new Set(context.sourcesRelatedToTestsInChangedFiles),
   );
 }

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -9,6 +9,7 @@ import chalk = require('chalk');
 import {getConsoleOutput} from '@jest/console';
 import type {
   AggregatedResult,
+  Test,
   TestCaseResult,
   TestResult,
 } from '@jest/test-result';
@@ -18,7 +19,7 @@ import BaseReporter from './BaseReporter';
 import Status from './Status';
 import getResultHeader from './getResultHeader';
 import getSnapshotStatus from './getSnapshotStatus';
-import type {ReporterOnStartOptions, Test} from './types';
+import type {ReporterOnStartOptions} from './types';
 
 type write = NodeJS.WriteStream['write'];
 type FlushBufferedOutput = () => void;

--- a/packages/jest-reporters/src/GitHubActionsReporter.ts
+++ b/packages/jest-reporters/src/GitHubActionsReporter.ts
@@ -6,9 +6,12 @@
  */
 
 import stripAnsi = require('strip-ansi');
-import type {AggregatedResult, TestResult} from '@jest/test-result';
+import type {
+  AggregatedResult,
+  TestContext,
+  TestResult,
+} from '@jest/test-result';
 import BaseReporter from './BaseReporter';
-import type {Context} from './types';
 
 const lineAndColumnInStackTrace = /^.*?:([0-9]+):([0-9]+).*$/;
 
@@ -24,7 +27,7 @@ function replaceEntities(s: string): string {
 
 export default class GitHubActionsReporter extends BaseReporter {
   override onRunComplete(
-    _contexts?: Set<Context>,
+    _testContexts?: Set<TestContext>,
     aggregatedResults?: AggregatedResult,
   ): void {
     const messages = getMessages(aggregatedResults?.testResults);

--- a/packages/jest-reporters/src/NotifyReporter.ts
+++ b/packages/jest-reporters/src/NotifyReporter.ts
@@ -8,11 +8,11 @@
 import * as path from 'path';
 import * as util from 'util';
 import exit = require('exit');
-import type {AggregatedResult} from '@jest/test-result';
+import type {AggregatedResult, TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import {pluralize} from 'jest-util';
 import BaseReporter from './BaseReporter';
-import type {Context, TestSchedulerContext} from './types';
+import type {ReporterContext} from './types';
 
 const isDarwin = process.platform === 'darwin';
 
@@ -20,31 +20,25 @@ const icon = path.resolve(__dirname, '../assets/jest_logo.png');
 
 export default class NotifyReporter extends BaseReporter {
   private _notifier = loadNotifier();
-  private _startRun: (globalConfig: Config.GlobalConfig) => unknown;
   private _globalConfig: Config.GlobalConfig;
-  private _context: TestSchedulerContext;
+  private _context: ReporterContext;
 
   static readonly filename = __filename;
 
-  constructor(
-    globalConfig: Config.GlobalConfig,
-    startRun: (globalConfig: Config.GlobalConfig) => unknown,
-    context: TestSchedulerContext,
-  ) {
+  constructor(globalConfig: Config.GlobalConfig, context: ReporterContext) {
     super();
     this._globalConfig = globalConfig;
-    this._startRun = startRun;
     this._context = context;
   }
 
   override onRunComplete(
-    contexts: Set<Context>,
+    testContexts: Set<TestContext>,
     result: AggregatedResult,
   ): void {
     const success =
       result.numFailedTests === 0 && result.numRuntimeErrorTestSuites === 0;
 
-    const firstContext = contexts.values().next();
+    const firstContext = testContexts.values().next();
 
     const hasteFS =
       firstContext && firstContext.value && firstContext.value.hasteFS;
@@ -145,8 +139,11 @@ export default class NotifyReporter extends BaseReporter {
               exit(0);
               return;
             }
-            if (metadata.activationValue === restartAnswer) {
-              this._startRun(this._globalConfig);
+            if (
+              metadata.activationValue === restartAnswer &&
+              this._context.startRun
+            ) {
+              this._context.startRun(this._globalConfig);
             }
           },
         );

--- a/packages/jest-reporters/src/Status.ts
+++ b/packages/jest-reporters/src/Status.ts
@@ -9,11 +9,12 @@ import chalk = require('chalk');
 import stringLength = require('string-length');
 import type {
   AggregatedResult,
+  Test,
   TestCaseResult,
   TestResult,
 } from '@jest/test-result';
 import type {Config} from '@jest/types';
-import type {ReporterOnStartOptions, Test} from './types';
+import type {ReporterOnStartOptions} from './types';
 import {
   getSummary,
   printDisplayName,

--- a/packages/jest-reporters/src/SummaryReporter.ts
+++ b/packages/jest-reporters/src/SummaryReporter.ts
@@ -6,13 +6,17 @@
  */
 
 import chalk = require('chalk');
-import type {AggregatedResult, SnapshotSummary} from '@jest/test-result';
+import type {
+  AggregatedResult,
+  SnapshotSummary,
+  TestContext,
+} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import {testPathPatternToRegExp} from 'jest-util';
 import BaseReporter from './BaseReporter';
 import getResultHeader from './getResultHeader';
 import getSnapshotSummary from './getSnapshotSummary';
-import type {Context, ReporterOnStartOptions} from './types';
+import type {ReporterOnStartOptions} from './types';
 import {getSummary} from './utils';
 
 const TEST_SUMMARY_THRESHOLD = 20;
@@ -79,7 +83,7 @@ export default class SummaryReporter extends BaseReporter {
   }
 
   override onRunComplete(
-    contexts: Set<Context>,
+    testContexts: Set<TestContext>,
     aggregatedResults: AggregatedResult,
   ): void {
     const {numTotalTestSuites, testResults, wasInterrupted} = aggregatedResults;
@@ -111,7 +115,7 @@ export default class SummaryReporter extends BaseReporter {
           message += `\n${
             wasInterrupted
               ? chalk.bold.red('Test run was interrupted.')
-              : this._getTestSummary(contexts, this._globalConfig)
+              : this._getTestSummary(testContexts, this._globalConfig)
           }`;
         }
         this.log(message);
@@ -188,7 +192,7 @@ export default class SummaryReporter extends BaseReporter {
   }
 
   private _getTestSummary(
-    contexts: Set<Context>,
+    contexts: Set<TestContext>,
     globalConfig: Config.GlobalConfig,
   ) {
     const getMatchingTestsInfo = () => {

--- a/packages/jest-reporters/src/VerboseReporter.ts
+++ b/packages/jest-reporters/src/VerboseReporter.ts
@@ -10,12 +10,12 @@ import type {
   AggregatedResult,
   AssertionResult,
   Suite,
+  Test,
   TestResult,
 } from '@jest/test-result';
 import type {Config} from '@jest/types';
 import {formatTime, specialChars} from 'jest-util';
 import DefaultReporter from './DefaultReporter';
-import type {Test} from './types';
 
 const {ICONS} = specialChars;
 

--- a/packages/jest-reporters/src/__tests__/CoverageWorker.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageWorker.test.js
@@ -11,7 +11,8 @@ jest.mock('graceful-fs').mock('../generateEmptyCoverage');
 
 const globalConfig = {collectCoverage: true};
 const config = {};
-const workerOptions = {config, globalConfig, path: 'banana.js'};
+const context = {};
+const workerOptions = {config, context, globalConfig, path: 'banana.js'};
 
 let fs;
 let generateEmptyCoverage;

--- a/packages/jest-reporters/src/index.ts
+++ b/packages/jest-reporters/src/index.ts
@@ -14,12 +14,6 @@ import {
   trimAndFormatPath,
 } from './utils';
 
-export type {Config} from '@jest/types';
-export type {
-  AggregatedResult,
-  SnapshotSummary,
-  TestResult,
-} from '@jest/test-result';
 export {default as BaseReporter} from './BaseReporter';
 export {default as CoverageReporter} from './CoverageReporter';
 export {default as DefaultReporter} from './DefaultReporter';
@@ -28,11 +22,10 @@ export {default as SummaryReporter} from './SummaryReporter';
 export {default as VerboseReporter} from './VerboseReporter';
 export {default as GitHubActionsReporter} from './GitHubActionsReporter';
 export type {
-  Context,
   Reporter,
   ReporterOnStartOptions,
+  ReporterContext,
   SummaryOptions,
-  Test,
 } from './types';
 export const utils = {
   formatTestPath,

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -7,13 +7,12 @@
 
 import type {
   AggregatedResult,
-  SerializableError,
+  Test,
   TestCaseResult,
+  TestContext,
   TestResult,
 } from '@jest/test-result';
 import type {Config} from '@jest/types';
-import type {FS as HasteFS, ModuleMap} from 'jest-haste-map';
-import type Resolver from 'jest-resolve';
 import type {worker} from './CoverageWorker';
 
 export type ReporterOnStartOptions = {
@@ -21,40 +20,7 @@ export type ReporterOnStartOptions = {
   showStatus: boolean;
 };
 
-export type Context = {
-  config: Config.ProjectConfig;
-  hasteFS: HasteFS;
-  moduleMap: ModuleMap;
-  resolver: Resolver;
-};
-
-export type Test = {
-  context: Context;
-  duration?: number;
-  path: string;
-};
-
 export type CoverageWorker = {worker: typeof worker};
-
-export type CoverageReporterOptions = {
-  changedFiles?: Set<string>;
-  sourcesRelatedToTestsInChangedFiles?: Set<string>;
-};
-
-export type CoverageReporterSerializedOptions = {
-  changedFiles?: Array<string>;
-  sourcesRelatedToTestsInChangedFiles?: Array<string>;
-};
-
-export type OnTestStart = (test: Test) => Promise<void>;
-export type OnTestFailure = (
-  test: Test,
-  error: SerializableError,
-) => Promise<unknown>;
-export type OnTestSuccess = (
-  test: Test,
-  result: TestResult,
-) => Promise<unknown>;
 
 export interface Reporter {
   readonly onTestResult?: (
@@ -78,30 +44,28 @@ export interface Reporter {
   readonly onTestStart?: (test: Test) => Promise<void> | void;
   readonly onTestFileStart?: (test: Test) => Promise<void> | void;
   readonly onRunComplete: (
-    contexts: Set<Context>,
+    testContexts: Set<TestContext>,
     results: AggregatedResult,
   ) => Promise<void> | void;
   readonly getLastError: () => Error | void;
 }
+
+export type ReporterContext = {
+  firstRun: boolean;
+  previousSuccess: boolean;
+  changedFiles?: Set<string>;
+  sourcesRelatedToTestsInChangedFiles?: Set<string>;
+  startRun?: (globalConfig: Config.GlobalConfig) => unknown;
+};
+
+export type ReporterContextSerialized = {
+  changedFiles?: Array<string>;
+  sourcesRelatedToTestsInChangedFiles?: Array<string>;
+};
 
 export type SummaryOptions = {
   currentTestCases?: Array<{test: Test; testCaseResult: TestCaseResult}>;
   estimatedTime?: number;
   roundTime?: boolean;
   width?: number;
-};
-
-export type TestRunnerOptions = {
-  serial: boolean;
-};
-
-export type TestRunData = Array<{
-  context: Context;
-  matches: {allTests: number; tests: Array<Test>; total: number};
-}>;
-
-export type TestSchedulerContext = {
-  firstRun: boolean;
-  previousSuccess: boolean;
-  changedFiles?: Set<string>;
 };

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -8,10 +8,10 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import slash = require('slash');
-import type {AggregatedResult, TestCaseResult} from '@jest/test-result';
+import type {AggregatedResult, Test, TestCaseResult} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import {formatTime, pluralize} from 'jest-util';
-import type {SummaryOptions, Test} from './types';
+import type {SummaryOptions} from './types';
 
 const PROGRESS_BAR_WIDTH = 40;
 

--- a/packages/jest-reporters/tsconfig.json
+++ b/packages/jest-reporters/tsconfig.json
@@ -8,7 +8,6 @@
   "exclude": ["./**/__tests__/**/*"],
   "references": [
     {"path": "../jest-console"},
-    {"path": "../jest-haste-map"},
     {"path": "../jest-resolve"},
     {"path": "../jest-test-result"},
     {"path": "../jest-transform"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,7 +2777,6 @@ __metadata:
     istanbul-lib-report: ^3.0.0
     istanbul-lib-source-maps: ^4.0.0
     istanbul-reports: ^3.1.3
-    jest-haste-map: ^28.0.0-alpha.8
     jest-resolve: ^28.0.0-alpha.8
     jest-util: ^28.0.0-alpha.8
     jest-worker: ^28.0.0-alpha.8


### PR DESCRIPTION
## Summary

Promise, I was refactoring `jest-worker`, but noticed strange details in types of `jest-reporters`. Just could not leave it.

What if constructors of custom reporters alongside with their config options would also receive `reporterContext`? 

Similarly default reporters all could receive unified `reporterContext` object. Currently context is passed to reporters, but is typed somewhat differently. That feels redundant.

Also this change would allow writing custom reporters similar to coverage or notify. Why not? (;

## Test plan

Green CI.