### PR TITLE
chore(typetests): add `"composite": false` to `tsconfig.json` for all type tests

### DIFF
--- a/packages/expect/__typetests__/tsconfig.json
+++ b/packages/expect/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-expect/__typetests__/tsconfig.json
+++ b/packages/jest-expect/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-mock/__typetests__/tsconfig.json
+++ b/packages/jest-mock/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-runner/__typetests__/tsconfig.json
+++ b/packages/jest-runner/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,

--- a/packages/jest-types/__typetests__/tsconfig.json
+++ b/packages/jest-types/__typetests__/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "composite": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

While working on #12680, I noticed that it would be good to include `"composite": false`  to `tsconfig.json` for all type tests. The type tests in that PR use a fixture which is imported to a test file. TS was complaining that this file is not in the program. Adding `"composite": false` is fixing the issue. Seemed like `false` makes more sense as well. Or?

## Test plan

Green CI.