### PR TITLE
fix: replace hash routine md5 with sha256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 ### Fixes
 
+- `[*]` Use `sha256` instead of `md5` as hashing algortihm for compatibility with FIPS systems ([#12722](https://github.com/facebook/jest/pull/12722))
 - `[babel-jest]` [**BREAKING**] Pass `rootDir` as `root` in Babel's options ([#12689](https://github.com/facebook/jest/pull/12689))
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[expect]` Throw useful error if `expect.extend` is called with invalid matchers ([#12488](https://github.com/facebook/jest/pull/12488))

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -78,7 +78,7 @@ function getCacheKeyFromConfig(
 
   const configPath = [babelOptions.config || '', babelOptions.babelrc || ''];
 
-  return createHash('md5')
+  return createHash('sha256')
     .update(THIS_FILE)
     .update('\0', 'utf8')
     .update(JSON.stringify(babelOptions.options))
@@ -98,7 +98,8 @@ function getCacheKeyFromConfig(
     .update(process.env.BABEL_ENV || '')
     .update('\0', 'utf8')
     .update(process.version)
-    .digest('hex');
+    .digest('hex')
+    .substring(0, 32);
 }
 
 function loadBabelConfig(

--- a/packages/jest-circus/src/__mocks__/testUtils.ts
+++ b/packages/jest-circus/src/__mocks__/testUtils.ts
@@ -31,7 +31,10 @@ interface Result extends ExecaSyncReturnValue {
 }
 
 export const runTest = (source: string) => {
-  const filename = createHash('md5').update(source).digest('hex');
+  const filename = createHash('sha256')
+    .update(source)
+    .digest('hex')
+    .substring(0, 32);
   const tmpFilename = path.join(tmpdir(), filename);
 
   const content = `

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -68,10 +68,11 @@ afterEach(() => {
 
 it('picks an id based on the rootDir', async () => {
   const rootDir = '/root/path/foo';
-  const expected = createHash('md5')
+  const expected = createHash('sha256')
     .update('/root/path/foo')
     .update(String(Infinity))
-    .digest('hex');
+    .digest('hex')
+    .substring(0, 32);
   const {options} = await normalize(
     {
       rootDir,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -333,12 +333,13 @@ const normalizeMissingOptions = (
   projectIndex: number,
 ): Config.InitialOptionsWithRootDir => {
   if (!options.id) {
-    options.id = createHash('md5')
+    options.id = createHash('sha256')
       .update(options.rootDir)
       // In case we load config from some path that has the same root dir
       .update(configPath || '')
       .update(String(projectIndex))
-      .digest('hex');
+      .digest('hex')
+      .substring(0, 32);
   }
 
   if (!options.setupFiles) {

--- a/packages/jest-create-cache-key-function/src/index.ts
+++ b/packages/jest-create-cache-key-function/src/index.ts
@@ -49,9 +49,10 @@ function getGlobalCacheKey(files: Array<string>, values: Array<string>) {
   ]
     .reduce(
       (hash, chunk) => hash.update('\0', 'utf8').update(chunk || ''),
-      createHash('md5'),
+      createHash('sha256'),
     )
-    .digest('hex');
+    .digest('hex')
+    .substring(0, 32);
 }
 
 function getCacheKeyFunction(globalCacheKey: string): GetCacheKeyFunction {
@@ -61,7 +62,7 @@ function getCacheKeyFunction(globalCacheKey: string): GetCacheKeyFunction {
     const inferredOptions = options || configString;
     const {config, instrument} = inferredOptions;
 
-    return createHash('md5')
+    return createHash('sha256')
       .update(globalCacheKey)
       .update('\0', 'utf8')
       .update(sourceText)
@@ -69,7 +70,8 @@ function getCacheKeyFunction(globalCacheKey: string): GetCacheKeyFunction {
       .update(config.rootDir ? relative(config.rootDir, sourcePath) : '')
       .update('\0', 'utf8')
       .update(instrument ? 'instrument' : '')
-      .digest('hex');
+      .digest('hex')
+      .substring(0, 32);
   };
 }
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -298,7 +298,10 @@ export default class HasteMap extends EventEmitter {
   }
 
   private async setupCachePath(options: Options): Promise<void> {
-    const rootDirHash = createHash('md5').update(options.rootDir).digest('hex');
+    const rootDirHash = createHash('sha256')
+      .update(options.rootDir)
+      .digest('hex')
+      .substring(0, 32);
     let hasteImplHash = '';
     let dependencyExtractorHash = '';
 
@@ -344,8 +347,11 @@ export default class HasteMap extends EventEmitter {
     id: string,
     ...extra: Array<string>
   ): string {
-    const hash = createHash('md5').update(extra.join(''));
-    return path.join(tmpdir, `${id.replace(/\W/g, '-')}-${hash.digest('hex')}`);
+    const hash = createHash('sha256').update(extra.join(''));
+    return path.join(
+      tmpdir,
+      `${id.replace(/\W/g, '-')}-${hash.digest('hex').substring(0, 32)}`,
+    );
   }
 
   static getModuleMapFromJSON(json: SerializableModuleMap): HasteModuleMap {

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -116,19 +116,21 @@ class ScriptTransformer {
     transformerCacheKey: string | undefined,
   ): string {
     if (transformerCacheKey) {
-      return createHash('md5')
+      return createHash('sha256')
         .update(transformerCacheKey)
         .update(CACHE_VERSION)
-        .digest('hex');
+        .digest('hex')
+        .substring(0, 32);
     }
 
-    return createHash('md5')
+    return createHash('sha256')
       .update(fileData)
       .update(transformOptions.configString)
       .update(transformOptions.instrument ? 'instrument' : '')
       .update(filename)
       .update(CACHE_VERSION)
-      .digest('hex');
+      .digest('hex')
+      .substring(0, 32);
   }
 
   private _getCacheKey(
@@ -869,7 +871,10 @@ const stripShebang = (content: string) => {
  * could get corrupted, out-of-sync, etc.
  */
 function writeCodeCacheFile(cachePath: string, code: string) {
-  const checksum = createHash('md5').update(code).digest('hex');
+  const checksum = createHash('sha256')
+    .update(code)
+    .digest('hex')
+    .substring(0, 32);
   writeCacheFile(cachePath, `${checksum}\n${code}`);
 }
 
@@ -885,7 +890,10 @@ function readCodeCacheFile(cachePath: string): string | null {
     return null;
   }
   const code = content.substring(33);
-  const checksum = createHash('md5').update(code).digest('hex');
+  const checksum = createHash('sha256')
+    .update(code)
+    .digest('hex')
+    .substring(0, 32);
   if (checksum === content.substring(0, 32)) {
     return code;
   }


### PR DESCRIPTION
swapping out the md5 hash routine with sha256 (truncated to 32 chars)
and base64url encoded.
this allows jest to run on a system where openssl is in a fips enabled
mode.

## Summary
https://github.com/facebook/jest/issues/10726

## Test plan
ran e2e tests.