### PR TITLE
Doc:-Added typing docs for custom Matchers

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -69,7 +69,24 @@ test('numeric ranges', () => {
 
 :::note
 
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
+In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this (`toBeWithinRange.ts`):
+
+```ts title="toBeWithinRange.ts"
+expect.extend({
+  toBeWithinRange(received: number, floor: number, ceiling: number) {
+    // ...
+  },
+});
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+```
+
+If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
 
 ```ts
 interface CustomMatchers<R = unknown> {
@@ -83,6 +100,8 @@ declare global {
     interface InverseAsymmetricMatchers extends CustomMatchers {}
   }
 }
+
+export {};
 ```
 
 :::

--- a/website/versioned_docs/version-25.x/ExpectAPI.md
+++ b/website/versioned_docs/version-25.x/ExpectAPI.md
@@ -67,9 +67,17 @@ test('numeric ranges', () => {
 });
 ```
 
-_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
+_Note_:
+
+In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this (`toBeWithinRange.ts`):
 
 ```ts
+expect.extend({
+  toBeWithinRange(received, floor, ceiling) {
+    // ...
+  },
+});
+
 interface CustomMatchers<R = unknown> {
   toBeWithinRange(floor: number, ceiling: number): R;
 }
@@ -81,6 +89,19 @@ declare global {
     interface InverseAsymmetricMatchers extends CustomMatchers {}
   }
 }
+```
+
+If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+export {};
 ```
 
 #### Async Matchers

--- a/website/versioned_docs/version-26.x/ExpectAPI.md
+++ b/website/versioned_docs/version-26.x/ExpectAPI.md
@@ -67,9 +67,15 @@ test('numeric ranges', () => {
 });
 ```
 
-_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
+_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this (`toBeWithinRange.ts`):
 
 ```ts
+expect.extend({
+  toBeWithinRange(received, floor, ceiling) {
+    // ...
+  },
+});
+
 interface CustomMatchers<R = unknown> {
   toBeWithinRange(floor: number, ceiling: number): R;
 }
@@ -81,6 +87,19 @@ declare global {
     interface InverseAsymmetricMatchers extends CustomMatchers {}
   }
 }
+```
+
+If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+export {};
 ```
 
 #### Async Matchers

--- a/website/versioned_docs/version-28.0/ExpectAPI.md
+++ b/website/versioned_docs/version-28.0/ExpectAPI.md
@@ -69,9 +69,17 @@ test('numeric ranges', () => {
 
 :::note
 
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
+In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this (`toBeWithinRange.ts`):
+
+:::
 
 ```ts
+expect.extend({
+  toBeWithinRange(received, floor, ceiling) {
+    // ...
+  },
+});
+
 interface CustomMatchers<R = unknown> {
   toBeWithinRange(floor: number, ceiling: number): R;
 }
@@ -85,7 +93,18 @@ declare global {
 }
 ```
 
-:::
+If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+export {};
+```
 
 #### Async Matchers
 


### PR DESCRIPTION
I tried to added some additional info to help the user to add typing for custom matchers