### PR TITLE
feat(jest-resolve): expose `ResolverOptions` type

### DIFF
--- a/packages/jest-resolve/__typetests__/resolver.test.ts
+++ b/packages/jest-resolve/__typetests__/resolver.test.ts
@@ -12,6 +12,7 @@ import type {
   PackageFilter,
   PackageJSON,
   PathFilter,
+  ResolverOptions,
   SyncResolver,
 } from 'jest-resolve';
 
@@ -41,6 +42,21 @@ const pathFilter = (pkg: PackageJSON, path: string, relativePath: string) =>
   relativePath;
 
 expectAssignable<PathFilter>(pathFilter);
+
+// ResolverOptions
+
+function customSyncResolver(path: string, options: ResolverOptions): string {
+  return path;
+}
+expectAssignable<SyncResolver>(customSyncResolver);
+
+async function customAsyncResolver(
+  path: string,
+  options: ResolverOptions,
+): Promise<string> {
+  return path;
+}
+expectAssignable<AsyncResolver>(customAsyncResolver);
 
 // AsyncResolver
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -51,7 +51,7 @@ export type PathFilter = (
   relativePath: string,
 ) => string;
 
-type ResolverOptions = {
+export type ResolverOptions = {
   /** Directory to begin resolving from. */
   basedir: string;
   /** List of export conditions. */

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -37,7 +37,7 @@ export type PackageFilter = (
 ) => PackageJSON;
 
 /**
- * Allows transforms a path within a package.
+ * Allows transforming a path within a package.
  *
  * @param pkg - Parsed `package.json` contents.
  * @param path - Path being resolved.

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -12,6 +12,7 @@ export type {
   SyncResolver,
   PackageFilter,
   PathFilter,
+  ResolverOptions,
 } from './defaultResolver';
 export type {
   FindNodeModuleConfig,


### PR DESCRIPTION
Following up #12707

## Summary

Tried out `jest-resolve` types. Works very nice. Missed one detail before – `ResolverOptions`. Possible to work around, but exposing it as well would be just perfect.

## Test plan

Type test is added.