### PR TITLE
feat(jest-core): allow using Summary Reporter as stand-alone reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[jest-core]` Pass project config to `globalSetup`/`globalTeardown` function as second argument ([#12440](https://github.com/facebook/jest/pull/12440))
 - `[jest-core]` Stabilize test runners with event emitters ([#12641](https://github.com/facebook/jest/pull/12641))
 - `[jest-core, jest-watcher]` [**BREAKING**] Move `TestWatcher` class to `jest-watcher` package ([#12652](https://github.com/facebook/jest/pull/12652))
+- `[jest-core]` Allow using Summary Reporter as stand-alone reporter ([#12687](https://github.com/facebook/jest/pull/12687))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade jsdom to 19.0.0 ([#12290](https://github.com/facebook/jest/pull/12290))
 - `[jest-environment-jsdom]` [**BREAKING**] Add default `browser` condition to `exportConditions` for `jsdom` environment ([#11924](https://github.com/facebook/jest/pull/11924))
 - `[jest-environment-jsdom]` [**BREAKING**] Pass global config to Jest environment constructor for `jsdom` environment ([#12461](https://github.com/facebook/jest/pull/12461))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -856,6 +856,16 @@ If included in the list, the built-in GitHub Actions Reporter will annotate chan
 }
 ```
 
+#### Summary Reporter
+
+Summary reporter prints out summary of all tests. It is a part of default reporter, hence it will be enabled if `'default'` is included in the list. For instance, you might want to use it as stand-alone reporter instead of the default one, or together with [Silent Reporter](https://github.com/rickhanlonii/jest-silent-reporter):
+
+```json
+{
+  "reporters": ["jest-silent-reporter", "summary"]
+}
+```
+
 #### Custom Reporters
 
 :::tip

--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -142,7 +142,6 @@ describe('Custom Reporters Integration', () => {
       'package.json': JSON.stringify({
         jest: {
           reporters: ['default', '<rootDir>/reporter.js'],
-          testEnvironment: 'node',
         },
       }),
       'reporter.js': `
@@ -167,7 +166,6 @@ describe('Custom Reporters Integration', () => {
         'package.json': JSON.stringify({
           jest: {
             reporters: ['default', '<rootDir>/reporter.mjs'],
-            testEnvironment: 'node',
           },
         }),
         'reporter.mjs': `

--- a/jest.config.ci.mjs
+++ b/jest.config.ci.mjs
@@ -20,5 +20,6 @@ export default {
       'jest-silent-reporter',
       {showPaths: true, showWarnings: true, useDots: true},
     ],
+    'summary',
   ],
 };

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -433,7 +433,7 @@ const normalizeReporters = (options: Config.InitialOptionsWithRootDir) => {
       normalizedReporterConfig[0],
     );
 
-    if (!['default', 'github-actions'].includes(reporterPath)) {
+    if (!['default', 'github-actions', 'summary'].includes(reporterPath)) {
       const reporter = Resolver.findNodeModule(reporterPath, {
         basedir: options.rootDir,
       });


### PR DESCRIPTION
Inspired by https://github.com/rickhanlonii/jest-silent-reporter/pull/29

## Summary

Currently there is no way to use only Summary Reporter. For instance, it might be useful together with Silent Reporter or simply as stand-alone reporter (that’s even more silent, why not?).

This idea came to my mind, while refactoring `setupReporters()` logic. Hence, this PR simplifies logic, adds more tests and one nice feature.

## Test plan

More tests added. All should pass.