### PR TITLE
feat: migrate from `source-map` to `@jridgewell/trace-mapping`

### DIFF
--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -17,6 +17,7 @@
     "@jest/test-result": "^28.0.0-alpha.9",
     "@jest/transform": "^28.0.0-alpha.9",
     "@jest/types": "^28.0.0-alpha.9",
+    "@jridgewell/trace-mapping": "^0.3.4",
     "@types/node": "*",
     "chalk": "^4.0.0",
     "collect-v8-coverage": "^1.0.0",
@@ -31,7 +32,6 @@
     "jest-util": "^28.0.0-alpha.9",
     "jest-worker": "^28.0.0-alpha.9",
     "slash": "^3.0.0",
-    "source-map": "^0.6.1",
     "string-length": "^4.0.1",
     "terminal-link": "^2.0.0",
     "v8-to-istanbul": "^8.1.0"

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'path';
 import {mergeProcessCovs} from '@bcoe/v8-coverage';
+import type {EncodedSourceMap} from '@jridgewell/trace-mapping';
 import chalk = require('chalk');
 import glob = require('glob');
 import * as fs from 'graceful-fs';
@@ -14,7 +15,6 @@ import istanbulCoverage = require('istanbul-lib-coverage');
 import istanbulReport = require('istanbul-lib-report');
 import libSourceMaps = require('istanbul-lib-source-maps');
 import istanbulReports = require('istanbul-reports');
-import type {RawSourceMap} from 'source-map';
 import v8toIstanbul = require('v8-to-istanbul');
 import type {
   AggregatedResult,
@@ -30,12 +30,6 @@ import {Worker} from 'jest-worker';
 import BaseReporter from './BaseReporter';
 import getWatermarks from './getWatermarks';
 import type {CoverageWorker, ReporterContext} from './types';
-
-// This is fixed in a newer versions of source-map, but our dependencies are still stuck on old versions
-interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
-  version: number;
-  file?: string;
-}
 
 const FAIL_COLOR = chalk.bold.red;
 const RUNNING_TEST_COLOR = chalk.bold.dim;
@@ -437,7 +431,7 @@ export default class CoverageReporter extends BaseReporter {
         mergedCoverages.result.map(async res => {
           const fileTransform = fileTransforms.get(res.url);
 
-          let sourcemapContent: FixedRawSourceMap | undefined = undefined;
+          let sourcemapContent: EncodedSourceMap | undefined = undefined;
 
           if (
             fileTransform?.sourceMapPath &&
@@ -456,7 +450,7 @@ export default class CoverageReporter extends BaseReporter {
                   originalSource: fileTransform.originalCode,
                   source: fileTransform.code,
                   sourceMap: {
-                    sourcemap: {file: res.url, ...sourcemapContent},
+                    sourcemap: {file: res.url, ...sourcemapContent} as any,
                   },
                 }
               : {source: fs.readFileSync(res.url, 'utf8')},

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -450,6 +450,7 @@ export default class CoverageReporter extends BaseReporter {
                   originalSource: fileTransform.originalCode,
                   source: fileTransform.code,
                   sourceMap: {
+                    // remove `as any` after https://github.com/istanbuljs/v8-to-istanbul/pull/186 is released
                     sourcemap: {file: res.url, ...sourcemapContent} as any,
                   },
                 }

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -17,9 +17,9 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@jridgewell/trace-mapping": "^0.3.4",
     "callsites": "^3.0.0",
-    "graceful-fs": "^4.2.9",
-    "source-map": "^0.6.1"
+    "graceful-fs": "^4.2.9"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.3"

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -5,23 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {TraceMap, originalPositionFor} from '@jridgewell/trace-mapping';
 import callsites = require('callsites');
 import {readFileSync} from 'graceful-fs';
-import {SourceMapConsumer} from 'source-map';
 import type {SourceMapRegistry} from './types';
 
 // Copied from https://github.com/rexxars/sourcemap-decorate-callsites/blob/5b9735a156964973a75dc62fd2c7f0c1975458e8/lib/index.js#L113-L158
 const addSourceMapConsumer = (
   callsite: callsites.CallSite,
-  consumer: SourceMapConsumer,
+  tracer: TraceMap,
 ) => {
   const getLineNumber = callsite.getLineNumber;
   const getColumnNumber = callsite.getColumnNumber;
-  let position: ReturnType<typeof consumer.originalPositionFor> | null = null;
+  let position: ReturnType<typeof originalPositionFor> | null = null;
 
   function getPosition() {
     if (!position) {
-      position = consumer.originalPositionFor({
+      position = originalPositionFor(tracer, {
         column: getColumnNumber.call(callsite) || -1,
         line: getLineNumber.call(callsite) || -1,
       });
@@ -57,8 +57,7 @@ export default function getCallsite(
   if (sourceMapFileName) {
     try {
       const sourceMap = readFileSync(sourceMapFileName, 'utf8');
-      // @ts-expect-error: Not allowed to pass string
-      addSourceMapConsumer(stack, new SourceMapConsumer(sourceMap));
+      addSourceMapConsumer(stack, new TraceMap(sourceMap));
     } catch {
       // ignore
     }

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/core": "^7.11.6",
     "@jest/types": "^28.0.0-alpha.9",
+    "@jridgewell/trace-mapping": "^0.3.4",
     "babel-plugin-istanbul": "^6.1.1",
     "chalk": "^4.0.0",
     "convert-source-map": "^1.4.0",
@@ -30,7 +31,6 @@
     "micromatch": "^4.0.4",
     "pirates": "^4.0.4",
     "slash": "^3.0.0",
-    "source-map": "^0.6.1",
     "write-file-atomic": "^4.0.1"
   },
   "devDependencies": {

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -26,9 +26,14 @@ export interface Options
   isInternalModule?: boolean;
 }
 
+// `babel` and `@jridgewell/trace-mapping` disagrees
+interface FixedRawSourceMap extends Omit<EncodedSourceMap, 'version'> {
+  version: number;
+}
+
 export type TransformedSource = {
   code: string;
-  map?: EncodedSourceMap | string | null;
+  map?: FixedRawSourceMap | string | null;
 };
 
 export type TransformResult = TransformTypes.TransformResult;

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {RawSourceMap} from 'source-map';
+import type {EncodedSourceMap} from '@jridgewell/trace-mapping';
 import type {Config, TransformTypes} from '@jest/types';
 
 export interface ShouldInstrumentOptions
@@ -26,14 +26,9 @@ export interface Options
   isInternalModule?: boolean;
 }
 
-// This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
-interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
-  version: number;
-}
-
 export type TransformedSource = {
   code: string;
-  map?: FixedRawSourceMap | string | null;
+  map?: EncodedSourceMap | string | null;
 };
 
 export type TransformResult = TransformTypes.TransformResult;

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -26,7 +26,7 @@ export interface Options
   isInternalModule?: boolean;
 }
 
-// `babel` and `@jridgewell/trace-mapping` disagrees
+// `babel` and `@jridgewell/trace-mapping` disagrees - `number` vs `3`
 interface FixedRawSourceMap extends Omit<EncodedSourceMap, 'version'> {
   version: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2758,6 +2758,7 @@ __metadata:
     "@jest/test-utils": ^28.0.0-alpha.9
     "@jest/transform": ^28.0.0-alpha.9
     "@jest/types": ^28.0.0-alpha.9
+    "@jridgewell/trace-mapping": ^0.3.4
     "@types/exit": ^0.1.30
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.3
@@ -2783,7 +2784,6 @@ __metadata:
     jest-worker: ^28.0.0-alpha.9
     mock-fs: ^5.1.2
     slash: ^3.0.0
-    source-map: ^0.6.1
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
     terminal-link: ^2.0.0
@@ -2808,10 +2808,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/source-map@workspace:packages/jest-source-map"
   dependencies:
+    "@jridgewell/trace-mapping": ^0.3.4
     "@types/graceful-fs": ^4.1.3
     callsites: ^3.0.0
     graceful-fs: ^4.2.9
-    source-map: ^0.6.1
   languageName: unknown
   linkType: soft
 
@@ -2872,6 +2872,7 @@ __metadata:
     "@babel/core": ^7.11.6
     "@jest/test-utils": ^28.0.0-alpha.9
     "@jest/types": ^28.0.0-alpha.9
+    "@jridgewell/trace-mapping": ^0.3.4
     "@types/babel__core": ^7.1.14
     "@types/convert-source-map": ^1.5.1
     "@types/fast-json-stable-stringify": ^2.0.0
@@ -2890,7 +2891,6 @@ __metadata:
     micromatch: ^4.0.4
     pirates: ^4.0.4
     slash: ^3.0.0
-    source-map: ^0.6.1
     write-file-atomic: ^4.0.1
   languageName: unknown
   linkType: soft
@@ -2950,7 +2950,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.0":
+"@jridgewell/trace-mapping@npm:^0.3.0, @jridgewell/trace-mapping@npm:^0.3.4":
   version: 0.3.4
   resolution: "@jridgewell/trace-mapping@npm:0.3.4"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Same motivation as https://github.com/istanbuljs/v8-to-istanbul/issues/185.

@jridgewell hi again! 😀 If this PR lands, there's only a single (non-transitive) usage of `source-map` in this repo, and that's https://github.com/facebook/jest/blob/5183c15a8e14089351d6403f4fdb72a6705aa379/e2e/coverage-handlebars/transform-handlebars.js. Would that use case be something you support as well? 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
