### PR TITLE
fix(jest-haste-map): Make watchman existence check lazy+async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - `[jest-environment-node]` Add `structuredClone` to globals ([#12631](https://github.com/facebook/jest/pull/12631))
 - `[@jest/expect-utils]` [**BREAKING**] Fix false positives when looking for `undefined` prop ([#8923](https://github.com/facebook/jest/pull/8923))
 - `[jest-haste-map]` Don't use partial results if file crawl errors ([#12420](https://github.com/facebook/jest/pull/12420))
+- `[jest-haste-map]` Make watchman existence check lazy+async ([#12675](https://github.com/facebook/jest/pull/12675))
 - `[jest-jasmine2, jest-types]` [**BREAKING**] Move all `jasmine` specific types from `@jest/types` to its own package ([#12125](https://github.com/facebook/jest/pull/12125))
 - `[jest-jasmine2]` Do not set `duration` to `0` for skipped tests ([#12518](https://github.com/facebook/jest/pull/12518))
 - `[jest-matcher-utils]` Pass maxWidth to `pretty-format` to avoid printing every element in arrays by default ([#12402](https://github.com/facebook/jest/pull/12402))

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -13,9 +13,9 @@ function mockHashContents(contents) {
   return crypto.createHash('sha1').update(contents).digest('hex');
 }
 
-jest.mock('child_process', () => ({
-  // If this does not throw, we'll use the (mocked) watchman crawler
-  execSync() {},
+jest.mock('../lib/isWatchmanInstalled', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(true),
 }));
 
 jest.mock('jest-worker', () => ({

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -13,9 +13,11 @@ function mockHashContents(contents) {
   return crypto.createHash('sha1').update(contents).digest('hex');
 }
 
+const mockIsWatchmanInstalled = jest.fn().mockResolvedValue(true);
+
 jest.mock('../lib/isWatchmanInstalled', () => ({
   __esModule: true,
-  default: jest.fn().mockResolvedValue(true),
+  default: mockIsWatchmanInstalled,
 }));
 
 jest.mock('jest-worker', () => ({
@@ -612,6 +614,8 @@ describe('HasteMap', () => {
         });
       });
 
+      mockIsWatchmanInstalled.mockClear();
+
       const hasteMap = await HasteMap.create({
         ...defaultConfig,
         computeSha1: true,
@@ -620,6 +624,10 @@ describe('HasteMap', () => {
       });
 
       const data = (await hasteMap.build()).__hasteMapForTest;
+
+      expect(mockIsWatchmanInstalled).toHaveBeenCalledTimes(
+        useWatchman ? 1 : 0,
+      );
 
       expect(data.files).toEqual(
         createMap({

--- a/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import isWatchmanInstalled from '../isWatchmanInstalled';
 import {execFile} from 'child_process';
+import isWatchmanInstalled from '../isWatchmanInstalled';
 
 jest.mock('child_process');
 

--- a/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/isWatchmanInstalled.test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import isWatchmanInstalled from '../isWatchmanInstalled';
+import {execFile} from 'child_process';
+
+jest.mock('child_process');
+
+describe('isWatchmanInstalled', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('executes watchman --version and returns true on success', async () => {
+    execFile.mockImplementation((file, args, cb) => {
+      expect(file).toBe('watchman');
+      expect(args).toStrictEqual(['--version']);
+      cb(null, {stdout: 'v123'});
+    });
+    expect(await isWatchmanInstalled()).toBe(true);
+    expect(execFile).toHaveBeenCalledWith(
+      'watchman',
+      ['--version'],
+      expect.any(Function),
+    );
+  });
+
+  it('returns false when execFile fails', async () => {
+    execFile.mockImplementation((file, args, cb) => {
+      cb(new Error());
+    });
+    expect(await isWatchmanInstalled()).toBe(false);
+    expect(execFile).toHaveBeenCalled();
+  });
+});

--- a/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
+++ b/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
+++ b/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {execFile} from 'child_process';
+import {promisify} from 'util';
+
+export default async function isWatchmanInstalled() {
+  try {
+    await promisify(execFile)('watchman', ['--version']);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
+++ b/packages/jest-haste-map/src/lib/isWatchmanInstalled.ts
@@ -8,7 +8,7 @@
 import {execFile} from 'child_process';
 import {promisify} from 'util';
 
-export default async function isWatchmanInstalled() {
+export default async function isWatchmanInstalled(): Promise<boolean> {
   try {
     await promisify(execFile)('watchman', ['--version']);
     return true;


### PR DESCRIPTION
## Summary

Currently, `jest-haste-map` checks for watchman existence at import time (top level) with a blocking `execSync` call. This has a few downsides
 - Blocking at the top level holds up main thread (by 20-200ms) at a time when there's CPU work to be done.
 - `execSync` spawns a shell, which isn't necessary here - `execFile` is more efficient.
 - The exec happens totally unnecessarily even if the consumer specifies `useWatchman: false`.
 
 This PR extracts this to an async utility function, executed lazily and memoized by the core class.

## Test plan
 - New unit tests cover `lib/isWatchmanInstalled.ts` and lazy execution
 
  - Behaviour of `execFile` when watchman is installed:
 ```
 $ node -e "util.promisify(child_process.execFile)('watchman', ['--version']).then(console.log)"
 { stdout: '20220411\n', stderr: '' }
 ``` 
  - And when we try to exec something unavailable:
 ```
 $ node -e "util.promisify(child_process.execFile)('nonexistentthing', ['--version']).then(console.log)"

node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

Error: spawn nonexistentthing ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:282:19)
    at onErrorNT (node:internal/child_process:477:16)
    at processTicksAndRejections (node:internal/process/task_queues:83:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn nonexistentthing',
  path: 'nonexistentthing',
  spawnargs: [ '--version' ],
  cmd: 'nonexistentthing --version',
  stdout: '',
  stderr: ''
}
```