### PR TITLE
Fix typo in Jest 28 upgrade docs

### DIFF
--- a/docs/UpgradingToJest28.md
+++ b/docs/UpgradingToJest28.md
@@ -30,7 +30,7 @@ The `extraGlobals` option was renamed to [`sandboxInjectedGlobals`](Configuratio
 
 ### `timers`
 
-The `timers` option was renamed to [`fakeTimers`](Configuration.md#faketimers-object). See [Fake Timers](#fake-timers) section bellow for details.
+The `timers` option was renamed to [`fakeTimers`](Configuration.md#faketimers-object). See [Fake Timers](#fake-timers) section below for details.
 
 ### `testURL`
 


### PR DESCRIPTION
## Summary

Caught a small typo in the Jest 28 upgrade docs from https://github.com/facebook/jest/pull/12633. Fixes the typo.

## Test plan

N/A