### PR TITLE
Do not collect `SIGNREQUEST` as open handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Lists ([#12763](https://github.com/facebook/jest/pull/12763))
+- `[jest-core]` Do not collect `SIGNREQUEST` as open handles ([#12789](https://github.com/facebook/jest/pull/12789))
 
 ### Chore & Maintenance
 

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -6,6 +6,7 @@
  *
  */
 
+import crypto from 'crypto';
 import {promises as dns} from 'dns';
 import http from 'http';
 import {PerformanceObserver} from 'perf_hooks';
@@ -64,6 +65,22 @@ describe('collectHandles', () => {
 
     expect(openHandles).not.toContainEqual(
       expect.objectContaining({message: 'ZLIB'}),
+    );
+  });
+
+  it('should not collect the SIGNREQUEST open handle', async () => {
+    const handleCollector = collectHandles();
+
+    const key =
+      '-----BEGIN PRIVATE KEY-----\r\nMC4CAQAwBQYDK2VwBCIEIHKj+sVa9WcD' +
+      '/q2DJUJaf43Kptc8xYuUQA4bOFj9vC8T\r\n-----END PRIVATE KEY-----';
+    const data = Buffer.from('a');
+    crypto.sign(null, data, key);
+
+    const openHandles = await handleCollector();
+
+    expect(openHandles).not.toContainEqual(
+      expect.objectContaining({message: 'SIGNREQUEST'}),
     );
   });
 

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -72,7 +72,8 @@ export default function collectHandles(): HandleCollectionResult {
         type === 'PerformanceObserver' ||
         type === 'RANDOMBYTESREQUEST' ||
         type === 'DNSCHANNEL' ||
-        type === 'ZLIB'
+        type === 'ZLIB' ||
+        type === 'SIGNREQUEST'
       ) {
         return;
       }


### PR DESCRIPTION
## Summary

See the linked issue for more information.
Fixes https://github.com/facebook/jest/issues/12775.

## Test Plan

Unit test added. See before:

```
➜  jest git:(main) ✗ yarn jest collectHandles
 FAIL  packages/jest-core/src/__tests__/collectHandles.test.js
  collectHandles
    ✓ should collect Timeout (107 ms)
    ✓ should not collect the PerformanceObserver open handle (102 ms)
    ✓ should not collect the DNSCHANNEL open handle (103 ms)
    ✓ should not collect the ZLIB open handle (103 ms)
    ✕ should not collect the SIGNREQUEST open handle (106 ms)
    ✓ should collect handles opened in test functions with `done` callbacks (106 ms)
    ✓ should not collect handles that have been queued to close (106 ms)
    ✓ should collect handles indirectly triggered by user code (110 ms)

  ● collectHandles › should not collect the SIGNREQUEST open handle

    expect(received).not.toContainEqual(expected) // deep equality

    Expected value: not ObjectContaining {"message": "SIGNREQUEST"}
    Received array:     [[Error: SIGNREQUEST], [Error: Timeout]]

      at Object.toContainEqual (packages/jest-core/src/__tests__/collectHandles.test.js:82:29)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 7 passed, 8 total
Snapshots:   0 total
Time:        1.095 s, estimated 2 s
```

See after:

```
➜  jest git:(patch-1) ✗ yarn jest collectHandles                                        
 PASS  packages/jest-core/src/__tests__/collectHandles.test.js
  collectHandles
    ✓ should collect Timeout (108 ms)
    ✓ should not collect the PerformanceObserver open handle (101 ms)
    ✓ should not collect the DNSCHANNEL open handle (104 ms)
    ✓ should not collect the ZLIB open handle (105 ms)
    ✓ should not collect the SIGNREQUEST open handle (104 ms)
    ✓ should collect handles opened in test functions with `done` callbacks (110 ms)
    ✓ should not collect handles that have been queued to close (106 ms)
    ✓ should collect handles indirectly triggered by user code (111 ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        1.127 s, estimated 2 s
```