### PR TITLE
chore: revert #12718 and simply do not bundle type declarations of `@jest/globals`

### DIFF
--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -38,16 +38,16 @@ const copyrightSnippet = `
 
 const typesNodeReferenceDirective = '/// <reference types="node" />';
 
+const excludedPackages = new Set(['@jest/globals']);
+
 (async () => {
   const packages = getPackages();
 
   const isTsPackage = p =>
     fs.existsSync(path.resolve(p.packageDir, 'tsconfig.json'));
 
-  const excludedPackages = ['@jest/globals'];
-
   const packagesToBundle = packages.filter(
-    p => isTsPackage(p) && !excludedPackages.includes(p.pkg.name),
+    p => isTsPackage(p) && !excludedPackages.has(p.pkg.name),
   );
 
   console.log(chalk.inverse(' Extracting TypeScript definition files '));

--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -36,22 +36,19 @@ const copyrightSnippet = `
  */
 `.trim();
 
+const typesNodeReferenceDirective = '/// <reference types="node" />';
+
 (async () => {
   const packages = getPackages();
 
   const isTsPackage = p =>
     fs.existsSync(path.resolve(p.packageDir, 'tsconfig.json'));
 
-  const hasMoreThanOneDefinitionFile = p =>
-    fs
-      .readdirSync(path.resolve(p.packageDir, 'build'))
-      .filter(f => f.endsWith('.d.ts')).length > 1;
+  const excludedPackages = ['@jest/globals'];
 
   const packagesToBundle = packages.filter(
-    p => isTsPackage(p) && hasMoreThanOneDefinitionFile(p),
+    p => isTsPackage(p) && !excludedPackages.includes(p.pkg.name),
   );
-
-  const typesNodeReferenceDirective = '/// <reference types="node" />';
 
   console.log(chalk.inverse(' Extracting TypeScript definition files '));
 


### PR DESCRIPTION
## Summary

Must admit, I made a wrong assumption in #12718. Apparently bundling of a single `.d.ts` file is nice idea: exported types get alphabetized and also Prettier makes it all more readable. There is no need of the code I introduced. Better to exclude problematic packages explicitly.

For instance, it looks like there is no need of bundling for `'@jest/globals'`.

Here is `tsc`s output:

<img width="676" alt="Screenshot 2022-04-23 at 16 45 39" src="https://user-images.githubusercontent.com/72159681/164903189-d5e1e1ac-d7fc-46d7-99a3-64fea01a2c08.png">

After bundling:

<img width="679" alt="Screenshot 2022-04-23 at 16 47 16" src="https://user-images.githubusercontent.com/72159681/164904718-2b1f89ca-4924-4ce4-8948-bb0c3add555d.png">


## Test plan

Green CI.