### PR TITLE
refactor(jest-reporters, jest-runner): use `SerializeSet` type helper

### DIFF
--- a/packages/jest-reporters/src/CoverageWorker.ts
+++ b/packages/jest-reporters/src/CoverageWorker.ts
@@ -15,11 +15,13 @@ import type {ReporterContext} from './types';
 
 type SerializeSet<T> = T extends Set<infer U> ? Array<U> : T;
 
+type CoverageReporterContext = Pick<
+  ReporterContext,
+  'changedFiles' | 'sourcesRelatedToTestsInChangedFiles'
+>;
+
 type CoverageReporterSerializedContext = {
-  [K in keyof Pick<
-    ReporterContext,
-    'changedFiles' | 'sourcesRelatedToTestsInChangedFiles'
-  >]: SerializeSet<ReporterContext[K]>;
+  [K in keyof CoverageReporterContext]: SerializeSet<ReporterContext[K]>;
 };
 
 export type CoverageWorkerData = {

--- a/packages/jest-reporters/src/CoverageWorker.ts
+++ b/packages/jest-reporters/src/CoverageWorker.ts
@@ -11,11 +11,20 @@ import type {Config} from '@jest/types';
 import generateEmptyCoverage, {
   CoverageWorkerResult,
 } from './generateEmptyCoverage';
-import type {ReporterContextSerialized} from './types';
+import type {ReporterContext} from './types';
+
+type SerializeSet<T> = T extends Set<infer U> ? Array<U> : T;
+
+type CoverageReporterSerializedContext = {
+  [K in keyof Pick<
+    ReporterContext,
+    'changedFiles' | 'sourcesRelatedToTestsInChangedFiles'
+  >]: SerializeSet<ReporterContext[K]>;
+};
 
 export type CoverageWorkerData = {
   config: Config.ProjectConfig;
-  context: ReporterContextSerialized;
+  context: CoverageReporterSerializedContext;
   globalConfig: Config.GlobalConfig;
   path: string;
 };

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -58,11 +58,6 @@ export type ReporterContext = {
   startRun?: (globalConfig: Config.GlobalConfig) => unknown;
 };
 
-export type ReporterContextSerialized = {
-  changedFiles?: Array<string>;
-  sourcesRelatedToTestsInChangedFiles?: Array<string>;
-};
-
 export type SummaryOptions = {
   currentTestCases?: Array<{test: Test; testCaseResult: TestCaseResult}>;
   estimatedTime?: number;

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -44,15 +44,15 @@ export type TestRunnerOptions = {
   serial: boolean;
 };
 
-// make sure all props here are present in the type below it as well
 export type TestRunnerContext = {
   changedFiles?: Set<string>;
   sourcesRelatedToTestsInChangedFiles?: Set<string>;
 };
 
+type SerializeSet<T> = T extends Set<infer U> ? Array<U> : T;
+
 export type TestRunnerSerializedContext = {
-  changedFiles?: Array<string>;
-  sourcesRelatedToTestsInChangedFiles?: Array<string>;
+  [K in keyof TestRunnerContext]: SerializeSet<TestRunnerContext[K]>;
 };
 
 export type UnsubscribeFn = () => void;


### PR DESCRIPTION
## Summary

This PR is introducing `SerializeSet<T>` helper to build mapped types that need to map `Set<T>` props to `Array<T>`. It simply helps to reduce repetition in ~~code~~ type definitions. 

## Test plan

Gren CI.