### PR TITLE
chore: set ESLint’s 'no-inferrable-types' rule to 'error'

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,6 +46,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/array-type': ['error', {default: 'generic'}],
         '@typescript-eslint/ban-types': 'error',
+        '@typescript-eslint/no-inferrable-types': 'error',
         '@typescript-eslint/no-unused-vars': [
           'error',
           {argsIgnorePattern: '^_'},

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -291,9 +291,10 @@ class StringMatching extends AsymmetricMatcher<RegExp> {
     return 'string';
   }
 }
+
 class CloseTo extends AsymmetricMatcher<number> {
   private precision: number;
-  constructor(sample: number, precision: number = 2, inverse: boolean = false) {
+  constructor(sample: number, precision = 2, inverse = false) {
     if (!isA('Number', sample)) {
       throw new Error('Expected is not a Number');
     }
@@ -311,7 +312,7 @@ class CloseTo extends AsymmetricMatcher<number> {
     if (!isA('Number', other)) {
       return false;
     }
-    let result: boolean = false;
+    let result = false;
     if (other === Infinity && this.sample === Infinity) {
       result = true; // Infinity - Infinity is NaN
     } else if (other === -Infinity && this.sample === -Infinity) {

--- a/packages/jest-console/src/BufferedConsole.ts
+++ b/packages/jest-console/src/BufferedConsole.ts
@@ -79,7 +79,7 @@ export default class BufferedConsole extends Console {
     }
   }
 
-  override count(label: string = 'default'): void {
+  override count(label = 'default'): void {
     if (!this._counters[label]) {
       this._counters[label] = 0;
     }
@@ -87,7 +87,7 @@ export default class BufferedConsole extends Console {
     this._log('count', format(`${label}: ${++this._counters[label]}`));
   }
 
-  override countReset(label: string = 'default'): void {
+  override countReset(label = 'default'): void {
     this._counters[label] = 0;
   }
 
@@ -138,7 +138,7 @@ export default class BufferedConsole extends Console {
     this._log('log', format(firstArg, ...rest));
   }
 
-  override time(label: string = 'default'): void {
+  override time(label = 'default'): void {
     if (this._timers[label]) {
       return;
     }
@@ -146,7 +146,7 @@ export default class BufferedConsole extends Console {
     this._timers[label] = new Date();
   }
 
-  override timeEnd(label: string = 'default'): void {
+  override timeEnd(label = 'default'): void {
     const startTime = this._timers[label];
 
     if (startTime) {

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -57,7 +57,7 @@ export default class CustomConsole extends Console {
     }
   }
 
-  override count(label: string = 'default'): void {
+  override count(label = 'default'): void {
     if (!this._counters[label]) {
       this._counters[label] = 0;
     }
@@ -65,7 +65,7 @@ export default class CustomConsole extends Console {
     this._log('count', format(`${label}: ${++this._counters[label]}`));
   }
 
-  override countReset(label: string = 'default'): void {
+  override countReset(label = 'default'): void {
     this._counters[label] = 0;
   }
 
@@ -116,7 +116,7 @@ export default class CustomConsole extends Console {
     this._log('log', format(firstArg, ...args));
   }
 
-  override time(label: string = 'default'): void {
+  override time(label = 'default'): void {
     if (this._timers[label]) {
       return;
     }
@@ -124,7 +124,7 @@ export default class CustomConsole extends Console {
     this._timers[label] = new Date();
   }
 
-  override timeEnd(label: string = 'default'): void {
+  override timeEnd(label = 'default'): void {
     const startTime = this._timers[label];
 
     if (startTime) {

--- a/packages/jest-core/src/lib/activeFiltersMessage.ts
+++ b/packages/jest-core/src/lib/activeFiltersMessage.ts
@@ -10,7 +10,7 @@ import type {Config} from '@jest/types';
 
 const activeFilters = (
   globalConfig: Config.GlobalConfig,
-  delimiter: string = '\n',
+  delimiter = '\n',
 ): string => {
   const {testNamePattern, testPathPattern} = globalConfig;
   if (testNamePattern || testPathPattern) {

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -30,7 +30,7 @@ type GlobalCallback = (
 
 export default function bind<EachCallback extends Global.TestCallback>(
   cb: GlobalCallback,
-  supportsDone: boolean = true,
+  supportsDone = true,
 ) {
   return (
     table: Global.EachTable,

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -91,8 +91,8 @@ export const SUGGEST_TO_CONTAIN_EQUAL = chalk.dim(
 
 export const stringify = (
   object: unknown,
-  maxDepth: number = 10,
-  maxWidth: number = 10,
+  maxDepth = 10,
+  maxWidth = 10,
 ): string => {
   const MAX_LENGTH = 10000;
   let result;

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -469,7 +469,7 @@ class ScriptTransformer {
     const {transformer, transformerConfig = {}} =
       this._getTransformer(filename) || {};
     const cacheFilePath = this._getFileCachePath(filename, content, options);
-    const sourceMapPath: string = `${cacheFilePath}.map`;
+    const sourceMapPath = `${cacheFilePath}.map`;
     // Ignore cache if `config.cache` is set (--no-cache)
     const code = this._config.cache ? readCodeCacheFile(cacheFilePath) : null;
 
@@ -528,7 +528,7 @@ class ScriptTransformer {
       content,
       options,
     );
-    const sourceMapPath: string = `${cacheFilePath}.map`;
+    const sourceMapPath = `${cacheFilePath}.map`;
     // Ignore cache if `config.cache` is set (--no-cache)
     const code = this._config.cache ? readCodeCacheFile(cacheFilePath) : null;
 
@@ -829,7 +829,7 @@ export async function createTranspilingRequire(
 
   return async function requireAndTranspileModule<TModuleType = unknown>(
     resolverPath: string,
-    applyInteropRequireDefault: boolean = false,
+    applyInteropRequireDefault = false,
   ) {
     const transpiledModule =
       await transformer.requireAndTranspileModule<TModuleType>(

--- a/packages/jest-util/src/formatTime.ts
+++ b/packages/jest-util/src/formatTime.ts
@@ -7,8 +7,8 @@
 
 export default function formatTime(
   time: number,
-  prefixPower: number = -3,
-  padLeftLength: number = 0,
+  prefixPower = -3,
+  padLeftLength = 0,
 ): string {
   const prefixes = ['n', 'μ', 'm', ''];
   const prefixIndex = Math.max(

--- a/packages/jest-util/src/isPromise.ts
+++ b/packages/jest-util/src/isPromise.ts
@@ -6,7 +6,7 @@
  */
 
 // capture globalThis.Promise before it may potentially be overwritten
-const Promise: any = globalThis.Promise;
+const Promise = globalThis.Promise;
 
 // see ES2015 spec 25.4.4.5, https://stackoverflow.com/a/38339199
 const isPromise = (candidate: unknown): candidate is Promise<unknown> =>

--- a/packages/pretty-format/src/collections.ts
+++ b/packages/pretty-format/src/collections.ts
@@ -40,7 +40,7 @@ export function printIteratorEntries(
   // Too bad, so sad that separator for ECMAScript Map has been ' => '
   // What a distracting diff if you change a data structure to/from
   // ECMAScript Object or Immutable.Map/OrderedMap which use the default.
-  separator: string = ': ',
+  separator = ': ',
 ): string {
   let result = '';
   let width = 0;


### PR DESCRIPTION
## Summary

Perhaps it makes sense to disallows type declarations if these can be inferred? Slightly less code and more consistent style across the code base.

## Test plan

Green CI.