### PR TITLE
fix(expect-utils): Treat ImmutableJS Lists as Sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[@jest/expect-utils]` Fix deep equality of ImmutableJS Lists ([#12763](https://github.com/facebook/jest/pull/12763))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -20,6 +20,7 @@
     "jest-get-type": "^28.0.2"
   },
   "devDependencies": {
+    "immutable": "^4.0.0",
     "jest-matcher-utils": "^28.0.2"
   },
   "engines": {

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {List} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {
   arrayBufferEquality,
@@ -514,6 +515,13 @@ describe('iterableEquality', () => {
     a.set('a', a);
     const b = new Map();
     b.set('a', b);
+
+    expect(iterableEquality(a, b)).toBe(true);
+  });
+
+  test('returns true when given Immutable Lists without an OwnerID', () => {
+    const a = List([1, 2, 3]);
+    const b = a.filter(v => v > 0);
 
     expect(iterableEquality(a, b)).toBe(true);
   });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -238,7 +238,7 @@ function isDomNode(obj: any): boolean {
   );
 }
 
-// SENTINEL constants are from https://github.com/facebook/immutable-js
+// SENTINEL constants are from https://github.com/immutable-js/immutable-js/tree/main/src/predicates
 const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
 const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
 const IS_LIST_SENTINEL = '@@__IMMUTABLE_LIST__@@';

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -241,6 +241,7 @@ function isDomNode(obj: any): boolean {
 // SENTINEL constants are from https://github.com/facebook/immutable-js
 const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
 const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
+const IS_LIST_SENTINEL = '@@__IMMUTABLE_LIST__@@';
 const IS_ORDERED_SENTINEL = '@@__IMMUTABLE_ORDERED__@@';
 
 export function isImmutableUnorderedKeyed(maybeKeyed: any) {
@@ -256,5 +257,12 @@ export function isImmutableUnorderedSet(maybeSet: any) {
     maybeSet &&
     maybeSet[IS_SET_SENTINEL] &&
     !maybeSet[IS_ORDERED_SENTINEL]
+  );
+}
+
+export function isImmutableList(maybeList: any) {
+  return !!(
+    maybeList &&
+    maybeList[IS_LIST_SENTINEL]
   );
 }

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -10,6 +10,7 @@ import {isPrimitive} from 'jest-get-type';
 import {
   equals,
   isA,
+  isImmutableList,
   isImmutableUnorderedKeyed,
   isImmutableUnorderedSet,
 } from './jasmineUtils';
@@ -254,10 +255,12 @@ export const iterableEquality = (
     return false;
   }
 
-  const aEntries = Object.entries(a);
-  const bEntries = Object.entries(b);
-  if (!equals(aEntries, bEntries)) {
-    return false;
+  if (!isImmutableList(a)) {
+    const aEntries = Object.entries(a);
+    const bEntries = Object.entries(b);
+    if (!equals(aEntries, bEntries)) {
+      return false;
+    }
   }
 
   // Remove the first value from the stack of traversed values.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,6 +2606,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect-utils@workspace:packages/expect-utils"
   dependencies:
+    immutable: ^4.0.0
     jest-get-type: ^28.0.2
     jest-matcher-utils: ^28.0.2
   languageName: unknown


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #12752

## Test plan

I could add a test case for `iterableEquality`, but I'd need to introduce `immutable` as a dev dependency. Let me know if you'd like to. Otherwise, this relies on the fact that immutable's `List` implements a similar API to native `Set` objects, importantly, [`.has()`][1].

[1]: https://immutable-js.com/docs/v4.0.0/List/#has()
