### PR TITLE
Fix: Handle multiline comments in parseWithComments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
+- `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
 
 ### Chore & Maintenance
 

--- a/packages/jest-docblock/src/__tests__/index.test.ts
+++ b/packages/jest-docblock/src/__tests__/index.test.ts
@@ -31,6 +31,11 @@ describe('docblock', () => {
     expect(docblock.extract(code)).toBe(`/*${EOL} * @team foo${EOL}*/`);
   });
 
+  it('extracts from invalid docblock singleline', () => {
+    const code = `/* some comment @team foo */${EOL}const x = foo;`;
+    expect(docblock.extract(code)).toBe('/* some comment @team foo */');
+  });
+
   it('returns extract and parsedocblock', () => {
     const code = `/** @provides module-name */${EOL}${EOL}.dummy {}${EOL}`;
 
@@ -201,6 +206,22 @@ describe('docblock', () => {
     expect(docblock.parseWithComments(code)).toEqual({
       comments: '// keep me',
       pragmas: {'format:': 'everything'},
+    });
+  });
+
+  it('extract from invalid docblock', () => {
+    const code = `/* @format: everything${EOL}// keep me */`;
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: '// keep me',
+      pragmas: {'format:': 'everything'},
+    });
+  });
+
+  it('extract from invalid docblock singleline', () => {
+    const code = '/* some test */';
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: ' some test',
+      pragmas: {},
     });
   });
 

--- a/packages/jest-docblock/src/index.ts
+++ b/packages/jest-docblock/src/index.ts
@@ -11,7 +11,7 @@ import detectNewline = require('detect-newline');
 type Pragmas = Record<string, string | Array<string>>;
 
 const commentEndRe = /\*\/$/;
-const commentStartRe = /^\/\*\*/;
+const commentStartRe = /^\/\*\*?/;
 const docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
 const lineCommentRe = /(^|\s+)\/\/([^\r\n]*)/g;
 const ltrimNewlineRe = /^(\r?\n)+/;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This problem was found while using prettier with pragmas enabled and I
[backtracked it to the `parseWithComments`](https://github.com/prettier/prettier/blob/main/src/language-js/pragma.js#L14) function from jest-docblock.
In this context it is especially problematic in cases were the top level
comment is not formatted as a dock lock but a "multi-line comment" to
disable an es-lint rule.

Sample:

```
/* eslint-disable @typescript-eslint/unbound-method */
```

Gets transformed to:

```
/**
 * /* eslint-disable @typescript-eslint/unbound-method
 * /
```

Especially given the fact that the `extract` function seems to handle
this case correctly.

Therefore this solution alters the commentStartRe to keep the second * as
optional. This should ensure that all existing use cases work as expected
with proper docblocks but also ensures that an "invalid" multiline comment
works as well.

Links:
https://github.com/ullumullu/jest/blob/main/packages/jest-docblock/src/__tests__/index.test.ts#L29


## Test plan

```
➜  packages git:(fix_multiline) npx jest packages/jest-docblock
 PASS  jest-docblock/src/__tests__/index.test.ts
  docblock
    ✓ extracts valid docblock with line comment (2 ms)
    ✓ extracts valid docblock (1 ms)
    ✓ extracts valid docblock with more comments
    ✓ extracts from invalid docblock
    ✓ extracts from invalid docblock singleline (1 ms)
    ✓ returns extract and parsedocblock (1 ms)
    ✓ parses directives out of a docblock
    ✓ parses multiple of the same directives out of a docblock
    ✓ parses >=3 of the same directives out of a docblock (1 ms)
    ✓ parses directives out of a docblock with comments
    ✓ parses directives out of a docblock with line comments
    ✓ parses multiline directives (1 ms)
    ✓ parses multiline directives even if there are linecomments within the docblock
    ✓ supports slashes in @team directive (1 ms)
    ✓ extracts comments from docblock
    ✓ extracts multiline comments from docblock
    ✓ preserves leading whitespace in multiline comments from docblock (1 ms)
    ✓ removes leading newlines in multiline comments from docblock
    ✓ extracts comments from beginning and end of docblock (1 ms)
    ✓ preserve urls within a pragma's values
    ✓ strip linecomments from pragmas but preserve for comments (1 ms)
    ✓ extract from invalid docblock
    ✓ extract from invalid docblock singleline (8 ms)
    ✓ extracts docblock comments as CRLF when docblock contains CRLF
    ✓ extracts docblock comments as LF when docblock contains LF
    ✓ strips the docblock out of a file that contains a top docblock
    ✓ returns a file unchanged if there is no top docblock to strip
    ✓ prints docblocks with no pragmas as empty string (1 ms)
    ✓ prints docblocks with one pragma on one line
    ✓ prints docblocks with multiple pragmas on multiple lines
    ✓ prints docblocks with multiple of the same pragma
    ✓ prints docblocks with pragmas
    ✓ prints docblocks with comments
    ✓ prints docblocks with comments and no keys
    ✓ prints docblocks with multiline comments (1 ms)
    ✓ prints docblocks that are parseable
    ✓ can augment existing docblocks with comments (1 ms)
    ✓ prints docblocks using CRLF if comments contains CRLF
    ✓ prints docblocks using LF if comments contains LF (1 ms)

Test Suites: 1 passed, 1 total
Tests:       39 passed, 39 total
Snapshots:   0 total
Time:        0.921 s, estimated 1 s
Ran all test suites matching /packages\/jest-docblock/
```
