### PR TITLE
Make it clearer that jest.setTimeout() is for the entire file

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -821,7 +821,7 @@ This function is not available when using legacy fake timers implementation.
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -819,7 +819,9 @@ This function is not available when using legacy fake timers implementation.
 
 ### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests and before/after hooks in milliseconds. This only affects the test file from which this function is called.
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -642,7 +642,9 @@ Returns the number of fake timers still left to run.
 
 ### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests and before/after hooks in milliseconds. This only affects the test file from which this function is called.
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -644,7 +644,7 @@ Returns the number of fake timers still left to run.
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -664,7 +664,7 @@ When mocking time, `Date.now()` will also be mocked. If you for some reason need
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -662,7 +662,9 @@ When mocking time, `Date.now()` will also be mocked. If you for some reason need
 
 ### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests and before/after hooks in milliseconds. This only affects the test file from which this function is called.
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -704,7 +704,7 @@ When mocking time, `Date.now()` will also be mocked. If you for some reason need
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -702,7 +702,9 @@ When mocking time, `Date.now()` will also be mocked. If you for some reason need
 
 ### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests and before/after hooks in milliseconds. This only affects the test file from which this function is called.
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -821,7 +821,7 @@ This function is not available when using legacy fake timers implementation.
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -821,7 +821,7 @@ This function is not available when using legacy fake timers implementation.
 
 Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
 
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](https://jestjs.io/docs/api#testname-fn-timeout).
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](API.md#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -819,7 +819,9 @@ This function is not available when using legacy fake timers implementation.
 
 ### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests and before/after hooks in milliseconds. This only affects the test file from which this function is called.
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called.
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](https://jestjs.io/docs/api#testname-fn-timeout).
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 


### PR DESCRIPTION
## Summary
Make it clearer that jest.setTimeout() is for the entire file. 

## Test plan
Docs only.