### PR TITLE
Lock source-map-support verion to 0.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `[jest-runner]` Allow `setupFiles` module to export an async function ([#12042](https://github.com/facebook/jest/pull/12042))
 - `[jest-runner]` Allow passing `testEnvironmentOptions` via docblocks ([#12470](https://github.com/facebook/jest/pull/12470))
 - `[jest-runner]` Expose `CallbackTestRunner`, `EmittingTestRunner` abstract classes and `CallbackTestRunnerInterface`, `EmittingTestRunnerInterface` to help typing third party runners ([#12646](https://github.com/facebook/jest/pull/12646), [#12715](https://github.com/facebook/jest/pull/12715))
+- `[jest-runner]` Lock version of `source-map-support` to 0.5.13 ([#12720](https://github.com/facebook/jest/pull/12720))
 - `[jest-runtime]` [**BREAKING**] `Runtime.createHasteMap` now returns a promise ([#12008](https://github.com/facebook/jest/pull/12008))
 - `[jest-runtime]` Calling `jest.resetModules` function will clear FS and transform cache ([#12531](https://github.com/facebook/jest/pull/12531))
 - `[jest-runtime]` [**BREAKING**] Remove `Context` type export, it must be imported from `@jest/test-result` ([#12685](https://github.com/facebook/jest/pull/12685))

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -36,7 +36,7 @@
     "jest-util": "^28.0.0-alpha.9",
     "jest-watcher": "^28.0.0-alpha.9",
     "jest-worker": "^28.0.0-alpha.11",
-    "source-map-support": "^0.5.6",
+    "source-map-support": "0.5.13",
     "throat": "^6.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13502,7 +13502,7 @@ __metadata:
     jest-util: ^28.0.0-alpha.9
     jest-watcher: ^28.0.0-alpha.9
     jest-worker: ^28.0.0-alpha.11
-    source-map-support: ^0.5.6
+    source-map-support: 0.5.13
     throat: ^6.0.1
     tsd-lite: ^0.5.1
   languageName: unknown
@@ -20294,6 +20294,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-support@npm:0.5.13":
+  version: 0.5.13
+  resolution: "source-map-support@npm:0.5.13"
+  dependencies:
+    buffer-from: ^1.0.0
+    source-map: ^0.6.0
+  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
+  languageName: node
+  linkType: hard
+
 "source-map-support@npm:^0.5.16, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -20301,16 +20311,6 @@ __metadata:
     buffer-from: ^1.0.0
     source-map: ^0.6.0
   checksum: 43e98d700d79af1d36f859bdb7318e601dfc918c7ba2e98456118ebc4c4872b327773e5a1df09b0524e9e5063bb18f0934538eace60cca2710d1fa687645d137
-  languageName: node
-  linkType: hard
-
-"source-map-support@npm:^0.5.6":
-  version: 0.5.13
-  resolution: "source-map-support@npm:0.5.13"
-  dependencies:
-    buffer-from: ^1.0.0
-    source-map: ^0.6.0
-  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

source-map-support 0.5.14 introduces a "breaking change" which will cause the original function name gets lost in the Jest error stack in the jest scenario. see this issue https://github.com/facebook/jest/issues/10633.

I think we should let source-map-support stay to 0.5.13 explicitly on `package.json` because `^0.5.6` could resolve to a version above 0.5.13. this will cause a problem on the user side.

I am working on [Yarn dedupe check](https://github.com/facebook/jest/pull/12717) on ci. When I ran `yarn dedupe` on jest codebase, `source-map-support ` will resolve to the latest version `0.5.21` which break a lot of snapshot test because the "breaking change" source-map-support 0.5.14 introduces. see this run for detail: https://github.com/facebook/jest/pull/12717/checks?check_run_id=6138255708


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Green CI.
