### PR TITLE
chore(dev-scripts): rework options passed to `glob`

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -62,9 +62,7 @@ function getBuildPath(file, buildFolder) {
 
 function buildNodePackage({packageDir, pkg}) {
   const srcDir = path.resolve(packageDir, SRC_DIR);
-  const files = glob
-    .sync('**/*', {cwd: srcDir, nodir: true})
-    .map(res => path.join(srcDir, res));
+  const files = glob.sync('**/*', {absolute: true, cwd: srcDir, nodir: true});
 
   process.stdout.write(adjustToTerminalWidth(`${pkg.name}\n`));
 

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -27,7 +27,7 @@ const globOptions = {absolute: true, cwd: rootDir, ignore: excludedModules};
 const e2eNodeModules = [
   ...glob.sync('e2e/*/node_modules/', globOptions),
   ...glob.sync('e2e/*/*/node_modules/', globOptions),
-];
+].sort();
 
 e2eNodeModules.forEach(dir => {
   rimraf.sync(dir, {glob: false});

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {dirname, join, normalize, resolve} from 'path';
+import {dirname, normalize, resolve} from 'path';
 import {fileURLToPath} from 'url';
 import glob from 'glob';
 import rimraf from 'rimraf';
@@ -22,15 +22,12 @@ const excludedModules = [
 ].map(dir => normalize(dir));
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const globOptions = {absolute: true, cwd: rootDir, ignore: excludedModules};
 
 const e2eNodeModules = [
-  ...glob.sync('e2e/*/node_modules/', {cwd: rootDir}),
-  ...glob.sync('e2e/*/*/node_modules/', {cwd: rootDir}),
-]
-  .map(res => join(rootDir, res))
-  .filter(dir => !excludedModules.includes(dir))
-  .map(dir => resolve(rootDir, dir))
-  .sort();
+  ...glob.sync('e2e/*/node_modules/', globOptions),
+  ...glob.sync('e2e/*/*/node_modules/', globOptions),
+];
 
 e2eNodeModules.forEach(dir => {
   rimraf.sync(dir, {glob: false});

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -24,10 +24,7 @@ const excludedModules = [
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const globOptions = {absolute: true, cwd: rootDir, ignore: excludedModules};
 
-const e2eNodeModules = [
-  ...glob.sync('e2e/*/node_modules/', globOptions),
-  ...glob.sync('e2e/*/*/node_modules/', globOptions),
-].sort();
+const e2eNodeModules = glob.sync('e2e/{*,*/*}/node_modules/', globOptions);
 
 e2eNodeModules.forEach(dir => {
   rimraf.sync(dir, {glob: false});

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -22,9 +22,12 @@ const excludedModules = [
 ].map(dir => normalize(dir));
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const globOptions = {absolute: true, cwd: rootDir, ignore: excludedModules};
 
-const e2eNodeModules = glob.sync('e2e/{*,*/*}/node_modules/', globOptions);
+const e2eNodeModules = glob.sync('e2e/{*,*/*}/node_modules/', {
+  absolute: true,
+  cwd: rootDir,
+  ignore: excludedModules,
+});
 
 e2eNodeModules.forEach(dir => {
   rimraf.sync(dir, {glob: false});


### PR DESCRIPTION
## Summary

Strange thing. `cleanE2e` script is removing all directories, which it should ignore (at least on my computer). Something is off after `glob` package was updated.

Here is an attempt to fix the script.

## Test plan

Tested locally. Works as expected.