### PR TITLE
fix: correctly throw an error if jest-environment-jsdom is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - `[jest-circus]` Improve `test.concurrent` ([#12748](https://github.com/facebook/jest/pull/12748))
-- `[jest-resolve]` Correctly throw an error if jsdom env is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
+- `[jest-resolve]` Correctly throw an error if `jsdom` env is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - `[jest-circus]` Improve `test.concurrent` ([#12748](https://github.com/facebook/jest/pull/12748))
-- `[jest-resolve]` Correctly throw an error if `jsdom` env is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
+- `[jest-resolve]` Correctly throw an error if `jsdom` test environment is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-circus]` Improve `test.concurrent` ([#12748](https://github.com/facebook/jest/pull/12748))
+- `[jest-resolve]` Correctly throw an error if jsdom env is used, but not installed ([#12749](https://github.com/facebook/jest/pull/12749))
 
 ### Chore & Maintenance
 

--- a/packages/jest-resolve/src/utils.ts
+++ b/packages/jest-resolve/src/utils.ts
@@ -98,7 +98,7 @@ export const resolveTestEnvironment = ({
   testEnvironment: string;
   requireResolveFunction: (moduleName: string) => string;
 }): string => {
-  // we don't want to resolve the actual `jsdom` env if `jest-environment-jsdom` is not installed
+  // we don't want to resolve the actual `jsdom` module if `jest-environment-jsdom` is not installed, but `jsdom` package is
   if (filePath === 'jsdom') {
     filePath = 'jest-environment-jsdom';
   }

--- a/packages/jest-resolve/src/utils.ts
+++ b/packages/jest-resolve/src/utils.ts
@@ -98,6 +98,11 @@ export const resolveTestEnvironment = ({
   testEnvironment: string;
   requireResolveFunction: (moduleName: string) => string;
 }): string => {
+  // we don't want to resolve the actual `jsdom` env if `jest-environment-jsdom` is not installed
+  if (filePath === 'jsdom') {
+    filePath = 'jest-environment-jsdom';
+  }
+
   try {
     return resolveWithPrefix(undefined, {
       filePath,
@@ -108,7 +113,7 @@ export const resolveTestEnvironment = ({
       rootDir,
     });
   } catch (error: any) {
-    if (filePath === 'jsdom' || filePath === 'jest-environment-jsdom') {
+    if (filePath === 'jest-environment-jsdom') {
       error.message +=
         '\n\nAs of Jest 28 "jest-environment-jsdom" is no longer shipped by default, make sure to install it separately.';
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

WIthout this, we return the `jsdom` module if it's installed, resulting in a `TypeError: TestEnvironment is not a constructor`.

<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1404810/165264503-3367650d-8910-4356-96c4-cbb62d78f5ee.png">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tested manually in a reproduction. Hard to test in this repo due to `jest-environment-jsdom` being present

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
