### PR TITLE
fix(@jest/resolve): Include stringifiedOptions in getModuleIDAsync

### DIFF
--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:899:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:900:17)
       at Object.require (index.js:10:1)"
 `;
 
@@ -70,6 +70,6 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:899:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:900:17)
       at Object.require (index.js:10:1)"
 `;

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`on node >=12.16.0 runs test with native ESM 1`] = `
 "Test Suites: 1 passed, 1 total
-Tests:       32 passed, 32 total
+Tests:       33 passed, 33 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /native-esm.test.js/i."

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -194,6 +194,15 @@ test('can mock module', async () => {
   expect(importedMock.foo).toEqual('bar');
 });
 
+test('can mock transitive module', async () => {
+  jestObject.unstable_mockModule('../index.js', () => ({foo: 'bar'}));
+
+  const importedMock = await import('../reexport.js');
+
+  expect(Object.keys(importedMock)).toEqual(['foo']);
+  expect(importedMock.foo).toEqual('bar');
+});
+
 test('supports imports using "node:" prefix', () => {
   expect(dns).toBe(prefixDns);
 });

--- a/e2e/native-esm/reexport.js
+++ b/e2e/native-esm/reexport.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from './index.js';

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -590,7 +590,8 @@ export default class Resolver {
       moduleType +
       sep +
       (absolutePath ? absolutePath + sep : '') +
-      (mockPath ? mockPath + sep : '');
+      (mockPath ? mockPath + sep : '') +
+      (stringifiedOptions ? stringifiedOptions + sep : '');
 
     this._moduleIDCache.set(key, id);
     return id;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I use native ESM with the `--experimental-vm-modules` flag. When upgrading to Jest 28, `jest.unstable_mockModule` stopped working:

```javascript
  jest.unstable_mockModule("../src/config/oidc.js", () => ({
    OIDC_CLIENT_ID: clientId,
    OIDC_CLIENT_SECRET: clientSecret,
    OIDC_ISSUER_URL: issuerUrl,
  }));

  // Not resolving the transitive mocked module in Jest 28!
  const authHandlers = await import("../src/handlers/oidc.js");
```

I tracked this down to the mock detection failing due to `getModuleID` and `getModuleIDAsync` not generating identical IDs. In this case `getModuleIDAsync` did not append the stringified options, so [the lookup using the ID as a key](https://github.com/facebook/jest/blob/880e04ce927c33713a32362b116e771654c865de/packages/jest-runtime/src/index.ts#L1866-L1877) failed. 

There are other slight differences between `getModuleID` and `getModuleIDAsync` that might lead to similar issues.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- `jest.unstable_mockModule` followed by a dynamic import should resolve the mocked module