### PR TITLE
refactor(jest-haste-map): clean up code and types

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -104,8 +104,6 @@ module.exports = {
         'packages/expect-utils/src/utils.ts',
         'packages/jest-core/src/collectHandles.ts',
         'packages/jest-core/src/plugins/UpdateSnapshotsInteractive.ts',
-        'packages/jest-haste-map/src/index.ts',
-        'packages/jest-haste-map/src/watchers/FSEventsWatcher.ts',
         'packages/jest-jasmine2/src/jasmine/SpyStrategy.ts',
         'packages/jest-jasmine2/src/jasmine/Suite.ts',
         'packages/jest-leak-detector/src/index.ts',

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -248,7 +248,7 @@ export default class HasteMap extends EventEmitter {
       dependencyExtractor: options.dependencyExtractor || null,
       enableSymlinks: options.enableSymlinks || false,
       extensions: options.extensions,
-      forceNodeFilesystemAPI: options.forceNodeFilesystemAPI || false,
+      forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
       hasteImplModulePath: options.hasteImplModulePath,
       id: options.id,
       maxWorkers: options.maxWorkers,
@@ -260,10 +260,10 @@ export default class HasteMap extends EventEmitter {
       retainAllFiles: options.retainAllFiles,
       rootDir: options.rootDir,
       roots: Array.from(new Set(options.roots)),
-      skipPackageJson: options.skipPackageJson || false,
-      throwOnModuleCollision: options.throwOnModuleCollision || false,
+      skipPackageJson: !!options.skipPackageJson,
+      throwOnModuleCollision: !!options.throwOnModuleCollision,
       useWatchman: options.useWatchman ?? true,
-      watch: options.watch || false,
+      watch: !!options.watch,
     };
     this._console = options.console || globalThis.console;
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable local/ban-types-eventually */
-
 import {createHash} from 'crypto';
 import {EventEmitter} from 'events';
 import {tmpdir} from 'os';
@@ -40,6 +38,7 @@ import type {
   HasteMap as InternalHasteMapObject,
   MockData,
   ModuleMapData,
+  ModuleMapItem,
   ModuleMetaData,
   SerializableModuleMap,
   WorkerMetadata,
@@ -212,14 +211,14 @@ function invariant(condition: unknown, message?: string): asserts condition {
  *
  */
 export default class HasteMap extends EventEmitter {
-  private _buildPromise: Promise<InternalHasteMapObject> | null;
-  private _cachePath: string;
+  private _buildPromise: Promise<InternalHasteMapObject> | null = null;
+  private _cachePath = '';
   private _changeInterval?: ReturnType<typeof setInterval>;
   private _console: Console;
   private _isWatchmanInstalledPromise: Promise<boolean> | null = null;
   private _options: InternalOptions;
-  private _watchers: Array<Watcher>;
-  private _worker: JestWorkerFarm<HasteWorker> | HasteWorker | null;
+  private _watchers: Array<Watcher> = [];
+  private _worker: JestWorkerFarm<HasteWorker> | HasteWorker | null = null;
 
   static getStatic(config: Config.ProjectConfig): HasteMapStatic {
     if (config.haste.hasteMapModulePath) {
@@ -244,15 +243,12 @@ export default class HasteMap extends EventEmitter {
     super();
     this._options = {
       cacheDirectory: options.cacheDirectory || tmpdir(),
-      computeDependencies:
-        options.computeDependencies === undefined
-          ? true
-          : options.computeDependencies,
+      computeDependencies: options.computeDependencies ?? true,
       computeSha1: options.computeSha1 || false,
       dependencyExtractor: options.dependencyExtractor || null,
       enableSymlinks: options.enableSymlinks || false,
       extensions: options.extensions,
-      forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
+      forceNodeFilesystemAPI: options.forceNodeFilesystemAPI || false,
       hasteImplModulePath: options.hasteImplModulePath,
       id: options.id,
       maxWorkers: options.maxWorkers,
@@ -264,10 +260,10 @@ export default class HasteMap extends EventEmitter {
       retainAllFiles: options.retainAllFiles,
       rootDir: options.rootDir,
       roots: Array.from(new Set(options.roots)),
-      skipPackageJson: !!options.skipPackageJson,
-      throwOnModuleCollision: !!options.throwOnModuleCollision,
-      useWatchman: options.useWatchman == null ? true : options.useWatchman,
-      watch: !!options.watch,
+      skipPackageJson: options.skipPackageJson || false,
+      throwOnModuleCollision: options.throwOnModuleCollision || false,
+      useWatchman: options.useWatchman ?? true,
+      watch: options.watch || false,
     };
     this._console = options.console || globalThis.console;
 
@@ -293,11 +289,6 @@ export default class HasteMap extends EventEmitter {
           'Set either `enableSymlinks` to false or `useWatchman` to false.',
       );
     }
-
-    this._cachePath = '';
-    this._buildPromise = null;
-    this._watchers = [];
-    this._worker = null;
   }
 
   private async setupCachePath(options: Options): Promise<void> {
@@ -444,7 +435,7 @@ export default class HasteMap extends EventEmitter {
     let hasteMap: InternalHasteMap;
     try {
       const read = this._options.resetCache ? this._createEmptyMap : this.read;
-      hasteMap = await read.call(this);
+      hasteMap = read.call(this);
     } catch {
       hasteMap = this._createEmptyMap();
     }
@@ -466,7 +457,7 @@ export default class HasteMap extends EventEmitter {
     const setModule = (id: string, module: ModuleMetaData) => {
       let moduleMap = map.get(id);
       if (!moduleMap) {
-        moduleMap = Object.create(null) as {};
+        moduleMap = Object.create(null) as ModuleMapItem;
         map.set(id, moduleMap);
       }
       const platform =
@@ -646,7 +637,7 @@ export default class HasteMap extends EventEmitter {
         const moduleId = fileMetadata[H.ID];
         let modulesByPlatform = map.get(moduleId);
         if (!modulesByPlatform) {
-          modulesByPlatform = Object.create(null) as {};
+          modulesByPlatform = Object.create(null) as ModuleMapItem;
           map.set(moduleId, modulesByPlatform);
         }
         modulesByPlatform[platform] = module;
@@ -729,7 +720,7 @@ export default class HasteMap extends EventEmitter {
   private _cleanup() {
     const worker = this._worker;
 
-    if (worker && 'end' in worker && typeof worker.end === 'function') {
+    if (worker && 'end' in worker) {
       worker.end();
     }
 
@@ -746,11 +737,11 @@ export default class HasteMap extends EventEmitter {
   /**
    * Creates workers or parses files and extracts metadata in-process.
    */
-  private _getWorker(options?: {
-    forceInBand: boolean;
-  }): JestWorkerFarm<HasteWorker> | HasteWorker {
+  private _getWorker(
+    options = {forceInBand: false},
+  ): JestWorkerFarm<HasteWorker> | HasteWorker {
     if (!this._worker) {
-      if ((options && options.forceInBand) || this._options.maxWorkers <= 1) {
+      if (options.forceInBand || this._options.maxWorkers <= 1) {
         this._worker = {getSha1, worker};
       } else {
         this._worker = new Worker(require.resolve('./worker'), {
@@ -1070,8 +1061,8 @@ export default class HasteMap extends EventEmitter {
 
     let dedupMap = hasteMap.map.get(moduleName);
 
-    if (dedupMap == null) {
-      dedupMap = Object.create(null) as {};
+    if (!dedupMap) {
+      dedupMap = Object.create(null) as ModuleMapItem;
       hasteMap.map.set(moduleName, dedupMap);
     }
     dedupMap[platform] = uniqueModule;

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -122,7 +122,7 @@ export type RawModuleMap = {
   mocks: MockData;
 };
 
-type ModuleMapItem = {[platform: string]: ModuleMetaData};
+export type ModuleMapItem = {[platform: string]: ModuleMetaData};
 export type ModuleMetaData = [path: string, type: number];
 
 export type HType = {

--- a/packages/jest-haste-map/src/watchers/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/watchers/FSEventsWatcher.ts
@@ -6,8 +6,6 @@
  *
  */
 
-/* eslint-disable local/ban-types-eventually */
-
 import {EventEmitter} from 'events';
 import * as path from 'path';
 import anymatch, {Matcher} from 'anymatch';
@@ -41,13 +39,13 @@ type FsEventsWatcherEvent =
  * Watches `dir`.
  */
 export class FSEventsWatcher extends EventEmitter {
-  public readonly root: string;
-  public readonly ignored?: Matcher;
-  public readonly glob: Array<string>;
-  public readonly dot: boolean;
-  public readonly hasIgnore: boolean;
-  public readonly doIgnore: (path: string) => boolean;
-  public readonly fsEventsWatchStopper: () => Promise<void>;
+  readonly root: string;
+  readonly ignored?: Matcher;
+  readonly glob: Array<string>;
+  readonly dot: boolean;
+  readonly hasIgnore: boolean;
+  readonly doIgnore: (path: string) => boolean;
+  readonly fsEventsWatchStopper: () => Promise<void>;
   private _tracked: Set<string>;
 
   static isSupported(): boolean {
@@ -65,8 +63,8 @@ export class FSEventsWatcher extends EventEmitter {
     dir: string,
     dirCallback: (normalizedPath: string, stats: fs.Stats) => void,
     fileCallback: (normalizedPath: string, stats: fs.Stats) => void,
-    endCallback: Function,
-    errorCallback: Function,
+    endCallback: () => void,
+    errorCallback: () => void,
     ignored?: Matcher,
   ) {
     walker(dir)


### PR DESCRIPTION
Split from #12680

## Summary

While pushing forward with #12680, I started noticing few details which can be cleaned up in `jest-haste-map`. Few initial values, nullish coalescing and some TS bits.

## Test plan

Green CI.