### PR TITLE
docs(upgrading): detail changes to NodeEnvironment export

### DIFF
--- a/docs/UpgradingToJest28.md
+++ b/docs/UpgradingToJest28.md
@@ -144,10 +144,10 @@ In addition, test environments are now exported with the name `TestEnvironment`,
 
 ```diff
 - const TestEnvironment = require('jest-environment-node');
-+ const { TestEnvironment } = require('jest-environment-node');
++ const {TestEnvironment} = require('jest-environment-node');
 
 - const TestEnvironment = require('jest-environment-jsdom');
-+ const { TestEnvironment } = require('jest-environment-jsdom');
++ const {TestEnvironment} = require('jest-environment-jsdom');
 ```
 
 ### `jsdom`

--- a/docs/UpgradingToJest28.md
+++ b/docs/UpgradingToJest28.md
@@ -140,6 +140,16 @@ The constructor of [test environment](Configuration.md#testenvironment-string) c
 +     const config = projectConfig;
 ```
 
+In addition, test environments are now exported with the name `TestEnvironment`, instead of simply exporting the class directly:
+
+```diff
+- const TestEnvironment = require('jest-environment-node');
++ const { TestEnvironment } = require('jest-environment-node');
+
+- const TestEnvironment = require('jest-environment-jsdom');
++ const { TestEnvironment } = require('jest-environment-jsdom');
+```
+
 ### `jsdom`
 
 If you are using JSDOM [test environment](Configuration.md#testenvironment-string), `jest-environment-jsdom` package now must be installed separately:

--- a/website/versioned_docs/version-28.0/UpgradingToJest28.md
+++ b/website/versioned_docs/version-28.0/UpgradingToJest28.md
@@ -144,10 +144,10 @@ In addition, test environments are now exported with the name `TestEnvironment`,
 
 ```diff
 - const TestEnvironment = require('jest-environment-node');
-+ const { TestEnvironment } = require('jest-environment-node');
++ const {TestEnvironment} = require('jest-environment-node');
 
 - const TestEnvironment = require('jest-environment-jsdom');
-+ const { TestEnvironment } = require('jest-environment-jsdom');
++ const {TestEnvironment} = require('jest-environment-jsdom');
 ```
 
 ### `jsdom`

--- a/website/versioned_docs/version-28.0/UpgradingToJest28.md
+++ b/website/versioned_docs/version-28.0/UpgradingToJest28.md
@@ -140,6 +140,13 @@ The constructor of [test environment](Configuration.md#testenvironment-string) c
 +     const config = projectConfig;
 ```
 
+In addition, test environments `"jest-environment-node"` is now exporting it's environment with a default export, instead of simply exporting the class directly:
+
+```diff
+- const NodeEnvironment = require('jest-environment-node');
++ const NodeEnvironment = require('jest-environment-node').default;
+```
+
 ### `jsdom`
 
 If you are using JSDOM [test environment](Configuration.md#testenvironment-string), `jest-environment-jsdom` package now must be installed separately:

--- a/website/versioned_docs/version-28.0/UpgradingToJest28.md
+++ b/website/versioned_docs/version-28.0/UpgradingToJest28.md
@@ -140,11 +140,14 @@ The constructor of [test environment](Configuration.md#testenvironment-string) c
 +     const config = projectConfig;
 ```
 
-In addition, test environments `"jest-environment-node"` is now exporting it's environment with a default export, instead of simply exporting the class directly:
+In addition, test environments are now exported with the name `TestEnvironment`, instead of simply exporting the class directly:
 
 ```diff
-- const NodeEnvironment = require('jest-environment-node');
-+ const NodeEnvironment = require('jest-environment-node').default;
+- const TestEnvironment = require('jest-environment-node');
++ const { TestEnvironment } = require('jest-environment-node');
+
+- const TestEnvironment = require('jest-environment-jsdom');
++ const { TestEnvironment } = require('jest-environment-jsdom');
 ```
 
 ### `jsdom`


### PR DESCRIPTION
A very simple change detailing the subtle change to the `NodeEnvironment` export.

Originally found in StrykerJS:

https://github.com/stryker-mutator/stryker-js/issues/3481