### PR TITLE
fix(@jest/transform): throw better error if an invalid return value if encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[@jest/reporters]` Fix trailing slash in matching `coverageThreshold` key ([#12714](https://github.com/facebook/jest/pull/12714))
+- `[@jest/transform]` Throw better error if an invalid return value if encountered ([#12764](https://github.com/facebook/jest/pull/12764))
 
 ### Chore & Maintenance
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -384,7 +384,9 @@ class ScriptTransformer {
       if (processed != null && typeof processed.code === 'string') {
         transformed = processed;
       } else {
-        throw new Error(makeInvalidReturnValueError());
+        const transformPath = this._getTransformPath(filename);
+        invariant(transformPath);
+        throw new Error(makeInvalidReturnValueError(transformPath));
       }
     }
 

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -358,9 +358,12 @@ exports[`ScriptTransformer passes expected transform options to getCacheKeyAsync
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 1`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -368,9 +371,12 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 2`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -378,9 +384,12 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 3`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -388,9 +397,12 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 4`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -398,9 +410,12 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 1`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor-fruits-banana-js" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -408,9 +423,12 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 2`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor-fruits-avocado-js" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -418,9 +436,12 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 3`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor-fruits-kiwi-js" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"
@@ -428,9 +449,12 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 4`] = `
 "<red><bold>● Invalid return value:</></>
-<red>  Code transformer's \`process\` method must return an object containing \`code\` key </>
-<red>  with processed string. If \`processAsync\` method is implemented it must return </>
-<red>  a Promise resolving to an object containing \`code\` key with processed string.</>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
+<red>  "passthrough-preprocessor-fruits-grapefruit-js" </>
+<red>  should return an object or a Promise resolving to an object. The object </>
+<red>  must have \`code\` property with a string of processed code.</>
+<red>  <bold>Upgrading Guide:</></>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
 <red></>"

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -362,7 +362,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  "passthrough-preprocessor" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -375,7 +375,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  "passthrough-preprocessor" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -388,7 +388,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  "passthrough-preprocessor" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -401,7 +401,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  "passthrough-preprocessor" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -414,7 +414,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  "passthrough-preprocessor-fruits-banana-js" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -427,7 +427,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  "passthrough-preprocessor-fruits-avocado-js" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -440,7 +440,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  "passthrough-preprocessor-fruits-kiwi-js" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>
@@ -453,7 +453,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  "passthrough-preprocessor-fruits-grapefruit-js" </>
 <red>  should return an object or a Promise resolving to an object. The object </>
 <red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>Upgrading Guide:</></>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
 <red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
 <red>  <bold>Code Transformation Documentation:</></>
 <red>  https://jestjs.io/docs/code-transformation</>

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -14,16 +14,22 @@ const DOCUMENTATION_NOTE = `  ${chalk.bold(
 )}
   https://jestjs.io/docs/code-transformation
 `;
+const UPGRADE_NOTE = `  ${chalk.bold('Upgrading Guide:')}
+  https://jestjs.io/docs/upgrading-to-jest28#transformer
+`;
 
-export const makeInvalidReturnValueError = (): string =>
+export const makeInvalidReturnValueError = (transformPath: string): string =>
   chalk.red(
     [
       chalk.bold(`${BULLET}Invalid return value:`),
-      "  Code transformer's `process` method must return an object containing `code` key ",
-      '  with processed string. If `processAsync` method is implemented it must return ',
-      '  a Promise resolving to an object containing `code` key with processed string.',
+      '  `process()` or/and `processAsync()` method of code transformer found at ',
+      `  "${slash(transformPath)}" `,
+      '  should return an object or a Promise resolving to an object. The object ',
+      '  must have `code` property with a string of processed code.',
       '',
-    ].join('\n') + DOCUMENTATION_NOTE,
+    ].join('\n') +
+      UPGRADE_NOTE +
+      DOCUMENTATION_NOTE,
   );
 
 export const makeInvalidSourceMapWarning = (

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -14,7 +14,9 @@ const DOCUMENTATION_NOTE = `  ${chalk.bold(
 )}
   https://jestjs.io/docs/code-transformation
 `;
-const UPGRADE_NOTE = `  ${chalk.bold('Upgrading Guide:')}
+const UPGRADE_NOTE = `  ${chalk.bold(
+  'This error may be caused by a breaking change in Jest 28:',
+)}
   https://jestjs.io/docs/upgrading-to-jest28#transformer
 `;
 


### PR DESCRIPTION
From https://github.com/facebook/jest/issues/12750#issuecomment-1109806603

## Summary

As it was mentioned in the comment: if a transformer returns an invalid value, it would be good to include transformer’s path in the error message. Link to Upgrade Guide is also a useful detail.

## Test plan

Green CI.