### PR TITLE
Doc: rootdir affects preset resolution

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -765,7 +765,7 @@ For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: 'foo-bar',
-}
+};
 ```
 
 Presets may also be relative to filesystem paths.
@@ -774,7 +774,7 @@ Presets may also be relative to filesystem paths.
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: './node_modules/foo-bar/jest-preset.js',
-}
+};
 ```
 
 :::info

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -761,17 +761,19 @@ A preset that is used as a base for Jest's configuration. A preset should point 
 
 For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 
-```json
-{
-  "preset": "foo-bar"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: 'foo-bar',
 }
 ```
 
 Presets may also be relative to filesystem paths.
 
-```json
-{
-  "preset": "./node_modules/foo-bar/jest-preset.js"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: './node_modules/foo-bar/jest-preset.js',
 }
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -777,6 +777,12 @@ module.exports = {
 }
 ```
 
+:::info
+
+Note that if you also have specified [`rootDir`](#rootdir-string) that the resolution of this file will be relative to that root directory.
+
+:::
+
 ### `prettierPath` \[string]
 
 Default: `'prettier'`

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -765,7 +765,7 @@ For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: 'foo-bar',
-}
+};
 ```
 
 Presets may also be relative to filesystem paths.
@@ -774,7 +774,7 @@ Presets may also be relative to filesystem paths.
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: './node_modules/foo-bar/jest-preset.js',
-}
+};
 ```
 
 :::info

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -761,17 +761,19 @@ A preset that is used as a base for Jest's configuration. A preset should point 
 
 For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 
-```json
-{
-  "preset": "foo-bar"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: 'foo-bar',
 }
 ```
 
 Presets may also be relative to filesystem paths.
 
-```json
-{
-  "preset": "./node_modules/foo-bar/jest-preset.js"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: './node_modules/foo-bar/jest-preset.js',
 }
 ```
 

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -777,6 +777,12 @@ module.exports = {
 }
 ```
 
+:::info
+
+Note that if you also have specified [`rootDir`](#rootdir-string) that the resolution of this file will be relative to that root directory.
+
+:::
+
 ### `prettierPath` \[string]
 
 Default: `'prettier'`

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -765,7 +765,7 @@ For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: 'foo-bar',
-}
+};
 ```
 
 Presets may also be relative to filesystem paths.
@@ -774,7 +774,7 @@ Presets may also be relative to filesystem paths.
 /** @type { import('@jest/types').Config.InitialOptions } */
 module.exports = {
   preset: './node_modules/foo-bar/jest-preset.js',
-}
+};
 ```
 
 :::info

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -761,17 +761,19 @@ A preset that is used as a base for Jest's configuration. A preset should point 
 
 For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 
-```json
-{
-  "preset": "foo-bar"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: 'foo-bar',
 }
 ```
 
 Presets may also be relative to filesystem paths.
 
-```json
-{
-  "preset": "./node_modules/foo-bar/jest-preset.js"
+```js
+/** @type { import('@jest/types').Config.InitialOptions } */
+module.exports = {
+  preset: './node_modules/foo-bar/jest-preset.js',
 }
 ```
 

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -777,6 +777,12 @@ module.exports = {
 }
 ```
 
+:::info
+
+Note that if you also have specified [`rootDir`](#rootdir-string) that the resolution of this file will be relative to that root directory.
+
+:::
+
 ### `prettierPath` \[string]
 
 Default: `'prettier'`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
The docs do not mention that `rootDir` can change the resolution of the `preset`.  See https://github.com/facebook/jest/issues/11399#issuecomment-1119642885 for an example.

Additionally, I noticed that the docs were referring to a jest preset javascript file, yet showing JSON.  Fixed that as well.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
n/a
