### PR TITLE
refactor(@jest/transform): rename generic `OptionType` to `TransformerConfig`

### DIFF
--- a/docs/CodeTransformation.md
+++ b/docs/CodeTransformation.md
@@ -33,19 +33,20 @@ Remember to include the default `babel-jest` transformer explicitly, if you wish
 You can write your own transformer. The API of a transformer is as follows:
 
 ```ts
-interface TransformOptions<OptionType = unknown> {
+interface TransformOptions<TransformerConfig = unknown> {
   supportsDynamicImport: boolean;
   supportsExportNamespaceFrom: boolean;
   supportsStaticESM: boolean;
   supportsTopLevelAwait: boolean;
   instrument: boolean;
-  /** a cached file system which is used in jest-runtime - useful to improve performance */
+  /** Cached file system which is used by `jest-runtime` to improve performance. */
   cacheFS: Map<string, string>;
-  config: Config.ProjectConfig;
-  /** A stringified version of the configuration - useful in cache busting */
+  /** Jest configuration of currently running project. */
+  config: ProjectConfig;
+  /** Stringified version of the `config` - useful in cache busting. */
   configString: string;
-  /** the options passed through Jest's config by the user */
-  transformerConfig: OptionType;
+  /** Transformer configuration passed through `transform` option by the user. */
+  transformerConfig: TransformerConfig;
 }
 
 type TransformedSource = {
@@ -53,70 +54,70 @@ type TransformedSource = {
   map?: RawSourceMap | string | null;
 };
 
-interface SyncTransformer<OptionType = unknown> {
+interface SyncTransformer<TransformerConfig = unknown> {
   canInstrument?: boolean;
 
   getCacheKey?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => string;
 
   getCacheKeyAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<string>;
 
   process: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => TransformedSource;
 
   processAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<TransformedSource>;
 }
 
-interface AsyncTransformer<OptionType = unknown> {
+interface AsyncTransformer<TransformerConfig = unknown> {
   canInstrument?: boolean;
 
   getCacheKey?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => string;
 
   getCacheKeyAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<string>;
 
   process?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => TransformedSource;
 
   processAsync: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<TransformedSource>;
 }
 
-type Transformer<OptionType = unknown> =
-  | SyncTransformer<OptionType>
-  | AsyncTransformer<OptionType>;
+type Transformer<TransformerConfig = unknown> =
+  | SyncTransformer<TransformerConfig>
+  | AsyncTransformer<TransformerConfig>;
 
 type TransformerCreator<
-  X extends Transformer<OptionType>,
-  OptionType = unknown,
-> = (options?: OptionType) => X;
+  X extends Transformer<TransformerConfig>,
+  TransformerConfig = unknown,
+> = (transformerConfig?: TransformerConfig) => X;
 
 type TransformerFactory<X extends Transformer> = {
   createTransformer: TransformerCreator<X>;

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -57,18 +57,19 @@ export interface RequireAndTranspileModuleOptions
 
 export type StringMap = Map<string, string>;
 
-export interface TransformOptions<OptionType = unknown>
+export interface TransformOptions<TransformerConfig = unknown>
   extends ReducedTransformOptions {
-  /** a cached file system which is used in jest-runtime - useful to improve performance */
+  /** Cached file system which is used by `jest-runtime` to improve performance. */
   cacheFS: StringMap;
+  /** Jest configuration of currently running project. */
   config: Config.ProjectConfig;
-  /** A stringified version of the configuration - useful in cache busting */
+  /** Stringified version of the `config` - useful in cache busting. */
   configString: string;
-  /** the options passed through Jest's config by the user */
-  transformerConfig: OptionType;
+  /** Transformer configuration passed through `transform` option by the user. */
+  transformerConfig: TransformerConfig;
 }
 
-export interface SyncTransformer<OptionType = unknown> {
+export interface SyncTransformer<TransformerConfig = unknown> {
   /**
    * Indicates if the transformer is capable of instrumenting the code for code coverage.
    *
@@ -80,29 +81,29 @@ export interface SyncTransformer<OptionType = unknown> {
   getCacheKey?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => string;
 
   getCacheKeyAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<string>;
 
   process: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => TransformedSource;
 
   processAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<TransformedSource>;
 }
 
-export interface AsyncTransformer<OptionType = unknown> {
+export interface AsyncTransformer<TransformerConfig = unknown> {
   /**
    * Indicates if the transformer is capable of instrumenting the code for code coverage.
    *
@@ -114,25 +115,25 @@ export interface AsyncTransformer<OptionType = unknown> {
   getCacheKey?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => string;
 
   getCacheKeyAsync?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<string>;
 
   process?: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => TransformedSource;
 
   processAsync: (
     sourceText: string,
     sourcePath: string,
-    options: TransformOptions<OptionType>,
+    options: TransformOptions<TransformerConfig>,
   ) => Promise<TransformedSource>;
 }
 
@@ -144,14 +145,14 @@ export interface AsyncTransformer<OptionType = unknown> {
  *
  * For more info on the sync vs async model, see https://jestjs.io/docs/code-transformation#writing-custom-transformers
  */
-export type Transformer<OptionType = unknown> =
-  | SyncTransformer<OptionType>
-  | AsyncTransformer<OptionType>;
+export type Transformer<TransformerConfig = unknown> =
+  | SyncTransformer<TransformerConfig>
+  | AsyncTransformer<TransformerConfig>;
 
 export type TransformerCreator<
-  X extends Transformer<OptionType>,
-  OptionType = unknown,
-> = (options?: OptionType) => X;
+  X extends Transformer<TransformerConfig>,
+  TransformerConfig = unknown,
+> = (transformerConfig?: TransformerConfig) => X;
 
 /**
  * Instead of having your custom transformer implement the Transformer interface


### PR DESCRIPTION
## Summary

`OptionType` generic is puzzling me each I look at typings of custom transformer. Not 100% sure, but perhaps `transformerConfig: TransformerConfig` would work better? More verbose, but also more descriptive.

## Test plan

Green CI.