### PR TITLE
fix(expect): add missing dependency `jest-util`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chore & Maintenance
 
 - `[jest-serializer]` Remove deprecated module from source tree ([#12735](https://github.com/facebook/jest/pull/12735))
+- `[expect]` add missing dependency `jest-util` ([#12744](https://github.com/facebook/jest/pull/12744))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@
 
 ### Fixes
 
+- `[expect]` Add missing dependency `jest-util` ([#12744](https://github.com/facebook/jest/pull/12744))
 - `[jest-circus]` Improve `test.concurrent` ([#12748](https://github.com/facebook/jest/pull/12748))
 - `[jest-resolve]` Correctly throw an error if `jsdom` test environment is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
-- `[expect]` Add missing dependency `jest-util` ([#12744](https://github.com/facebook/jest/pull/12744))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 
 ### Fixes
 
+- `[expect]` add missing dependency `jest-util` ([#12744](https://github.com/facebook/jest/pull/12744))
+
 ### Chore & Maintenance
 
 - `[jest-serializer]` Remove deprecated module from source tree ([#12735](https://github.com/facebook/jest/pull/12735))
-- `[expect]` add missing dependency `jest-util` ([#12744](https://github.com/facebook/jest/pull/12744))
 
 ### Performance
 

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -21,7 +21,8 @@
     "@jest/expect-utils": "^28.0.0",
     "jest-get-type": "^28.0.0",
     "jest-matcher-utils": "^28.0.0",
-    "jest-message-util": "^28.0.0"
+    "jest-message-util": "^28.0.0",
+    "jest-util": "^28.0.0"
   },
   "devDependencies": {
     "@jest/test-utils": "^28.0.0",

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -11,6 +11,7 @@
     {"path": "../jest-get-type"},
     {"path": "../jest-matcher-utils"},
     {"path": "../jest-message-util"},
+    {"path": "../jest-util"},
     {"path": "../test-utils"}
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10241,6 +10241,7 @@ __metadata:
     jest-get-type: ^28.0.0
     jest-matcher-utils: ^28.0.0
     jest-message-util: ^28.0.0
+    jest-util: ^28.0.0
     tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

`expect` depends on `jest-util` but doesn't declare it as a dependency.
https://github.com/facebook/jest/blob/045367ad9ca773536a73efdfad019eeb2778ee32/packages/expect/src/asymmetricMatchers.ts#L16

Fixes https://github.com/yarnpkg/berry/runs/6157024113?check_suite_focus=true#step:4:44

## Test plan

```sh
yarn init -2
yarn add jest@^28
  
echo "it('should pass', () => { expect(true).toBeTruthy(); });" | tee pass.test.js
yarn jest pass.test.js
```