### PR TITLE
feat(jest-runner): export `TestRunner` interface types and reexport types from other packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 - `[jest-resolve]` Expose `JestResolver`, `AsyncResolver`, `SyncResolver`, `PackageFilter`, `PathFilter` and `PackageJSON` types ([#12707](https://github.com/facebook/jest/pull/12707), ([#12712](https://github.com/facebook/jest/pull/12712))
 - `[jest-runner]` Allow `setupFiles` module to export an async function ([#12042](https://github.com/facebook/jest/pull/12042))
 - `[jest-runner]` Allow passing `testEnvironmentOptions` via docblocks ([#12470](https://github.com/facebook/jest/pull/12470))
-- `[jest-runner]` Exposing `CallbackTestRunner`, `EmittingTestRunner` abstract classes to help typing third party runners ([#12646](https://github.com/facebook/jest/pull/12646))
+- `[jest-runner]` Expose `CallbackTestRunner`, `EmittingTestRunner` abstract classes and `CallbackTestRunnerInterface`, `EmittingTestRunnerInterface` to help typing third party runners ([#12646](https://github.com/facebook/jest/pull/12646), [#12715](https://github.com/facebook/jest/pull/12715))
 - `[jest-runtime]` [**BREAKING**] `Runtime.createHasteMap` now returns a promise ([#12008](https://github.com/facebook/jest/pull/12008))
 - `[jest-runtime]` Calling `jest.resetModules` function will clear FS and transform cache ([#12531](https://github.com/facebook/jest/pull/12531))
 - `[jest-runtime]` [**BREAKING**] Remove `Context` type export, it must be imported from `@jest/test-result` ([#12685](https://github.com/facebook/jest/pull/12685))

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -6,18 +6,21 @@
  */
 
 import {expectType} from 'tsd-lite';
-import type {Test, TestEvents} from '@jest/test-result';
-import type {Config} from '@jest/types';
 import {CallbackTestRunner, EmittingTestRunner} from 'jest-runner';
 import type {
+  CallbackTestRunnerInterface,
+  Config,
+  EmittingTestRunnerInterface,
   OnTestFailure,
   OnTestStart,
   OnTestSuccess,
+  Test,
+  TestEvents,
   TestRunnerContext,
   TestRunnerOptions,
+  TestWatcher,
   UnsubscribeFn,
 } from 'jest-runner';
-import type {TestWatcher} from 'jest-watcher';
 
 const globalConfig = {} as Config.GlobalConfig;
 const runnerContext = {} as TestRunnerContext;
@@ -45,6 +48,32 @@ const callbackRunner = new CallbackRunner(globalConfig, runnerContext);
 expectType<boolean | undefined>(callbackRunner.isSerial);
 expectType<false>(callbackRunner.supportsEventEmitters);
 
+// CallbackTestRunnerInterface
+
+class CustomCallbackRunner implements CallbackTestRunnerInterface {
+  readonly #maxConcurrency: number;
+  readonly #globalConfig: Config.GlobalConfig;
+
+  constructor(globalConfig: Config.GlobalConfig) {
+    this.#globalConfig = globalConfig;
+    this.#maxConcurrency = globalConfig.maxWorkers;
+  }
+
+  async runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    onStart: OnTestStart,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
+    options: TestRunnerOptions,
+  ): Promise<void> {
+    expectType<Config.GlobalConfig>(this.#globalConfig);
+    expectType<number>(this.#maxConcurrency);
+
+    return;
+  }
+}
+
 // EmittingRunner
 
 class EmittingRunner extends EmittingTestRunner {
@@ -71,3 +100,34 @@ const emittingRunner = new EmittingRunner(globalConfig, runnerContext);
 
 expectType<boolean | undefined>(emittingRunner.isSerial);
 expectType<true>(emittingRunner.supportsEventEmitters);
+
+// EmittingTestRunnerInterface
+
+class CustomEmittingRunner implements EmittingTestRunnerInterface {
+  readonly #maxConcurrency: number;
+  readonly #globalConfig: Config.GlobalConfig;
+  readonly supportsEventEmitters = true;
+
+  constructor(globalConfig: Config.GlobalConfig) {
+    this.#globalConfig = globalConfig;
+    this.#maxConcurrency = globalConfig.maxWorkers;
+  }
+
+  async runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void> {
+    expectType<Config.GlobalConfig>(this.#globalConfig);
+    expectType<number>(this.#maxConcurrency);
+
+    return;
+  }
+
+  on<Name extends keyof TestEvents>(
+    eventName: string,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn {
+    return () => {};
+  }
+}

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -27,8 +27,13 @@ interface WorkerInterface extends Worker {
   worker: typeof worker;
 }
 
+export type {Test, TestEvents} from '@jest/test-result';
+export type {Config} from '@jest/types';
+export type {TestWatcher} from 'jest-watcher';
 export {CallbackTestRunner, EmittingTestRunner} from './types';
 export type {
+  CallbackTestRunnerInterface,
+  EmittingTestRunnerInterface,
   OnTestFailure,
   OnTestStart,
   OnTestSuccess,

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -57,6 +57,36 @@ export type TestRunnerSerializedContext = {
 
 export type UnsubscribeFn = () => void;
 
+export interface CallbackTestRunnerInterface {
+  readonly isSerial?: boolean;
+  readonly supportsEventEmitters?: boolean;
+
+  runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    onStart: OnTestStart,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+}
+
+export interface EmittingTestRunnerInterface {
+  readonly isSerial?: boolean;
+  readonly supportsEventEmitters: true;
+
+  runTests(
+    tests: Array<Test>,
+    watcher: TestWatcher,
+    options: TestRunnerOptions,
+  ): Promise<void>;
+
+  on<Name extends keyof TestEvents>(
+    eventName: Name,
+    listener: (eventData: TestEvents[Name]) => void | Promise<void>,
+  ): UnsubscribeFn;
+}
+
 abstract class BaseTestRunner {
   readonly isSerial?: boolean;
   abstract readonly supportsEventEmitters: boolean;
@@ -67,7 +97,10 @@ abstract class BaseTestRunner {
   ) {}
 }
 
-export abstract class CallbackTestRunner extends BaseTestRunner {
+export abstract class CallbackTestRunner
+  extends BaseTestRunner
+  implements CallbackTestRunnerInterface
+{
   readonly supportsEventEmitters = false;
 
   abstract runTests(
@@ -80,7 +113,10 @@ export abstract class CallbackTestRunner extends BaseTestRunner {
   ): Promise<void>;
 }
 
-export abstract class EmittingTestRunner extends BaseTestRunner {
+export abstract class EmittingTestRunner
+  extends BaseTestRunner
+  implements EmittingTestRunnerInterface
+{
   readonly supportsEventEmitters = true;
 
   abstract runTests(


### PR DESCRIPTION
Following up #12646

## Summary

Just tried out `jest-runner` exports added in #12646. All works fine, but gave me somewhat clumsy feel ;D

Would be really useful to have types of other packages reexported. Also `CallbackTestRunnerInterface` and `EmittingTestRunnerInterface` would give more implementation flexibility for the user.

## Test plan

Type tests added.