### PR TITLE
chore(lint): Allow "Meta Platforms" copyright headers

### DIFF
--- a/scripts/checkCopyrightHeaders.mjs
+++ b/scripts/checkCopyrightHeaders.mjs
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -117,6 +117,13 @@ const INCLUDED_PATTERNS = [
 ];
 
 const COPYRIGHT_LICENSE = [
+  ' * Copyright (c) Meta Platforms, Inc. and affiliates.',
+  ' *',
+  ' * This source code is licensed under the MIT license found in the',
+  ' * LICENSE file in the root directory of this source tree.',
+].join('\n');
+
+const LEGACY_COPYRIGHT_LICENSE = [
   ' * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.',
   ' *',
   ' * This source code is licensed under the MIT license found in the',
@@ -125,7 +132,11 @@ const COPYRIGHT_LICENSE = [
 
 function needsCopyrightHeader(file) {
   const contents = getFileContents(file);
-  return contents.trim().length > 0 && !contents.includes(COPYRIGHT_LICENSE);
+  return (
+    contents.trim().length > 0 &&
+    !contents.includes(COPYRIGHT_LICENSE) &&
+    !contents.includes(LEGACY_COPYRIGHT_LICENSE)
+  );
 }
 
 function check() {


### PR DESCRIPTION
## Summary

IANAL, and this isn't vetted, but this is the copyright header we've been using since the rename in other MIT licensed OSS projects - eg https://github.com/facebook/react-native/commit/8bd3edec88148d0ab1f225d2119435681fbbba33, https://github.com/facebook/metro/commit/347b1d7ed87995d7951aaa9fd597c04b06013dac

This PR just updates the linter to allow both, to reduce the potential merge friction of a subsequent update.

## Test plan

CI + `checkCopyrightHeaders.mjs` passes lint
