### PR TITLE
chore: do not bundle `@jest/types`

### DIFF
--- a/packages/jest-reporters/src/index.ts
+++ b/packages/jest-reporters/src/index.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+import * as utils from './utils';
 
 export type {
   AggregatedResult,
@@ -27,4 +28,4 @@ export type {
   ReporterContext,
   SummaryOptions,
 } from './types';
-export * as utils from './utils';
+export {utils};

--- a/packages/jest-reporters/src/index.ts
+++ b/packages/jest-reporters/src/index.ts
@@ -5,17 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import getResultHeader from './getResultHeader';
-import getSnapshotStatus from './getSnapshotStatus';
-import getSnapshotSummary from './getSnapshotSummary';
-import {
-  formatTestPath,
-  getSummary,
-  printDisplayName,
-  relativePath,
-  trimAndFormatPath,
-} from './utils';
-
 export type {
   AggregatedResult,
   SnapshotSummary,
@@ -38,13 +27,4 @@ export type {
   ReporterContext,
   SummaryOptions,
 } from './types';
-export const utils = {
-  formatTestPath,
-  getResultHeader,
-  getSnapshotStatus,
-  getSnapshotSummary,
-  getSummary,
-  printDisplayName,
-  relativePath,
-  trimAndFormatPath,
-};
+export * as utils from './utils';

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -5,249 +5,251 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type * as Global from './Global';
+import type {Global} from './Global';
 
 type Process = NodeJS.Process;
 
-export type DoneFn = Global.DoneFn;
-export type BlockFn = Global.BlockFn;
-export type BlockName = Global.BlockName;
-export type BlockNameLike = Global.BlockNameLike;
-export type BlockMode = void | 'skip' | 'only' | 'todo';
-export type TestMode = BlockMode;
-export type TestName = Global.TestName;
-export type TestNameLike = Global.TestNameLike;
-export type TestFn = Global.TestFn;
-export type ConcurrentTestFn = Global.ConcurrentTestFn;
-export type HookFn = Global.HookFn;
-export type AsyncFn = TestFn | HookFn;
-export type SharedHookType = 'afterAll' | 'beforeAll';
-export type HookType = SharedHookType | 'afterEach' | 'beforeEach';
-export type TestContext = Global.TestContext;
-export type Exception = any; // Since in JS anything can be thrown as an error.
-export type FormattedError = string; // String representation of error.
-export type Hook = {
-  asyncError: Error;
-  fn: HookFn;
-  type: HookType;
-  parent: DescribeBlock;
-  seenDone: boolean;
-  timeout: number | undefined | null;
-};
+export declare namespace Circus {
+  export type DoneFn = Global.DoneFn;
+  export type BlockFn = Global.BlockFn;
+  export type BlockName = Global.BlockName;
+  export type BlockNameLike = Global.BlockNameLike;
+  export type BlockMode = void | 'skip' | 'only' | 'todo';
+  export type TestMode = BlockMode;
+  export type TestName = Global.TestName;
+  export type TestNameLike = Global.TestNameLike;
+  export type TestFn = Global.TestFn;
+  export type ConcurrentTestFn = Global.ConcurrentTestFn;
+  export type HookFn = Global.HookFn;
+  export type AsyncFn = TestFn | HookFn;
+  export type SharedHookType = 'afterAll' | 'beforeAll';
+  export type HookType = SharedHookType | 'afterEach' | 'beforeEach';
+  export type TestContext = Global.TestContext;
+  export type Exception = any; // Since in JS anything can be thrown as an error.
+  export type FormattedError = string; // String representation of error.
+  export type Hook = {
+    asyncError: Error;
+    fn: HookFn;
+    type: HookType;
+    parent: DescribeBlock;
+    seenDone: boolean;
+    timeout: number | undefined | null;
+  };
 
-export interface EventHandler {
-  (event: AsyncEvent, state: State): void | Promise<void>;
-  (event: SyncEvent, state: State): void;
+  export interface EventHandler {
+    (event: AsyncEvent, state: State): void | Promise<void>;
+    (event: SyncEvent, state: State): void;
+  }
+
+  export type Event = SyncEvent | AsyncEvent;
+
+  export interface JestGlobals extends Global.TestFrameworkGlobals {
+    // we cannot type `expect` properly as it'd create circular dependencies
+    expect: unknown;
+  }
+
+  export type SyncEvent =
+    | {
+        asyncError: Error;
+        mode: BlockMode;
+        name: 'start_describe_definition';
+        blockName: BlockName;
+      }
+    | {
+        mode: BlockMode;
+        name: 'finish_describe_definition';
+        blockName: BlockName;
+      }
+    | {
+        asyncError: Error;
+        name: 'add_hook';
+        hookType: HookType;
+        fn: HookFn;
+        timeout: number | undefined;
+      }
+    | {
+        asyncError: Error;
+        name: 'add_test';
+        testName: TestName;
+        fn: TestFn;
+        mode?: TestMode;
+        concurrent: boolean;
+        timeout: number | undefined;
+      }
+    | {
+        // Any unhandled error that happened outside of test/hooks (unless it is
+        // an `afterAll` hook)
+        name: 'error';
+        error: Exception;
+      };
+
+  export type AsyncEvent =
+    | {
+        // first action to dispatch. Good time to initialize all settings
+        name: 'setup';
+        testNamePattern?: string;
+        runtimeGlobals: JestGlobals;
+        parentProcess: Process;
+      }
+    | {
+        name: 'include_test_location_in_result';
+      }
+    | {
+        name: 'hook_start';
+        hook: Hook;
+      }
+    | {
+        name: 'hook_success';
+        describeBlock?: DescribeBlock;
+        test?: TestEntry;
+        hook: Hook;
+      }
+    | {
+        name: 'hook_failure';
+        error: string | Exception;
+        describeBlock?: DescribeBlock;
+        test?: TestEntry;
+        hook: Hook;
+      }
+    | {
+        name: 'test_fn_start';
+        test: TestEntry;
+      }
+    | {
+        name: 'test_fn_success';
+        test: TestEntry;
+      }
+    | {
+        name: 'test_fn_failure';
+        error: Exception;
+        test: TestEntry;
+      }
+    | {
+        name: 'test_retry';
+        test: TestEntry;
+      }
+    | {
+        // the `test` in this case is all hooks + it/test function, not just the
+        // function passed to `it/test`
+        name: 'test_start';
+        test: TestEntry;
+      }
+    | {
+        name: 'test_skip';
+        test: TestEntry;
+      }
+    | {
+        name: 'test_todo';
+        test: TestEntry;
+      }
+    | {
+        // test failure is defined by presence of errors in `test.errors`,
+        // `test_done` indicates that the test and all its hooks were run,
+        // and nothing else will change it's state in the future. (except third
+        // party extentions/plugins)
+        name: 'test_done';
+        test: TestEntry;
+      }
+    | {
+        name: 'run_describe_start';
+        describeBlock: DescribeBlock;
+      }
+    | {
+        name: 'run_describe_finish';
+        describeBlock: DescribeBlock;
+      }
+    | {
+        name: 'run_start';
+      }
+    | {
+        name: 'run_finish';
+      }
+    | {
+        // Action dispatched after everything is finished and we're about to wrap
+        // things up and return test results to the parent process (caller).
+        name: 'teardown';
+      };
+
+  export type MatcherResults = {
+    actual: unknown;
+    expected: unknown;
+    name: string;
+    pass: boolean;
+  };
+
+  export type TestStatus = 'skip' | 'done' | 'todo';
+  export type TestResult = {
+    duration?: number | null;
+    errors: Array<FormattedError>;
+    errorsDetailed: Array<MatcherResults | unknown>;
+    invocations: number;
+    status: TestStatus;
+    location?: {column: number; line: number} | null;
+    retryReasons: Array<FormattedError>;
+    testPath: Array<TestName | BlockName>;
+  };
+
+  export type RunResult = {
+    unhandledErrors: Array<FormattedError>;
+    testResults: TestResults;
+  };
+
+  export type TestResults = Array<TestResult>;
+
+  export type GlobalErrorHandlers = {
+    uncaughtException: Array<(exception: Exception) => void>;
+    unhandledRejection: Array<
+      (exception: Exception, promise: Promise<unknown>) => void
+    >;
+  };
+
+  export type State = {
+    currentDescribeBlock: DescribeBlock;
+    currentlyRunningTest?: TestEntry | null; // including when hooks are being executed
+    expand?: boolean; // expand error messages
+    hasFocusedTests: boolean; // that are defined using test.only
+    hasStarted: boolean; // whether the rootDescribeBlock has started running
+    // Store process error handlers. During the run we inject our own
+    // handlers (so we could fail tests on unhandled errors) and later restore
+    // the original ones.
+    originalGlobalErrorHandlers?: GlobalErrorHandlers;
+    parentProcess: Process | null; // process object from the outer scope
+    rootDescribeBlock: DescribeBlock;
+    testNamePattern?: RegExp | null;
+    testTimeout: number;
+    unhandledErrors: Array<Exception>;
+    includeTestLocationInResult: boolean;
+    maxConcurrency: number;
+  };
+
+  export type DescribeBlock = {
+    type: 'describeBlock';
+    children: Array<DescribeBlock | TestEntry>;
+    hooks: Array<Hook>;
+    mode: BlockMode;
+    name: BlockName;
+    parent?: DescribeBlock;
+    /** @deprecated Please get from `children` array instead */
+    tests: Array<TestEntry>;
+  };
+
+  export type TestError = Exception | [Exception | undefined, Exception]; // the error from the test, as well as a backup error for async
+
+  export type TestEntry = {
+    type: 'test';
+    asyncError: Exception; // Used if the test failure contains no usable stack trace
+    errors: Array<TestError>;
+    retryReasons: Array<TestError>;
+    fn: TestFn;
+    invocations: number;
+    mode: TestMode;
+    concurrent: boolean;
+    name: TestName;
+    parent: DescribeBlock;
+    startedAt?: number | null;
+    duration?: number | null;
+    seenDone: boolean;
+    status?: TestStatus | null; // whether the test has been skipped or run already
+    timeout?: number;
+  };
 }
-
-export type Event = SyncEvent | AsyncEvent;
-
-interface JestGlobals extends Global.TestFrameworkGlobals {
-  // we cannot type `expect` properly as it'd create circular dependencies
-  expect: unknown;
-}
-
-export type SyncEvent =
-  | {
-      asyncError: Error;
-      mode: BlockMode;
-      name: 'start_describe_definition';
-      blockName: BlockName;
-    }
-  | {
-      mode: BlockMode;
-      name: 'finish_describe_definition';
-      blockName: BlockName;
-    }
-  | {
-      asyncError: Error;
-      name: 'add_hook';
-      hookType: HookType;
-      fn: HookFn;
-      timeout: number | undefined;
-    }
-  | {
-      asyncError: Error;
-      name: 'add_test';
-      testName: TestName;
-      fn: TestFn;
-      mode?: TestMode;
-      concurrent: boolean;
-      timeout: number | undefined;
-    }
-  | {
-      // Any unhandled error that happened outside of test/hooks (unless it is
-      // an `afterAll` hook)
-      name: 'error';
-      error: Exception;
-    };
-
-export type AsyncEvent =
-  | {
-      // first action to dispatch. Good time to initialize all settings
-      name: 'setup';
-      testNamePattern?: string;
-      runtimeGlobals: JestGlobals;
-      parentProcess: Process;
-    }
-  | {
-      name: 'include_test_location_in_result';
-    }
-  | {
-      name: 'hook_start';
-      hook: Hook;
-    }
-  | {
-      name: 'hook_success';
-      describeBlock?: DescribeBlock;
-      test?: TestEntry;
-      hook: Hook;
-    }
-  | {
-      name: 'hook_failure';
-      error: string | Exception;
-      describeBlock?: DescribeBlock;
-      test?: TestEntry;
-      hook: Hook;
-    }
-  | {
-      name: 'test_fn_start';
-      test: TestEntry;
-    }
-  | {
-      name: 'test_fn_success';
-      test: TestEntry;
-    }
-  | {
-      name: 'test_fn_failure';
-      error: Exception;
-      test: TestEntry;
-    }
-  | {
-      name: 'test_retry';
-      test: TestEntry;
-    }
-  | {
-      // the `test` in this case is all hooks + it/test function, not just the
-      // function passed to `it/test`
-      name: 'test_start';
-      test: TestEntry;
-    }
-  | {
-      name: 'test_skip';
-      test: TestEntry;
-    }
-  | {
-      name: 'test_todo';
-      test: TestEntry;
-    }
-  | {
-      // test failure is defined by presence of errors in `test.errors`,
-      // `test_done` indicates that the test and all its hooks were run,
-      // and nothing else will change it's state in the future. (except third
-      // party extentions/plugins)
-      name: 'test_done';
-      test: TestEntry;
-    }
-  | {
-      name: 'run_describe_start';
-      describeBlock: DescribeBlock;
-    }
-  | {
-      name: 'run_describe_finish';
-      describeBlock: DescribeBlock;
-    }
-  | {
-      name: 'run_start';
-    }
-  | {
-      name: 'run_finish';
-    }
-  | {
-      // Action dispatched after everything is finished and we're about to wrap
-      // things up and return test results to the parent process (caller).
-      name: 'teardown';
-    };
-
-export type MatcherResults = {
-  actual: unknown;
-  expected: unknown;
-  name: string;
-  pass: boolean;
-};
-
-export type TestStatus = 'skip' | 'done' | 'todo';
-export type TestResult = {
-  duration?: number | null;
-  errors: Array<FormattedError>;
-  errorsDetailed: Array<MatcherResults | unknown>;
-  invocations: number;
-  status: TestStatus;
-  location?: {column: number; line: number} | null;
-  retryReasons: Array<FormattedError>;
-  testPath: Array<TestName | BlockName>;
-};
-
-export type RunResult = {
-  unhandledErrors: Array<FormattedError>;
-  testResults: TestResults;
-};
-
-export type TestResults = Array<TestResult>;
-
-export type GlobalErrorHandlers = {
-  uncaughtException: Array<(exception: Exception) => void>;
-  unhandledRejection: Array<
-    (exception: Exception, promise: Promise<unknown>) => void
-  >;
-};
-
-export type State = {
-  currentDescribeBlock: DescribeBlock;
-  currentlyRunningTest?: TestEntry | null; // including when hooks are being executed
-  expand?: boolean; // expand error messages
-  hasFocusedTests: boolean; // that are defined using test.only
-  hasStarted: boolean; // whether the rootDescribeBlock has started running
-  // Store process error handlers. During the run we inject our own
-  // handlers (so we could fail tests on unhandled errors) and later restore
-  // the original ones.
-  originalGlobalErrorHandlers?: GlobalErrorHandlers;
-  parentProcess: Process | null; // process object from the outer scope
-  rootDescribeBlock: DescribeBlock;
-  testNamePattern?: RegExp | null;
-  testTimeout: number;
-  unhandledErrors: Array<Exception>;
-  includeTestLocationInResult: boolean;
-  maxConcurrency: number;
-};
-
-export type DescribeBlock = {
-  type: 'describeBlock';
-  children: Array<DescribeBlock | TestEntry>;
-  hooks: Array<Hook>;
-  mode: BlockMode;
-  name: BlockName;
-  parent?: DescribeBlock;
-  /** @deprecated Please get from `children` array instead */
-  tests: Array<TestEntry>;
-};
-
-export type TestError = Exception | [Exception | undefined, Exception]; // the error from the test, as well as a backup error for async
-
-export type TestEntry = {
-  type: 'test';
-  asyncError: Exception; // Used if the test failure contains no usable stack trace
-  errors: Array<TestError>;
-  retryReasons: Array<TestError>;
-  fn: TestFn;
-  invocations: number;
-  mode: TestMode;
-  concurrent: boolean;
-  name: TestName;
-  parent: DescribeBlock;
-  startedAt?: number | null;
-  duration?: number | null;
-  seenDone: boolean;
-  status?: TestStatus | null; // whether the test has been skipped or run already
-  timeout?: number;
-};

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -10,517 +10,265 @@ import type {ReportOptions} from 'istanbul-reports';
 import type {Arguments} from 'yargs';
 import type {SnapshotFormat} from '@jest/schemas';
 
-type CoverageProvider = 'babel' | 'v8';
+export declare namespace Config {
+  export type CoverageProvider = 'babel' | 'v8';
 
-export type FakeableAPI =
-  | 'Date'
-  | 'hrtime'
-  | 'nextTick'
-  | 'performance'
-  | 'queueMicrotask'
-  | 'requestAnimationFrame'
-  | 'cancelAnimationFrame'
-  | 'requestIdleCallback'
-  | 'cancelIdleCallback'
-  | 'setImmediate'
-  | 'clearImmediate'
-  | 'setInterval'
-  | 'clearInterval'
-  | 'setTimeout'
-  | 'clearTimeout';
+  export type FakeableAPI =
+    | 'Date'
+    | 'hrtime'
+    | 'nextTick'
+    | 'performance'
+    | 'queueMicrotask'
+    | 'requestAnimationFrame'
+    | 'cancelAnimationFrame'
+    | 'requestIdleCallback'
+    | 'cancelIdleCallback'
+    | 'setImmediate'
+    | 'clearImmediate'
+    | 'setInterval'
+    | 'clearInterval'
+    | 'setTimeout'
+    | 'clearTimeout';
 
-export type GlobalFakeTimersConfig = {
-  /**
-   * Whether fake timers should be enabled globally for all test files.
-   *
-   * @defaultValue
-   * The default is `false`.
-   * */
-  enableGlobally?: boolean;
-};
-
-export type FakeTimersConfig = {
-  /**
-   * If set to `true` all timers will be advanced automatically
-   * by 20 milliseconds every 20 milliseconds. A custom time delta
-   * may be provided by passing a number.
-   *
-   * @defaultValue
-   * The default is `false`.
-   */
-  advanceTimers?: boolean | number;
-  /**
-   * List of names of APIs (e.g. `Date`, `nextTick()`, `setImmediate()`,
-   * `setTimeout()`) that should not be faked.
-   *
-   * @defaultValue
-   * The default is `[]`, meaning all APIs are faked.
-   * */
-  doNotFake?: Array<FakeableAPI>;
-  /**
-   * Sets current system time to be used by fake timers.
-   *
-   * @defaultValue
-   * The default is `Date.now()`.
-   */
-  now?: number | Date;
-  /**
-   * The maximum number of recursive timers that will be run when calling
-   * `jest.runAllTimers()`.
-   *
-   * @defaultValue
-   * The default is `100_000` timers.
-   */
-  timerLimit?: number;
-  /**
-   * Use the old fake timers implementation instead of one backed by
-   * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
-   *
-   * @defaultValue
-   * The default is `false`.
-   */
-  legacyFakeTimers?: false;
-};
-
-export type LegacyFakeTimersConfig = {
-  /**
-   * Use the old fake timers implementation instead of one backed by
-   * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
-   *
-   * @defaultValue
-   * The default is `false`.
-   */
-  legacyFakeTimers?: true;
-};
-
-type FakeTimers = GlobalFakeTimersConfig &
-  (
-    | (FakeTimersConfig & {
-        now?: Exclude<FakeTimersConfig['now'], Date>;
-      })
-    | LegacyFakeTimersConfig
-  );
-
-export type HasteConfig = {
-  /** Whether to hash files using SHA-1. */
-  computeSha1?: boolean;
-  /** The platform to use as the default, e.g. 'ios'. */
-  defaultPlatform?: string | null;
-  /** Force use of Node's `fs` APIs rather than shelling out to `find` */
-  forceNodeFilesystemAPI?: boolean;
-  /**
-   * Whether to follow symlinks when crawling for files.
-   *   This options cannot be used in projects which use watchman.
-   *   Projects with `watchman` set to true will error if this option is set to true.
-   */
-  enableSymlinks?: boolean;
-  /** string to a custom implementation of Haste. */
-  hasteImplModulePath?: string;
-  /** All platforms to target, e.g ['ios', 'android']. */
-  platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
-  throwOnModuleCollision?: boolean;
-  /** Custom HasteMap module */
-  hasteMapModulePath?: string;
-  /** Whether to retain all files, allowing e.g. search for tests in `node_modules`. */
-  retainAllFiles?: boolean;
-};
-
-export type CoverageReporterName = keyof ReportOptions;
-
-export type CoverageReporterWithOptions<K = CoverageReporterName> =
-  K extends CoverageReporterName
-    ? ReportOptions[K] extends never
-      ? never
-      : [K, Partial<ReportOptions[K]>]
-    : never;
-
-export type CoverageReporters = Array<
-  CoverageReporterName | CoverageReporterWithOptions
->;
-
-export type ReporterConfig = [string, Record<string, unknown>];
-export type TransformerConfig = [string, Record<string, unknown>];
-
-export interface ConfigGlobals {
-  [K: string]: unknown;
-}
-
-export type DefaultOptions = {
-  automock: boolean;
-  bail: number;
-  cache: boolean;
-  cacheDirectory: string;
-  changedFilesWithAncestor: boolean;
-  ci: boolean;
-  clearMocks: boolean;
-  collectCoverage: boolean;
-  coveragePathIgnorePatterns: Array<string>;
-  coverageReporters: Array<CoverageReporterName>;
-  coverageProvider: CoverageProvider;
-  detectLeaks: boolean;
-  detectOpenHandles: boolean;
-  errorOnDeprecated: boolean;
-  expand: boolean;
-  extensionsToTreatAsEsm: Array<string>;
-  fakeTimers: FakeTimers;
-  forceCoverageMatch: Array<string>;
-  globals: ConfigGlobals;
-  haste: HasteConfig;
-  injectGlobals: boolean;
-  listTests: boolean;
-  maxConcurrency: number;
-  maxWorkers: number | string;
-  moduleDirectories: Array<string>;
-  moduleFileExtensions: Array<string>;
-  moduleNameMapper: Record<string, string | Array<string>>;
-  modulePathIgnorePatterns: Array<string>;
-  noStackTrace: boolean;
-  notify: boolean;
-  notifyMode: NotifyMode;
-  passWithNoTests: boolean;
-  prettierPath: string;
-  resetMocks: boolean;
-  resetModules: boolean;
-  restoreMocks: boolean;
-  roots: Array<string>;
-  runTestsByPath: boolean;
-  runner: string;
-  setupFiles: Array<string>;
-  setupFilesAfterEnv: Array<string>;
-  skipFilter: boolean;
-  slowTestThreshold: number;
-  snapshotSerializers: Array<string>;
-  testEnvironment: string;
-  testEnvironmentOptions: Record<string, unknown>;
-  testFailureExitCode: string | number;
-  testLocationInResults: boolean;
-  testMatch: Array<string>;
-  testPathIgnorePatterns: Array<string>;
-  testRegex: Array<string>;
-  testRunner: string;
-  testSequencer: string;
-  transformIgnorePatterns: Array<string>;
-  useStderr: boolean;
-  watch: boolean;
-  watchPathIgnorePatterns: Array<string>;
-  watchman: boolean;
-};
-
-export type DisplayName = {
-  name: string;
-  color: typeof ForegroundColor;
-};
-
-export type InitialOptionsWithRootDir = InitialOptions &
-  Required<Pick<InitialOptions, 'rootDir'>>;
-
-export type InitialProjectOptions = Pick<
-  InitialOptions & {cwd?: string},
-  keyof ProjectConfig
->;
-
-export type InitialOptions = Partial<{
-  automock: boolean;
-  bail: boolean | number;
-  cache: boolean;
-  cacheDirectory: string;
-  ci: boolean;
-  clearMocks: boolean;
-  changedFilesWithAncestor: boolean;
-  changedSince: string;
-  collectCoverage: boolean;
-  collectCoverageFrom: Array<string>;
-  collectCoverageOnlyFrom: {
-    [key: string]: boolean;
+  export type GlobalFakeTimersConfig = {
+    /**
+     * Whether fake timers should be enabled globally for all test files.
+     *
+     * @defaultValue
+     * The default is `false`.
+     * */
+    enableGlobally?: boolean;
   };
-  coverageDirectory: string;
-  coveragePathIgnorePatterns: Array<string>;
-  coverageProvider: CoverageProvider;
-  coverageReporters: CoverageReporters;
-  coverageThreshold: CoverageThreshold;
-  dependencyExtractor: string;
-  detectLeaks: boolean;
-  detectOpenHandles: boolean;
-  displayName: string | DisplayName;
-  expand: boolean;
-  extensionsToTreatAsEsm: Array<string>;
-  fakeTimers: FakeTimers;
-  filter: string;
-  findRelatedTests: boolean;
-  forceCoverageMatch: Array<string>;
-  forceExit: boolean;
-  json: boolean;
-  globals: ConfigGlobals;
-  globalSetup: string | null | undefined;
-  globalTeardown: string | null | undefined;
-  haste: HasteConfig;
-  id: string;
-  injectGlobals: boolean;
-  reporters: Array<string | ReporterConfig>;
-  logHeapUsage: boolean;
-  lastCommit: boolean;
-  listTests: boolean;
-  maxConcurrency: number;
-  maxWorkers: number | string;
-  moduleDirectories: Array<string>;
-  moduleFileExtensions: Array<string>;
-  moduleNameMapper: {
-    [key: string]: string | Array<string>;
+
+  export type FakeTimersConfig = {
+    /**
+     * If set to `true` all timers will be advanced automatically
+     * by 20 milliseconds every 20 milliseconds. A custom time delta
+     * may be provided by passing a number.
+     *
+     * @defaultValue
+     * The default is `false`.
+     */
+    advanceTimers?: boolean | number;
+    /**
+     * List of names of APIs (e.g. `Date`, `nextTick()`, `setImmediate()`,
+     * `setTimeout()`) that should not be faked.
+     *
+     * @defaultValue
+     * The default is `[]`, meaning all APIs are faked.
+     * */
+    doNotFake?: Array<FakeableAPI>;
+    /**
+     * Sets current system time to be used by fake timers.
+     *
+     * @defaultValue
+     * The default is `Date.now()`.
+     */
+    now?: number | Date;
+    /**
+     * The maximum number of recursive timers that will be run when calling
+     * `jest.runAllTimers()`.
+     *
+     * @defaultValue
+     * The default is `100_000` timers.
+     */
+    timerLimit?: number;
+    /**
+     * Use the old fake timers implementation instead of one backed by
+     * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
+     *
+     * @defaultValue
+     * The default is `false`.
+     */
+    legacyFakeTimers?: false;
   };
-  modulePathIgnorePatterns: Array<string>;
-  modulePaths: Array<string>;
-  noStackTrace: boolean;
-  notify: boolean;
-  notifyMode: string;
-  onlyChanged: boolean;
-  onlyFailures: boolean;
-  outputFile: string;
-  passWithNoTests: boolean;
-  preset: string | null | undefined;
-  prettierPath: string | null | undefined;
-  projects: Array<string | InitialProjectOptions>;
-  replname: string | null | undefined;
-  resetMocks: boolean;
-  resetModules: boolean;
-  resolver: string | null | undefined;
-  restoreMocks: boolean;
-  rootDir: string;
-  roots: Array<string>;
-  runner: string;
-  runTestsByPath: boolean;
-  runtime: string;
-  sandboxInjectedGlobals: Array<string>;
-  setupFiles: Array<string>;
-  setupFilesAfterEnv: Array<string>;
-  silent: boolean;
-  skipFilter: boolean;
-  skipNodeResolution: boolean;
-  slowTestThreshold: number;
-  snapshotResolver: string;
-  snapshotSerializers: Array<string>;
-  snapshotFormat: SnapshotFormat;
-  errorOnDeprecated: boolean;
-  testEnvironment: string;
-  testEnvironmentOptions: Record<string, unknown>;
-  testFailureExitCode: string | number;
-  testLocationInResults: boolean;
-  testMatch: Array<string>;
-  testNamePattern: string;
-  testPathIgnorePatterns: Array<string>;
-  testRegex: string | Array<string>;
-  testResultsProcessor: string;
-  testRunner: string;
-  testSequencer: string;
-  testTimeout: number;
-  transform: {
-    [regex: string]: string | TransformerConfig;
+
+  export type LegacyFakeTimersConfig = {
+    /**
+     * Use the old fake timers implementation instead of one backed by
+     * [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers).
+     *
+     * @defaultValue
+     * The default is `false`.
+     */
+    legacyFakeTimers?: true;
   };
-  transformIgnorePatterns: Array<string>;
-  watchPathIgnorePatterns: Array<string>;
-  unmockedModulePathPatterns: Array<string>;
-  updateSnapshot: boolean;
-  useStderr: boolean;
-  verbose?: boolean;
-  watch: boolean;
-  watchAll: boolean;
-  watchman: boolean;
-  watchPlugins: Array<string | [string, Record<string, unknown>]>;
-}>;
 
-export type SnapshotUpdateState = 'all' | 'new' | 'none';
+  export type FakeTimers = GlobalFakeTimersConfig &
+    (
+      | (FakeTimersConfig & {
+          now?: Exclude<FakeTimersConfig['now'], Date>;
+        })
+      | LegacyFakeTimersConfig
+    );
 
-type NotifyMode =
-  | 'always'
-  | 'failure'
-  | 'success'
-  | 'change'
-  | 'success-change'
-  | 'failure-change';
-
-export type CoverageThresholdValue = {
-  branches?: number;
-  functions?: number;
-  lines?: number;
-  statements?: number;
-};
-
-type CoverageThreshold = {
-  [path: string]: CoverageThresholdValue;
-  global: CoverageThresholdValue;
-};
-
-type ShardConfig = {
-  shardIndex: number;
-  shardCount: number;
-};
-
-export type GlobalConfig = {
-  bail: number;
-  changedSince?: string;
-  changedFilesWithAncestor: boolean;
-  ci: boolean;
-  collectCoverage: boolean;
-  collectCoverageFrom: Array<string>;
-  collectCoverageOnlyFrom?: {
-    [key: string]: boolean;
+  export type HasteConfig = {
+    /** Whether to hash files using SHA-1. */
+    computeSha1?: boolean;
+    /** The platform to use as the default, e.g. 'ios'. */
+    defaultPlatform?: string | null;
+    /** Force use of Node's `fs` APIs rather than shelling out to `find` */
+    forceNodeFilesystemAPI?: boolean;
+    /**
+     * Whether to follow symlinks when crawling for files.
+     *   This options cannot be used in projects which use watchman.
+     *   Projects with `watchman` set to true will error if this option is set to true.
+     */
+    enableSymlinks?: boolean;
+    /** string to a custom implementation of Haste. */
+    hasteImplModulePath?: string;
+    /** All platforms to target, e.g ['ios', 'android']. */
+    platforms?: Array<string>;
+    /** Whether to throw on error on module collision. */
+    throwOnModuleCollision?: boolean;
+    /** Custom HasteMap module */
+    hasteMapModulePath?: string;
+    /** Whether to retain all files, allowing e.g. search for tests in `node_modules`. */
+    retainAllFiles?: boolean;
   };
-  coverageDirectory: string;
-  coveragePathIgnorePatterns?: Array<string>;
-  coverageProvider: CoverageProvider;
-  coverageReporters: CoverageReporters;
-  coverageThreshold?: CoverageThreshold;
-  detectLeaks: boolean;
-  detectOpenHandles: boolean;
-  expand: boolean;
-  filter?: string;
-  findRelatedTests: boolean;
-  forceExit: boolean;
-  json: boolean;
-  globalSetup?: string;
-  globalTeardown?: string;
-  lastCommit: boolean;
-  logHeapUsage: boolean;
-  listTests: boolean;
-  maxConcurrency: number;
-  maxWorkers: number;
-  noStackTrace: boolean;
-  nonFlagArgs: Array<string>;
-  noSCM?: boolean;
-  notify: boolean;
-  notifyMode: NotifyMode;
-  outputFile?: string;
-  onlyChanged: boolean;
-  onlyFailures: boolean;
-  passWithNoTests: boolean;
-  projects: Array<string>;
-  replname?: string;
-  reporters?: Array<ReporterConfig>;
-  runTestsByPath: boolean;
-  rootDir: string;
-  shard?: ShardConfig;
-  silent?: boolean;
-  skipFilter: boolean;
-  snapshotFormat: SnapshotFormat;
-  errorOnDeprecated: boolean;
-  testFailureExitCode: number;
-  testNamePattern?: string;
-  testPathPattern: string;
-  testResultsProcessor?: string;
-  testSequencer: string;
-  testTimeout?: number;
-  updateSnapshot: SnapshotUpdateState;
-  useStderr: boolean;
-  verbose?: boolean;
-  watch: boolean;
-  watchAll: boolean;
-  watchman: boolean;
-  watchPlugins?: Array<{
-    path: string;
-    config: Record<string, unknown>;
-  }> | null;
-};
 
-export type ProjectConfig = {
-  automock: boolean;
-  cache: boolean;
-  cacheDirectory: string;
-  clearMocks: boolean;
-  coveragePathIgnorePatterns: Array<string>;
-  cwd: string;
-  dependencyExtractor?: string;
-  detectLeaks: boolean;
-  detectOpenHandles: boolean;
-  displayName?: DisplayName;
-  errorOnDeprecated: boolean;
-  extensionsToTreatAsEsm: Array<string>;
-  fakeTimers: FakeTimers;
-  filter?: string;
-  forceCoverageMatch: Array<string>;
-  globalSetup?: string;
-  globalTeardown?: string;
-  globals: ConfigGlobals;
-  haste: HasteConfig;
-  id: string;
-  injectGlobals: boolean;
-  moduleDirectories: Array<string>;
-  moduleFileExtensions: Array<string>;
-  moduleNameMapper: Array<[string, string]>;
-  modulePathIgnorePatterns: Array<string>;
-  modulePaths?: Array<string>;
-  prettierPath: string;
-  resetMocks: boolean;
-  resetModules: boolean;
-  resolver?: string;
-  restoreMocks: boolean;
-  rootDir: string;
-  roots: Array<string>;
-  runner: string;
-  runtime?: string;
-  sandboxInjectedGlobals: Array<keyof typeof globalThis>;
-  setupFiles: Array<string>;
-  setupFilesAfterEnv: Array<string>;
-  skipFilter: boolean;
-  skipNodeResolution?: boolean;
-  slowTestThreshold: number;
-  snapshotResolver?: string;
-  snapshotSerializers: Array<string>;
-  snapshotFormat: SnapshotFormat;
-  testEnvironment: string;
-  testEnvironmentOptions: Record<string, unknown>;
-  testMatch: Array<string>;
-  testLocationInResults: boolean;
-  testPathIgnorePatterns: Array<string>;
-  testRegex: Array<string | RegExp>;
-  testRunner: string;
-  transform: Array<[string, string, Record<string, unknown>]>;
-  transformIgnorePatterns: Array<string>;
-  watchPathIgnorePatterns: Array<string>;
-  unmockedModulePathPatterns?: Array<string>;
-};
+  export type CoverageReporterName = keyof ReportOptions;
 
-export type Argv = Arguments<
-  Partial<{
-    all: boolean;
+  export type CoverageReporterWithOptions<K = CoverageReporterName> =
+    K extends CoverageReporterName
+      ? ReportOptions[K] extends never
+        ? never
+        : [K, Partial<ReportOptions[K]>]
+      : never;
+
+  export type CoverageReporters = Array<
+    CoverageReporterName | CoverageReporterWithOptions
+  >;
+
+  export type ReporterConfig = [string, Record<string, unknown>];
+  export type TransformerConfig = [string, Record<string, unknown>];
+
+  export interface ConfigGlobals {
+    [K: string]: unknown;
+  }
+
+  export type DefaultOptions = {
+    automock: boolean;
+    bail: number;
+    cache: boolean;
+    cacheDirectory: string;
+    changedFilesWithAncestor: boolean;
+    ci: boolean;
+    clearMocks: boolean;
+    collectCoverage: boolean;
+    coveragePathIgnorePatterns: Array<string>;
+    coverageReporters: Array<CoverageReporterName>;
+    coverageProvider: CoverageProvider;
+    detectLeaks: boolean;
+    detectOpenHandles: boolean;
+    errorOnDeprecated: boolean;
+    expand: boolean;
+    extensionsToTreatAsEsm: Array<string>;
+    fakeTimers: FakeTimers;
+    forceCoverageMatch: Array<string>;
+    globals: ConfigGlobals;
+    haste: HasteConfig;
+    injectGlobals: boolean;
+    listTests: boolean;
+    maxConcurrency: number;
+    maxWorkers: number | string;
+    moduleDirectories: Array<string>;
+    moduleFileExtensions: Array<string>;
+    moduleNameMapper: Record<string, string | Array<string>>;
+    modulePathIgnorePatterns: Array<string>;
+    noStackTrace: boolean;
+    notify: boolean;
+    notifyMode: NotifyMode;
+    passWithNoTests: boolean;
+    prettierPath: string;
+    resetMocks: boolean;
+    resetModules: boolean;
+    restoreMocks: boolean;
+    roots: Array<string>;
+    runTestsByPath: boolean;
+    runner: string;
+    setupFiles: Array<string>;
+    setupFilesAfterEnv: Array<string>;
+    skipFilter: boolean;
+    slowTestThreshold: number;
+    snapshotSerializers: Array<string>;
+    testEnvironment: string;
+    testEnvironmentOptions: Record<string, unknown>;
+    testFailureExitCode: string | number;
+    testLocationInResults: boolean;
+    testMatch: Array<string>;
+    testPathIgnorePatterns: Array<string>;
+    testRegex: Array<string>;
+    testRunner: string;
+    testSequencer: string;
+    transformIgnorePatterns: Array<string>;
+    useStderr: boolean;
+    watch: boolean;
+    watchPathIgnorePatterns: Array<string>;
+    watchman: boolean;
+  };
+
+  export type DisplayName = {
+    name: string;
+    color: typeof ForegroundColor;
+  };
+
+  export type InitialOptionsWithRootDir = InitialOptions &
+    Required<Pick<InitialOptions, 'rootDir'>>;
+
+  export type InitialProjectOptions = Pick<
+    InitialOptions & {cwd?: string},
+    keyof ProjectConfig
+  >;
+
+  export type InitialOptions = Partial<{
     automock: boolean;
     bail: boolean | number;
     cache: boolean;
     cacheDirectory: string;
+    ci: boolean;
+    clearMocks: boolean;
     changedFilesWithAncestor: boolean;
     changedSince: string;
-    ci: boolean;
-    clearCache: boolean;
-    clearMocks: boolean;
     collectCoverage: boolean;
-    collectCoverageFrom: string;
-    collectCoverageOnlyFrom: Array<string>;
-    color: boolean;
-    colors: boolean;
-    config: string;
-    coverage: boolean;
+    collectCoverageFrom: Array<string>;
+    collectCoverageOnlyFrom: {
+      [key: string]: boolean;
+    };
     coverageDirectory: string;
     coveragePathIgnorePatterns: Array<string>;
-    coverageReporters: Array<string>;
-    coverageThreshold: string;
-    debug: boolean;
-    env: string;
+    coverageProvider: CoverageProvider;
+    coverageReporters: CoverageReporters;
+    coverageThreshold: CoverageThreshold;
+    dependencyExtractor: string;
+    detectLeaks: boolean;
+    detectOpenHandles: boolean;
+    displayName: string | DisplayName;
     expand: boolean;
+    extensionsToTreatAsEsm: Array<string>;
+    fakeTimers: FakeTimers;
+    filter: string;
     findRelatedTests: boolean;
+    forceCoverageMatch: Array<string>;
     forceExit: boolean;
-    globals: string;
+    json: boolean;
+    globals: ConfigGlobals;
     globalSetup: string | null | undefined;
     globalTeardown: string | null | undefined;
-    haste: string;
-    ignoreProjects: Array<string>;
-    init: boolean;
+    haste: HasteConfig;
+    id: string;
     injectGlobals: boolean;
-    json: boolean;
-    lastCommit: boolean;
+    reporters: Array<string | ReporterConfig>;
     logHeapUsage: boolean;
+    lastCommit: boolean;
+    listTests: boolean;
+    maxConcurrency: number;
     maxWorkers: number | string;
     moduleDirectories: Array<string>;
     moduleFileExtensions: Array<string>;
-    moduleNameMapper: string;
+    moduleNameMapper: {
+      [key: string]: string | Array<string>;
+    };
     modulePathIgnorePatterns: Array<string>;
     modulePaths: Array<string>;
     noStackTrace: boolean;
@@ -529,46 +277,300 @@ export type Argv = Arguments<
     onlyChanged: boolean;
     onlyFailures: boolean;
     outputFile: string;
+    passWithNoTests: boolean;
     preset: string | null | undefined;
     prettierPath: string | null | undefined;
-    projects: Array<string>;
-    reporters: Array<string>;
+    projects: Array<string | InitialProjectOptions>;
+    replname: string | null | undefined;
     resetMocks: boolean;
     resetModules: boolean;
     resolver: string | null | undefined;
     restoreMocks: boolean;
     rootDir: string;
     roots: Array<string>;
-    runInBand: boolean;
-    selectProjects: Array<string>;
+    runner: string;
+    runTestsByPath: boolean;
+    runtime: string;
+    sandboxInjectedGlobals: Array<string>;
     setupFiles: Array<string>;
     setupFilesAfterEnv: Array<string>;
-    shard: string;
-    showConfig: boolean;
     silent: boolean;
+    skipFilter: boolean;
+    skipNodeResolution: boolean;
+    slowTestThreshold: number;
+    snapshotResolver: string;
     snapshotSerializers: Array<string>;
+    snapshotFormat: SnapshotFormat;
+    errorOnDeprecated: boolean;
     testEnvironment: string;
-    testEnvironmentOptions: string;
-    testFailureExitCode: string | null | undefined;
+    testEnvironmentOptions: Record<string, unknown>;
+    testFailureExitCode: string | number;
+    testLocationInResults: boolean;
     testMatch: Array<string>;
     testNamePattern: string;
     testPathIgnorePatterns: Array<string>;
-    testPathPattern: Array<string>;
     testRegex: string | Array<string>;
     testResultsProcessor: string;
     testRunner: string;
     testSequencer: string;
-    testTimeout: number | null | undefined;
-    transform: string;
+    testTimeout: number;
+    transform: {
+      [regex: string]: string | TransformerConfig;
+    };
     transformIgnorePatterns: Array<string>;
-    unmockedModulePathPatterns: Array<string> | null | undefined;
+    watchPathIgnorePatterns: Array<string>;
+    unmockedModulePathPatterns: Array<string>;
     updateSnapshot: boolean;
     useStderr: boolean;
-    verbose: boolean;
-    version: boolean;
+    verbose?: boolean;
     watch: boolean;
     watchAll: boolean;
     watchman: boolean;
+    watchPlugins: Array<string | [string, Record<string, unknown>]>;
+  }>;
+
+  export type SnapshotUpdateState = 'all' | 'new' | 'none';
+
+  export type NotifyMode =
+    | 'always'
+    | 'failure'
+    | 'success'
+    | 'change'
+    | 'success-change'
+    | 'failure-change';
+
+  export type CoverageThresholdValue = {
+    branches?: number;
+    functions?: number;
+    lines?: number;
+    statements?: number;
+  };
+
+  export type CoverageThreshold = {
+    [path: string]: CoverageThresholdValue;
+    global: CoverageThresholdValue;
+  };
+
+  export type ShardConfig = {
+    shardIndex: number;
+    shardCount: number;
+  };
+
+  export type GlobalConfig = {
+    bail: number;
+    changedSince?: string;
+    changedFilesWithAncestor: boolean;
+    ci: boolean;
+    collectCoverage: boolean;
+    collectCoverageFrom: Array<string>;
+    collectCoverageOnlyFrom?: {
+      [key: string]: boolean;
+    };
+    coverageDirectory: string;
+    coveragePathIgnorePatterns?: Array<string>;
+    coverageProvider: CoverageProvider;
+    coverageReporters: CoverageReporters;
+    coverageThreshold?: CoverageThreshold;
+    detectLeaks: boolean;
+    detectOpenHandles: boolean;
+    expand: boolean;
+    filter?: string;
+    findRelatedTests: boolean;
+    forceExit: boolean;
+    json: boolean;
+    globalSetup?: string;
+    globalTeardown?: string;
+    lastCommit: boolean;
+    logHeapUsage: boolean;
+    listTests: boolean;
+    maxConcurrency: number;
+    maxWorkers: number;
+    noStackTrace: boolean;
+    nonFlagArgs: Array<string>;
+    noSCM?: boolean;
+    notify: boolean;
+    notifyMode: NotifyMode;
+    outputFile?: string;
+    onlyChanged: boolean;
+    onlyFailures: boolean;
+    passWithNoTests: boolean;
+    projects: Array<string>;
+    replname?: string;
+    reporters?: Array<ReporterConfig>;
+    runTestsByPath: boolean;
+    rootDir: string;
+    shard?: ShardConfig;
+    silent?: boolean;
+    skipFilter: boolean;
+    snapshotFormat: SnapshotFormat;
+    errorOnDeprecated: boolean;
+    testFailureExitCode: number;
+    testNamePattern?: string;
+    testPathPattern: string;
+    testResultsProcessor?: string;
+    testSequencer: string;
+    testTimeout?: number;
+    updateSnapshot: SnapshotUpdateState;
+    useStderr: boolean;
+    verbose?: boolean;
+    watch: boolean;
+    watchAll: boolean;
+    watchman: boolean;
+    watchPlugins?: Array<{
+      path: string;
+      config: Record<string, unknown>;
+    }> | null;
+  };
+
+  export type ProjectConfig = {
+    automock: boolean;
+    cache: boolean;
+    cacheDirectory: string;
+    clearMocks: boolean;
+    coveragePathIgnorePatterns: Array<string>;
+    cwd: string;
+    dependencyExtractor?: string;
+    detectLeaks: boolean;
+    detectOpenHandles: boolean;
+    displayName?: DisplayName;
+    errorOnDeprecated: boolean;
+    extensionsToTreatAsEsm: Array<string>;
+    fakeTimers: FakeTimers;
+    filter?: string;
+    forceCoverageMatch: Array<string>;
+    globalSetup?: string;
+    globalTeardown?: string;
+    globals: ConfigGlobals;
+    haste: HasteConfig;
+    id: string;
+    injectGlobals: boolean;
+    moduleDirectories: Array<string>;
+    moduleFileExtensions: Array<string>;
+    moduleNameMapper: Array<[string, string]>;
+    modulePathIgnorePatterns: Array<string>;
+    modulePaths?: Array<string>;
+    prettierPath: string;
+    resetMocks: boolean;
+    resetModules: boolean;
+    resolver?: string;
+    restoreMocks: boolean;
+    rootDir: string;
+    roots: Array<string>;
+    runner: string;
+    runtime?: string;
+    sandboxInjectedGlobals: Array<keyof typeof globalThis>;
+    setupFiles: Array<string>;
+    setupFilesAfterEnv: Array<string>;
+    skipFilter: boolean;
+    skipNodeResolution?: boolean;
+    slowTestThreshold: number;
+    snapshotResolver?: string;
+    snapshotSerializers: Array<string>;
+    snapshotFormat: SnapshotFormat;
+    testEnvironment: string;
+    testEnvironmentOptions: Record<string, unknown>;
+    testMatch: Array<string>;
+    testLocationInResults: boolean;
+    testPathIgnorePatterns: Array<string>;
+    testRegex: Array<string | RegExp>;
+    testRunner: string;
+    transform: Array<[string, string, Record<string, unknown>]>;
+    transformIgnorePatterns: Array<string>;
     watchPathIgnorePatterns: Array<string>;
-  }>
->;
+    unmockedModulePathPatterns?: Array<string>;
+  };
+
+  export type Argv = Arguments<
+    Partial<{
+      all: boolean;
+      automock: boolean;
+      bail: boolean | number;
+      cache: boolean;
+      cacheDirectory: string;
+      changedFilesWithAncestor: boolean;
+      changedSince: string;
+      ci: boolean;
+      clearCache: boolean;
+      clearMocks: boolean;
+      collectCoverage: boolean;
+      collectCoverageFrom: string;
+      collectCoverageOnlyFrom: Array<string>;
+      color: boolean;
+      colors: boolean;
+      config: string;
+      coverage: boolean;
+      coverageDirectory: string;
+      coveragePathIgnorePatterns: Array<string>;
+      coverageReporters: Array<string>;
+      coverageThreshold: string;
+      debug: boolean;
+      env: string;
+      expand: boolean;
+      findRelatedTests: boolean;
+      forceExit: boolean;
+      globals: string;
+      globalSetup: string | null | undefined;
+      globalTeardown: string | null | undefined;
+      haste: string;
+      ignoreProjects: Array<string>;
+      init: boolean;
+      injectGlobals: boolean;
+      json: boolean;
+      lastCommit: boolean;
+      logHeapUsage: boolean;
+      maxWorkers: number | string;
+      moduleDirectories: Array<string>;
+      moduleFileExtensions: Array<string>;
+      moduleNameMapper: string;
+      modulePathIgnorePatterns: Array<string>;
+      modulePaths: Array<string>;
+      noStackTrace: boolean;
+      notify: boolean;
+      notifyMode: string;
+      onlyChanged: boolean;
+      onlyFailures: boolean;
+      outputFile: string;
+      preset: string | null | undefined;
+      prettierPath: string | null | undefined;
+      projects: Array<string>;
+      reporters: Array<string>;
+      resetMocks: boolean;
+      resetModules: boolean;
+      resolver: string | null | undefined;
+      restoreMocks: boolean;
+      rootDir: string;
+      roots: Array<string>;
+      runInBand: boolean;
+      selectProjects: Array<string>;
+      setupFiles: Array<string>;
+      setupFilesAfterEnv: Array<string>;
+      shard: string;
+      showConfig: boolean;
+      silent: boolean;
+      snapshotSerializers: Array<string>;
+      testEnvironment: string;
+      testEnvironmentOptions: string;
+      testFailureExitCode: string | null | undefined;
+      testMatch: Array<string>;
+      testNamePattern: string;
+      testPathIgnorePatterns: Array<string>;
+      testPathPattern: Array<string>;
+      testRegex: string | Array<string>;
+      testResultsProcessor: string;
+      testRunner: string;
+      testSequencer: string;
+      testTimeout: number | null | undefined;
+      transform: string;
+      transformIgnorePatterns: Array<string>;
+      unmockedModulePathPatterns: Array<string> | null | undefined;
+      updateSnapshot: boolean;
+      useStderr: boolean;
+      verbose: boolean;
+      version: boolean;
+      watch: boolean;
+      watchAll: boolean;
+      watchman: boolean;
+      watchPathIgnorePatterns: Array<string>;
+    }>
+  >;
+}

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -7,121 +7,127 @@
 
 import type {CoverageMapData} from 'istanbul-lib-coverage';
 
-export type ValidTestReturnValues = void | undefined;
-type TestReturnValuePromise = Promise<unknown>;
-type TestReturnValueGenerator = Generator<void, unknown, void>;
-export type TestReturnValue = ValidTestReturnValues | TestReturnValuePromise;
+export declare namespace Global {
+  export type ValidTestReturnValues = void | undefined;
+  export type TestReturnValuePromise = Promise<unknown>;
+  export type TestReturnValueGenerator = Generator<void, unknown, void>;
+  export type TestReturnValue = ValidTestReturnValues | TestReturnValuePromise;
 
-export type TestContext = Record<string, unknown>;
+  export type TestContext = Record<string, unknown>;
 
-export type DoneFn = (reason?: string | Error) => void;
+  export type DoneFn = (reason?: string | Error) => void;
 
-export type DoneTakingTestFn = (
-  this: TestContext,
-  done: DoneFn,
-) => ValidTestReturnValues;
-export type PromiseReturningTestFn = (this: TestContext) => TestReturnValue;
-export type GeneratorReturningTestFn = (
-  this: TestContext,
-) => TestReturnValueGenerator;
+  export type DoneTakingTestFn = (
+    this: TestContext,
+    done: DoneFn,
+  ) => ValidTestReturnValues;
+  export type PromiseReturningTestFn = (this: TestContext) => TestReturnValue;
+  export type GeneratorReturningTestFn = (
+    this: TestContext,
+  ) => TestReturnValueGenerator;
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-export type NameLike = number | Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  export type NameLike = number | Function;
 
-export type TestName = string;
-export type TestNameLike = TestName | NameLike;
-export type TestFn =
-  | PromiseReturningTestFn
-  | GeneratorReturningTestFn
-  | DoneTakingTestFn;
-export type ConcurrentTestFn = () => TestReturnValuePromise;
-export type BlockFn = () => void;
-export type BlockName = string;
-export type BlockNameLike = BlockName | NameLike;
+  export type TestName = string;
+  export type TestNameLike = TestName | NameLike;
+  export type TestFn =
+    | PromiseReturningTestFn
+    | GeneratorReturningTestFn
+    | DoneTakingTestFn;
+  export type ConcurrentTestFn = () => TestReturnValuePromise;
+  export type BlockFn = () => void;
+  export type BlockName = string;
+  export type BlockNameLike = BlockName | NameLike;
 
-export type HookFn = TestFn;
+  export type HookFn = TestFn;
 
-export type Col = unknown;
-export type Row = ReadonlyArray<Col>;
-export type Table = ReadonlyArray<Row>;
-export type ArrayTable = Table | Row;
-export type TemplateTable = TemplateStringsArray;
-export type TemplateData = ReadonlyArray<unknown>;
-export type EachTable = ArrayTable | TemplateTable;
+  export type Col = unknown;
+  export type Row = ReadonlyArray<Col>;
+  export type Table = ReadonlyArray<Row>;
+  export type ArrayTable = Table | Row;
+  export type TemplateTable = TemplateStringsArray;
+  export type TemplateData = ReadonlyArray<unknown>;
+  export type EachTable = ArrayTable | TemplateTable;
 
-export type TestCallback = BlockFn | TestFn | ConcurrentTestFn;
+  export type TestCallback = BlockFn | TestFn | ConcurrentTestFn;
 
-export type EachTestFn<EachCallback extends TestCallback> = (
-  ...args: ReadonlyArray<any>
-) => ReturnType<EachCallback>;
+  export type EachTestFn<EachCallback extends TestCallback> = (
+    ...args: ReadonlyArray<any>
+  ) => ReturnType<EachCallback>;
 
-type Each<EachCallback extends TestCallback, Name> =
-  | ((
-      table: EachTable,
-      ...taggedTemplateData: TemplateData
-    ) => (name: Name, test: EachTestFn<EachCallback>, timeout?: number) => void)
-  | (() => () => void);
+  export type Each<EachCallback extends TestCallback, Name> =
+    | ((
+        table: EachTable,
+        ...taggedTemplateData: TemplateData
+      ) => (
+        name: Name,
+        test: EachTestFn<EachCallback>,
+        timeout?: number,
+      ) => void)
+    | (() => () => void);
 
-export interface HookBase {
-  (fn: HookFn, timeout?: number): void;
-}
+  export interface HookBase {
+    (fn: HookFn, timeout?: number): void;
+  }
 
-export interface ItBase {
-  (testName: TestNameLike, fn: TestFn, timeout?: number): void;
-  each: Each<TestFn, TestNameLike>;
-}
+  export interface ItBase {
+    (testName: TestNameLike, fn: TestFn, timeout?: number): void;
+    each: Each<TestFn, TestNameLike>;
+  }
 
-export interface It extends ItBase {
-  only: ItBase;
-  skip: ItBase;
-  todo: (testName: TestNameLike) => void;
-}
+  export interface It extends ItBase {
+    only: ItBase;
+    skip: ItBase;
+    todo: (testName: TestNameLike) => void;
+  }
 
-export interface ItConcurrentBase {
-  (testName: TestNameLike, testFn: ConcurrentTestFn, timeout?: number): void;
-  each: Each<ConcurrentTestFn, TestNameLike>;
-}
+  export interface ItConcurrentBase {
+    (testName: TestNameLike, testFn: ConcurrentTestFn, timeout?: number): void;
+    each: Each<ConcurrentTestFn, TestNameLike>;
+  }
 
-export interface ItConcurrentExtended extends ItConcurrentBase {
-  only: ItConcurrentBase;
-  skip: ItConcurrentBase;
-}
+  export interface ItConcurrentExtended extends ItConcurrentBase {
+    only: ItConcurrentBase;
+    skip: ItConcurrentBase;
+  }
 
-export interface ItConcurrent extends It {
-  concurrent: ItConcurrentExtended;
-}
+  export interface ItConcurrent extends It {
+    concurrent: ItConcurrentExtended;
+  }
 
-export interface DescribeBase {
-  (blockName: BlockNameLike, blockFn: BlockFn): void;
-  each: Each<BlockFn, BlockNameLike | TestNameLike>;
-}
+  export interface DescribeBase {
+    (blockName: BlockNameLike, blockFn: BlockFn): void;
+    each: Each<BlockFn, BlockNameLike | TestNameLike>;
+  }
 
-export interface Describe extends DescribeBase {
-  only: DescribeBase;
-  skip: DescribeBase;
-}
+  export interface Describe extends DescribeBase {
+    only: DescribeBase;
+    skip: DescribeBase;
+  }
 
-export interface TestFrameworkGlobals {
-  it: ItConcurrent;
-  test: ItConcurrent;
-  fit: ItBase & {concurrent?: ItConcurrentBase};
-  xit: ItBase;
-  xtest: ItBase;
-  describe: Describe;
-  xdescribe: DescribeBase;
-  fdescribe: DescribeBase;
-  beforeAll: HookBase;
-  beforeEach: HookBase;
-  afterEach: HookBase;
-  afterAll: HookBase;
-}
+  export interface TestFrameworkGlobals {
+    it: ItConcurrent;
+    test: ItConcurrent;
+    fit: ItBase & {concurrent?: ItConcurrentBase};
+    xit: ItBase;
+    xtest: ItBase;
+    describe: Describe;
+    xdescribe: DescribeBase;
+    fdescribe: DescribeBase;
+    beforeAll: HookBase;
+    beforeEach: HookBase;
+    afterEach: HookBase;
+    afterAll: HookBase;
+  }
 
-export interface GlobalAdditions extends TestFrameworkGlobals {
-  __coverage__: CoverageMapData;
-}
+  export interface GlobalAdditions extends TestFrameworkGlobals {
+    __coverage__: CoverageMapData;
+  }
 
-export interface Global
-  extends GlobalAdditions,
-    Omit<typeof globalThis, keyof GlobalAdditions> {
-  [extras: PropertyKey]: unknown;
+  export interface Global
+    extends GlobalAdditions,
+      Omit<typeof globalThis, keyof GlobalAdditions> {
+    [extras: PropertyKey]: unknown;
+  }
 }

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -5,33 +5,41 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type Milliseconds = number;
-
-type Status = 'passed' | 'failed' | 'skipped' | 'pending' | 'todo' | 'disabled';
-
-type Callsite = {
-  column: number;
-  line: number;
-};
-
 // this is here to make it possible to avoid huge dependency trees just for types
-export type AssertionResult = {
-  ancestorTitles: Array<string>;
-  duration?: Milliseconds | null;
-  failureDetails: Array<unknown>;
-  failureMessages: Array<string>;
-  fullName: string;
-  invocations?: number;
-  location?: Callsite | null;
-  numPassingAsserts: number;
-  retryReasons?: Array<string>;
-  status: Status;
-  title: string;
-};
+export declare namespace TestResult {
+  export type Milliseconds = number;
 
-export type SerializableError = {
-  code?: unknown;
-  message: string;
-  stack: string | null | undefined;
-  type?: string;
-};
+  export type Status =
+    | 'passed'
+    | 'failed'
+    | 'skipped'
+    | 'pending'
+    | 'todo'
+    | 'disabled';
+
+  export type Callsite = {
+    column: number;
+    line: number;
+  };
+
+  export type AssertionResult = {
+    ancestorTitles: Array<string>;
+    duration?: Milliseconds | null;
+    failureDetails: Array<unknown>;
+    failureMessages: Array<string>;
+    fullName: string;
+    invocations?: number;
+    location?: Callsite | null;
+    numPassingAsserts: number;
+    retryReasons?: Array<string>;
+    status: Status;
+    title: string;
+  };
+
+  export type SerializableError = {
+    code?: unknown;
+    message: string;
+    stack: string | null | undefined;
+    type?: string;
+  };
+}

--- a/packages/jest-types/src/Transform.ts
+++ b/packages/jest-types/src/Transform.ts
@@ -6,8 +6,10 @@
  */
 
 // this is here to make it possible to avoid huge dependency trees just for types
-export type TransformResult = {
-  code: string;
-  originalCode: string;
-  sourceMapPath: string | null;
-};
+export declare namespace Transform {
+  export type TransformResult = {
+    code: string;
+    originalCode: string;
+    sourceMapPath: string | null;
+  };
+}

--- a/packages/jest-types/src/index.ts
+++ b/packages/jest-types/src/index.ts
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type * as Circus from './Circus';
-import type * as Config from './Config';
-import type * as Global from './Global';
-import type * as TestResult from './TestResult';
-import type * as TransformTypes from './Transform';
-
-export type {Circus, Config, Global, TestResult, TransformTypes};
+export type {Circus} from './Circus';
+export type {Config} from './Config';
+export type {Global} from './Global';
+export type {TestResult} from './TestResult';
+export type {Transform as TransformTypes} from './Transform';

--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -38,7 +38,7 @@ const copyrightSnippet = `
 
 const typesNodeReferenceDirective = '/// <reference types="node" />';
 
-const excludedPackages = new Set(['@jest/globals', '@jest/types']);
+const excludedPackages = new Set(['@jest/globals']);
 
 (async () => {
   const packages = getPackages();

--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -38,7 +38,7 @@ const copyrightSnippet = `
 
 const typesNodeReferenceDirective = '/// <reference types="node" />';
 
-const excludedPackages = new Set(['@jest/globals']);
+const excludedPackages = new Set(['@jest/globals', '@jest/types']);
 
 (async () => {
   const packages = getPackages();


### PR DESCRIPTION
Fixes #12772

## Summary

#12772 seems to get fixed, if definitions of `@jest/types` are not bundled.

---

`tsc` generates the following definitions for `@jest/reporters`:

```ts
import type { Config } from '@jest/types';
export declare const utils: {
  formatTestPath: (config: import("@jest/types/build/Config").GlobalConfig | import("@jest/types/build/Config").ProjectConfig, testPath: string) => string;
  printDisplayName: (config: import("@jest/types/build/Config").ProjectConfig) => string;
  // ...
};
```

The bundler turns them into:

```ts
import {GlobalConfig} from '@jest/types/build/Config';
import {ProjectConfig} from '@jest/types/build/Config';
export declare const utils: {
  formatTestPath: (
    config: GlobalConfig | ProjectConfig,
    testPath: string,
  ) => string;
  printDisplayName: (config: ProjectConfig) => string;
}
```

## Test plan

Needs a test.