### PR TITLE
Document differences in coverage ignore comments between providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[docs]` Updated docs to indicate that `jest-environment-jsdom` is a separate package [#12828](https://github.com/facebook/jest/issues/12828)
 - `[jest-haste-map]` Bump `walker` version ([#12324](https://github.com/facebook/jest/pull/12324))
+- `[docs]` Document the comments used by coverage providers [#12835](https://github.com/facebook/jest/issues/12835)
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -230,9 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -230,7 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -158,6 +158,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -227,12 +235,6 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -228,6 +228,14 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -141,6 +141,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -214,12 +222,6 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 1. Your node version must include `vm.compileFunction`, which was introduced in [node 10.10](https://nodejs.org/dist/latest-v12.x/docs/api/vm.html#vm_vm_compilefunction_code_params_options)
 1. Tests needs to run in Node test environment (support for `jsdom` requires [`jest-environment-jsdom-sixteen`](https://www.npmjs.com/package/jest-environment-jsdom-sixteen))
 1. V8 has way better data in the later versions, so using the latest versions of node (v13 at the time of this writing) will yield better results
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -217,7 +217,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -215,6 +215,14 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 1. Tests needs to run in Node test environment (support for `jsdom` requires [`jest-environment-jsdom-sixteen`](https://www.npmjs.com/package/jest-environment-jsdom-sixteen))
 1. V8 has way better data in the later versions, so using the latest versions of node (v13 at the time of this writing) will yield better results
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -217,9 +217,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -154,6 +154,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -215,12 +223,6 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -218,7 +218,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -218,9 +218,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -216,6 +216,14 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -154,6 +154,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -215,12 +223,6 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -218,7 +218,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -218,9 +218,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -216,6 +216,14 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -230,9 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -230,7 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -158,6 +158,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -227,12 +235,6 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -228,6 +228,14 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -230,9 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
-
-The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -230,7 +230,7 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 
 :::note
 
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` to exclude lines from coverage reports, respectively. For more information, you can view [the istanbuljs documentation](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md) and [the c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
 
 :::
 

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -158,6 +158,14 @@ Default: `false`
 
 Indicates whether the coverage information should be collected while executing the test. Because this retrofits all executed files with coverage collection statements, it may significantly slow down your tests.
 
+Jest ships with two coverage providers: `babel` (default) and `v8`. See the [`coverageProvider`](#coverageprovider-string) option for more details.
+
+:::note
+
+The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `collectCoverageFrom` \[array]
 
 Default: `undefined`
@@ -227,12 +235,6 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
-
-:::note
-
-The `babel` and `v8` coverage providers use `/* istanbul ignore next */` and `/* c8 ignore next */` comments to exclude lines from coverage reports, respectively. For more information, you can view the [`istanbuljs` documentation](https://github.com/istanbuljs/nyc#parsing-hints-ignoring-lines) and the [`c8` documentation](https://github.com/bcoe/c8#ignoring-uncovered-lines-functions-and-blocks).
-
-:::
 
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -228,6 +228,14 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
+:::note
+
+The `babel` and `v8` coverage providers use different comments to exclude code from the coverage reports. When using the `babel` coverage provider, you can use comments in the format `/* istanbul ignore <word>[non-word] [optional-docs] /*`. The simplest ignore comment is `/* istanbul ignore next */`. More information can be found [here](https://github.com/gotwarlost/istanbul/blob/f17cb56fa8664c129b497ce86c22a922a6d64d12/ignoring-code-for-coverage.md).
+
+The `v8` coverage provider uses c8 comments in the format `/* c8 ignore <next [number] | start | stop> /*`. For example, `/* c8 ignore next */`. For more details, you can view the [c8 documentation](https://github.com/bcoe/c8/blob/49c45b3395e3354c2463cf40247c6c8eab4bbe1c/README.md#ignoring-uncovered-lines-functions-and-blocks).
+
+:::
+
 ### `coverageReporters` \[array&lt;string | \[string, options]&gt;]
 
 Default: `["clover", "json", "lcov", "text"]`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

It wasn't immediately clear how to ignore lines from the coverage report, and where to find the documentation on ignore comments.

This adds a note to the `coverageProvider` configuration option providing the basic ignore comments to ignore a line, and also permalinks to documentation for more complex ignore comment usage.

Addresses #12835

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Only documentation was changed, so likely N/A 🤔 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
