### PR TITLE
chore(jest-snapshot): add type tests for `SnapshotResolver`

### DIFF
--- a/packages/jest-snapshot/__typetests__/jest-snapshot.test.ts
+++ b/packages/jest-snapshot/__typetests__/jest-snapshot.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {expectError, expectType} from 'tsd-lite';
+import type {SnapshotResolver} from 'jest-snapshot';
+
+// SnapshotResolver
+
+const snapshotResolver: SnapshotResolver = {
+  resolveSnapshotPath: (testPath, snapshotExtension) => {
+    expectType<string>(testPath);
+    expectType<string | undefined>(snapshotExtension);
+    return 'snapshot/path';
+  },
+
+  resolveTestPath: (snapshotPath, snapshotExtension) => {
+    expectType<string>(snapshotPath);
+    expectType<string | undefined>(snapshotExtension);
+    return 'test/path';
+  },
+
+  testPathForConsistencyCheck: 'test/path/example',
+};
+
+// resolveSnapshotPath
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: (testPath: string, snapshotExtension: boolean) =>
+    'snapshot/path',
+  resolveTestPath: () => 'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: (testPath: boolean) => 'snapshot/path',
+  resolveTestPath: () => 'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => true,
+  resolveTestPath: () => 'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveTestPath: () => 'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+// resolveTestPath
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  resolveTestPath: (snapshotPath: string, snapshotExtension: boolean) =>
+    'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  resolveTestPath: (snapshotPath: boolean) => 'test/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  resolveTestPath: () => true,
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  testPathForConsistencyCheck: 'test/path/example',
+});
+
+// testPathForConsistencyCheck
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  resolveTestPath: () => 'test/path',
+  testPathForConsistencyCheck: true,
+});
+
+expectError<SnapshotResolver>({
+  resolveSnapshotPath: () => 'snapshot/path',
+  resolveTestPath: () => 'test/path',
+});

--- a/packages/jest-snapshot/__typetests__/tsconfig.json
+++ b/packages/jest-snapshot/__typetests__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+
+    "types": []
+  },
+  "include": ["./**/*"]
+}

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -45,12 +45,14 @@
     "@babel/preset-flow": "^7.7.2",
     "@babel/preset-react": "^7.12.1",
     "@jest/test-utils": "^28.0.2",
+    "@tsd/typescript": "~4.6.2",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
     "@types/semver": "^7.1.0",
     "ansi-regex": "^5.0.1",
     "ansi-styles": "^5.0.0",
-    "prettier": "^2.1.1"
+    "prettier": "^2.1.1",
+    "tsd-lite": "^0.5.1"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"

--- a/packages/jest-snapshot/src/SnapshotResolver.ts
+++ b/packages/jest-snapshot/src/SnapshotResolver.ts
@@ -12,9 +12,12 @@ import type {Config} from '@jest/types';
 import {interopRequireDefault} from 'jest-util';
 
 export type SnapshotResolver = {
+  /** Resolves from `testPath` to snapshot path. */
+  resolveSnapshotPath(testPath: string, snapshotExtension?: string): string;
+  /** Resolves from `snapshotPath` to test path. */
+  resolveTestPath(snapshotPath: string, snapshotExtension?: string): string;
+  /** Example test path, used for preflight consistency check of the implementation above. */
   testPathForConsistencyCheck: string;
-  resolveSnapshotPath(testPath: string, extension?: string): string;
-  resolveTestPath(snapshotPath: string, extension?: string): string;
 };
 
 export const EXTENSION = 'snap';
@@ -95,7 +98,7 @@ async function createCustomSnapshotResolver(
     }
   });
 
-  const customResolver = {
+  const customResolver: SnapshotResolver = {
     resolveSnapshotPath: (testPath: string) =>
       custom.resolveSnapshotPath(testPath, DOT_EXTENSION),
     resolveTestPath: (snapshotPath: string) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -13549,6 +13549,7 @@ __metadata:
     "@jest/test-utils": ^28.0.2
     "@jest/transform": ^28.0.3
     "@jest/types": ^28.0.2
+    "@tsd/typescript": ~4.6.2
     "@types/babel__traverse": ^7.0.6
     "@types/graceful-fs": ^4.1.3
     "@types/natural-compare": ^1.4.0
@@ -13570,6 +13571,7 @@ __metadata:
     prettier: ^2.1.1
     pretty-format: ^28.0.2
     semver: ^7.3.5
+    tsd-lite: ^0.5.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

This is part of ongoing effort to test types of Jest’s public APIs. Types of `SnapshotMatchers` are already tested together with other matchers. Seems like only `SnapshotResolver` needs to be tested.

## Test plan

Green CI.