### PR TITLE
fix(jest-environment-jsdom) Change the default value of JSDOM export condition

### DIFF
--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -33,7 +33,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
   global: Win;
   private errorEventListener: ((event: Event & {error: Error}) => void) | null;
   moduleMocker: ModuleMocker | null;
-  customExportConditions = ['browser'];
+  customExportConditions = ['node', 'node-addons'];
 
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     const {projectConfig} = config;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
`preact-testing-library` no longer works with Jest28 and jest-environment-jsdom@28.0.2.

Below is the reproduction code and result.
https://github.com/hnisiji/preact-jest-repro/blob/main/fail%2Btesting_library.spec.tsx
https://github.com/hnisiji/preact-jest-repro/runs/6246766634?check_suite_focus=true

The cause is that `exports conditions` of jest-environment-jsdom is `browser`, so that dependencies is resolved by referring `exports.browser` field of package.json.

It seems that the same value as `jest-environment-node` is correct for export condition. Because JSDOM runs on Node.js.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
