### PR TITLE
chore(CI): enable one more Mercurial test

### DIFF
--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -312,13 +312,6 @@ test('onlyChanged in config is overwritten by --all or testPathPattern', () => {
 });
 
 testIfHg('gets changed files for hg', async () => {
-  if (process.env.CI) {
-    // Circle and Travis have very old version of hg (v2, and current
-    // version is v4.2) and its API changed since then and not compatible
-    // any more. Changing the SCM version on CIs is not trivial, so we'll just
-    // skip this test and run it only locally.
-    return;
-  }
   writeFiles(DIR, {
     '.watchmanconfig': '',
     '__tests__/file1.test.js': "require('../file1'); test('file1', () => {});",


### PR DESCRIPTION
Following up #12322

## Summary

Apparently there is one more Mercurial test disable on CI. Should be fine to enable it.

## Test plan

Green CI.