### PR TITLE
fix(jest-worker): make `JestWorkerFarm` helper type to include methods that take more than one argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
+
 ### Chore & Maintenance
 
 - `[docs]` Updated docs to indicate that `jest-environment-jsdom` is a separate package [#12828](https://github.com/facebook/jest/issues/12828)

--- a/packages/jest-worker/__typetests__/jest-worker.test.ts
+++ b/packages/jest-worker/__typetests__/jest-worker.test.ts
@@ -10,7 +10,8 @@ import type {JestWorkerFarm} from 'jest-worker';
 import type * as testWorker from './testWorker';
 
 type TestWorker = {
-  runTest: () => void;
+  runTest: (a: string, b: number) => void;
+  doSomething: () => void;
   isResult: boolean;
   end: () => void; // reserved keys should be excluded from returned type
   getStderr: () => string;
@@ -40,8 +41,20 @@ expectType<NodeJS.ReadableStream>(unknownWorkerFarm.getStdout());
 
 declare const detectedWorkerFarm: JestWorkerFarm<typeof testWorker>;
 
-expectType<Promise<void>>(detectedWorkerFarm.runTest());
-expectType<Promise<void>>(detectedWorkerFarm.runTestAsync());
+expectType<Promise<void>>(detectedWorkerFarm.runTest('abc', true));
+expectType<Promise<void>>(detectedWorkerFarm.runTestAsync(123, 456));
+
+expectType<Promise<void>>(detectedWorkerFarm.doSomething());
+expectType<Promise<void>>(detectedWorkerFarm.doSomething());
+expectType<Promise<void>>(detectedWorkerFarm.doSomethingAsync());
+expectType<Promise<void>>(detectedWorkerFarm.doSomethingAsync());
+
+expectError(detectedWorkerFarm.runTest());
+expectError(detectedWorkerFarm.runTest('abc'));
+expectError(detectedWorkerFarm.runTestAsync());
+expectError(detectedWorkerFarm.runTestAsync(123));
+expectError(detectedWorkerFarm.doSomething(123));
+expectError(detectedWorkerFarm.doSomethingAsync('abc'));
 
 expectError(detectedWorkerFarm.getResult());
 expectError(detectedWorkerFarm.isResult);
@@ -62,7 +75,12 @@ expectType<NodeJS.ReadableStream>(detectedWorkerFarm.getStdout());
 
 declare const typedWorkerFarm: JestWorkerFarm<TestWorker>;
 
-expectType<Promise<void>>(typedWorkerFarm.runTest());
+expectType<Promise<void>>(typedWorkerFarm.runTest('abc', 123));
+expectType<Promise<void>>(typedWorkerFarm.doSomething());
+
+expectError(typedWorkerFarm.runTest());
+expectError(typedWorkerFarm.runTest('abc'));
+expectError(typedWorkerFarm.doSomething('abc'));
 
 expectError(typedWorkerFarm.isResult);
 expectError(typedWorkerFarm.runTestAsync());

--- a/packages/jest-worker/__typetests__/testWorker.ts
+++ b/packages/jest-worker/__typetests__/testWorker.ts
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export function runTest(): void {}
-export async function runTestAsync(): Promise<void> {}
+export function runTest(a: string, b: boolean): void {}
+export async function runTestAsync(c: number, d: number): Promise<void> {}
+
+export function doSomething(): void {}
+export async function doSomethingAsync(): Promise<void> {}
 
 function getResult(): string {
   return 'result';

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -12,7 +12,7 @@ import type {ResourceLimits} from 'worker_threads';
 type ReservedKeys = 'end' | 'getStderr' | 'getStdout' | 'setup' | 'teardown';
 type ExcludeReservedKeys<K> = Exclude<K, ReservedKeys>;
 
-type FunctionLike = (args: any) => unknown;
+type FunctionLike = (...args: any) => unknown;
 
 type MethodLikeKeys<T> = {
   [K in keyof T]: T[K] extends FunctionLike ? K : never;


### PR DESCRIPTION
## Summary

Apparently `JestWorkerFarm` helper type does not include methods of worker module that take more than one argument. Spread operator was missed in `FunctionLike` type. Fixed that.

## Test plan

Type tests are added.