### PR TITLE
feat(jest): expose `Config` type from `jest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest]` Expose `JestConfig` type ([#12848](https://github.com/facebook/jest/pull/12848))
 - `[@jest/reporters]` Improve `GitHubActionsReporter`s annotation format ([#12826](https://github.com/facebook/jest/pull/12826))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest]` Expose `JestConfig` type ([#12848](https://github.com/facebook/jest/pull/12848))
+- `[jest]` Expose `Config` type ([#12848](https://github.com/facebook/jest/pull/12848))
 - `[@jest/reporters]` Improve `GitHubActionsReporter`s annotation format ([#12826](https://github.com/facebook/jest/pull/12826))
 
 ### Fixes

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -106,6 +106,8 @@ Alternatively Jest's configuration can be defined through the `"jest"` key in th
 
 ## Options
 
+:::info
+
 You can retrieve Jest's defaults from `jest-config` to extend them if needed:
 
 <Tabs groupId="examples">
@@ -116,7 +118,7 @@ const {defaults} = require('jest-config');
 
 /** @type {import('jest').JestConfig} */
 const config = {
-  moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts'],
+  moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts', 'cts'],
 };
 
 module.exports = config;
@@ -139,6 +141,8 @@ export default config;
 
 </TabItem>
 </Tabs>
+
+:::
 
 import TOCInline from '@theme/TOCInline';
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,7 +22,7 @@ The configuration file should simply export an object:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   verbose: true,
 };
@@ -35,9 +35,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   verbose: true,
 };
 
@@ -53,7 +53,7 @@ Or a function returning an object:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @returns {Promise<import('jest').JestConfig>} */
+/** @returns {Promise<import('jest').Config>} */
 module.exports = async () => {
   return {
     verbose: true,
@@ -66,9 +66,9 @@ module.exports = async () => {
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-export default async (): Promise<JestConfig> => {
+export default async (): Promise<Config> => {
   return {
     verbose: true,
   };
@@ -116,7 +116,7 @@ You can retrieve Jest's defaults from `jest-config` to extend them if needed:
 ```js
 const {defaults} = require('jest-config');
 
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts', 'cts'],
 };
@@ -129,10 +129,10 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 import {defaults} from 'jest-config';
 
-const config: JestConfig = {
+const config: Config = {
   moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts'],
 };
 
@@ -237,7 +237,7 @@ An array of [glob patterns](https://github.com/micromatch/micromatch) indicating
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   collectCoverageFrom: [
     '**/*.{js,jsx}',
@@ -254,9 +254,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   collectCoverageFrom: [
     '**/*.{js,jsx}',
     '!**/node_modules/**',
@@ -340,7 +340,7 @@ Additional options can be passed using the tuple form. For example, you may hide
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   coverageReporters: ['clover', 'json', 'lcov', ['text', {skipFull: true}]],
 };
@@ -353,9 +353,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   coverageReporters: ['clover', 'json', 'lcov', ['text', {skipFull: true}]],
 };
 
@@ -379,7 +379,7 @@ For example, with the following configuration jest will fail if there is less th
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   coverageThreshold: {
     global: {
@@ -399,9 +399,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   coverageThreshold: {
     global: {
       branches: 80,
@@ -426,7 +426,7 @@ For example, with the following configuration:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   coverageThreshold: {
     global: {
@@ -459,9 +459,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   coverageThreshold: {
     global: {
       branches: 50,
@@ -537,7 +537,7 @@ Allows for a label to be printed alongside a test while it is running. This beco
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   displayName: 'CLIENT',
 };
@@ -550,9 +550,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   displayName: 'CLIENT',
 };
 
@@ -568,7 +568,7 @@ Alternatively, an object with the properties `name` and `color` can be passed. T
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   displayName: {
     name: 'CLIENT',
@@ -584,9 +584,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   displayName: {
     name: 'CLIENT',
     color: 'blue',
@@ -615,7 +615,7 @@ Jest will run `.mjs` and `.js` files with nearest `package.json`'s `type` field 
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   extensionsToTreatAsEsm: ['.ts'],
 };
@@ -628,9 +628,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   extensionsToTreatAsEsm: ['.ts'],
 };
 
@@ -658,7 +658,7 @@ This option provides the default configuration of fake timers for all tests. Cal
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   fakeTimers: {
     doNotFake: ['nextTick'],
@@ -674,9 +674,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   fakeTimers: {
     doNotFake: ['nextTick'],
     timerLimit: 1000,
@@ -707,7 +707,7 @@ Instead of including `jest.useFakeTimers()` in each test file, you can enable fa
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   fakeTimers: {
     enableGlobally: true,
@@ -722,9 +722,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   fakeTimers: {
     enableGlobally: true,
   },
@@ -792,7 +792,7 @@ For some reason you might have to use legacy implementation of fake timers. Here
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   fakeTimers: {
     enableGlobally: true,
@@ -808,9 +808,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   fakeTimers: {
     enableGlobally: true,
     legacyFakeTimers: true,
@@ -851,7 +851,7 @@ You can collect coverage from those files with setting `forceCoverageMatch`.
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   forceCoverageMatch: ['**/*.t.js'],
 };
@@ -864,9 +864,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   forceCoverageMatch: ['**/*.t.js'],
 };
 
@@ -888,7 +888,7 @@ For example, the following would create a global `__DEV__` variable set to `true
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   globals: {
     __DEV__: true,
@@ -903,9 +903,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   globals: {
     __DEV__: true,
   },
@@ -1039,7 +1039,7 @@ For environments with variable CPUs available, you can use percentage based conf
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   maxWorkers: '50%',
 };
@@ -1052,9 +1052,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   maxWorkers: '50%',
 };
 
@@ -1074,7 +1074,7 @@ An array of directory names to be searched recursively up from the requiring mod
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   moduleDirectories: ['node_modules', 'bower_components'],
 };
@@ -1087,9 +1087,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   moduleDirectories: ['node_modules', 'bower_components'],
 };
 
@@ -1123,7 +1123,7 @@ Additionally, you can substitute captured regex groups using numbered backrefere
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   moduleNameMapper: {
     '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
@@ -1145,9 +1145,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   moduleNameMapper: {
     '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
     '^[./a-zA-Z0-9$_-]+\\.png$': '<rootDir>/RelativeImageStub.js',
@@ -1186,7 +1186,7 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   modulePathIgnorePatterns: ['<rootDir>/build/'],
 };
@@ -1199,9 +1199,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   modulePathIgnorePatterns: ['<rootDir>/build/'],
 };
 
@@ -1221,7 +1221,7 @@ An alternative API to setting the `NODE_PATH` env variable, `modulePaths` is an 
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   modulePaths: ['<rootDir>/app/'],
 };
@@ -1234,9 +1234,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   modulePaths: ['<rootDir>/app/'],
 };
 
@@ -1291,7 +1291,7 @@ For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   preset: 'foo-bar',
 };
@@ -1304,9 +1304,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   preset: 'foo-bar',
 };
 
@@ -1322,7 +1322,7 @@ Presets may also be relative to filesystem paths:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   preset: './node_modules/foo-bar/jest-preset.js',
 };
@@ -1335,9 +1335,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   preset: './node_modules/foo-bar/jest-preset.js',
 };
 
@@ -1369,7 +1369,7 @@ When the `projects` configuration is provided with an array of paths or glob pat
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   projects: ['<rootDir>', '<rootDir>/examples/*'],
 };
@@ -1382,9 +1382,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   projects: ['<rootDir>', '<rootDir>/examples/*'],
 };
 
@@ -1402,7 +1402,7 @@ The projects feature can also be used to run multiple configurations or multiple
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   projects: [
     {
@@ -1424,9 +1424,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   projects: [
     {
       displayName: 'test',
@@ -1461,7 +1461,7 @@ Use this configuration option to add reporters to Jest. It must be a list of rep
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   reporters: [
     'default',
@@ -1477,9 +1477,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   reporters: [
     'default',
     ['<rootDir>/custom-reporter.js', {banana: 'yes', pineapple: 'no'}],
@@ -1500,7 +1500,7 @@ If custom reporters are specified, the default Jest reporter will be overridden.
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   reporters: [
     'default',
@@ -1516,9 +1516,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   reporters: [
     'default',
     ['jest-junit', {outputDirectory: 'reports', outputName: 'report.xml'}],
@@ -1539,7 +1539,7 @@ If included in the list, the built-in GitHub Actions Reporter will annotate chan
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   reporters: ['default', 'github-actions'],
 };
@@ -1552,9 +1552,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   reporters: ['default', 'github-actions'],
 };
 
@@ -1572,7 +1572,7 @@ Summary reporter prints out summary of all tests. It is a part of default report
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   reporters: ['jest-silent-reporter', 'summary'],
 };
@@ -1585,9 +1585,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   reporters: ['jest-silent-reporter', 'summary'],
 };
 
@@ -1700,7 +1700,7 @@ And add it to Jest configuration:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   resolver: '<rootDir>/resolver.js',
 };
@@ -1713,9 +1713,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   resolver: '<rootDir>/resolver.js',
 };
 
@@ -1830,7 +1830,7 @@ For example, if your tests call `Math` often, you can pass it by setting `sandbo
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   sandboxInjectedGlobals: ['Math'],
 };
@@ -1843,9 +1843,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   sandboxInjectedGlobals: ['Math'],
 };
 
@@ -1894,7 +1894,7 @@ afterEach(() => {
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
@@ -1907,9 +1907,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
 };
 
@@ -1935,7 +1935,7 @@ Allows overriding specific snapshot formatting options documented in the [pretty
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   snapshotFormat: {
     printBasicPrototype: false,
@@ -1950,9 +1950,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   snapshotFormat: {
     printBasicPrototype: false,
   },
@@ -2032,7 +2032,7 @@ Add `custom-serializer` to your Jest configuration:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   snapshotSerializers: ['path/to/custom-serializer.js'],
 };
@@ -2045,9 +2045,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   snapshotSerializers: ['path/to/custom-serializer.js'],
 };
 
@@ -2394,7 +2394,7 @@ Add `custom-sequencer` to your Jest configuration:
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   testSequencer: 'path/to/custom-sequencer.js',
 };
@@ -2407,9 +2407,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   testSequencer: 'path/to/custom-sequencer.js',
 };
 
@@ -2445,7 +2445,7 @@ Remember to include the default `babel-jest` transformer explicitly, if you wish
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
@@ -2461,9 +2461,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '\\.css$': 'some-css-transformer',
@@ -2490,7 +2490,7 @@ Providing regexp patterns that overlap with each other may result in files not b
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   transformIgnorePatterns: ['/node_modules/(?!(foo|bar)/)', '/bar/'],
 };
@@ -2503,9 +2503,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   transformIgnorePatterns: ['/node_modules/(?!(foo|bar)/)', '/bar/'],
 };
 
@@ -2525,7 +2525,7 @@ These pattern strings match against the full path. Use the `<rootDir>` string to
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   transformIgnorePatterns: [
     '<rootDir>/bower_components/',
@@ -2541,9 +2541,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   transformIgnorePatterns: [
     '<rootDir>/bower_components/',
     '<rootDir>/node_modules/',
@@ -2586,7 +2586,7 @@ Even if nothing is specified here, the watcher will ignore changes to the versio
 <TabItem value="js" label="JavaScript">
 
 ```js
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 const config = {
   watchPathIgnorePatterns: ['<rootDir>/\\.tmp/', '<rootDir>/bar/'],
 };
@@ -2599,9 +2599,9 @@ module.exports = config;
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-import type {JestConfig} from 'jest';
+import type {Config} from 'jest';
 
-const config: JestConfig = {
+const config: Config = {
   watchPathIgnorePatterns: ['<rootDir>/\\.tmp/', '<rootDir>/bar/'],
 };
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -16,7 +16,7 @@ Keep in mind that the resulting configuration object must always be JSON-seriali
 
 :::
 
-The configuration file should simply export an object or a function returning an object:
+The configuration file should simply export an object:
 
 <Tabs groupId="examples">
 <TabItem value="js" label="JavaScript">
@@ -42,6 +42,37 @@ const config: JestConfig = {
 };
 
 export default config;
+```
+
+</TabItem>
+</Tabs>
+
+Or a function returning an object:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @returns {Promise<import('jest').JestConfig>} */
+module.exports = async () => {
+  return {
+    verbose: true,
+  };
+};
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+export default async (): Promise<JestConfig> => {
+  return {
+    verbose: true,
+  };
+};
 ```
 
 </TabItem>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -80,7 +80,7 @@ export default async (): Promise<Config> => {
 
 :::tip
 
-To read TypeScript configuration files Jest requires [`ts-node`](https://github.com/TypeStrong/ts-node). Make sure it is installed in your project.
+To read TypeScript configuration files Jest requires [`ts-node`](https://npmjs.com/package/ts-node). Make sure it is installed in your project.
 
 :::
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -3,9 +3,68 @@ id: configuration
 title: Configuring Jest
 ---
 
-Jest's configuration can be defined in the `package.json` file of your project, or through a `jest.config.js`, or `jest.config.ts` file or through the `--config <path/to/file.js|ts|cjs|mjs|json>` option. If you'd like to use your `package.json` to store Jest's config, the `"jest"` key should be used on the top level so Jest will know how to find your settings:
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
-```json
+The Jest philosophy is to work great by default, but sometimes you just need more configuration power.
+
+It is recommended to define the configuration in a dedicated JavaScript, TypeScript or JSON file. The file will be discovered automatically, if it is named `jest.config.js|ts|mjs|cjs|json`. You can use [`--config`](CLI.md#--configpath) flag to pass an explicit path to the file.
+
+:::note
+
+Keep in mind that the resulting configuration object must always be JSON-serializable.
+
+:::
+
+The configuration file should simply export an object or a function returning an object:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  verbose: true,
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  verbose: true,
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
+
+:::tip
+
+To read TypeScript configuration files Jest requires [`ts-node`](https://github.com/TypeStrong/ts-node). Make sure it is installed in your project.
+
+:::
+
+The configuration also can be stored in a JSON file as a plain object:
+
+```json title="jest.config.json"
+{
+  "bail": 1,
+  "verbose": true
+}
+```
+
+Alternatively Jest's configuration can be defined through the `"jest"` key in the `package.json` of your project:
+
+```json title="package.json"
 {
   "name": "my-project",
   "jest": {
@@ -14,71 +73,41 @@ Jest's configuration can be defined in the `package.json` file of your project, 
 }
 ```
 
-Or through JavaScript:
+## Options
 
-```js title="jest.config.js"
-// Sync object
-/** @type {import('@jest/types').Config.InitialOptions} */
+You can retrieve Jest's defaults from `jest-config` to extend them if needed:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+const {defaults} = require('jest-config');
+
+/** @type {import('jest').JestConfig} */
 const config = {
-  verbose: true,
+  moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts'],
 };
 
 module.exports = config;
-
-// Or async function
-module.exports = async () => {
-  return {
-    verbose: true,
-  };
-};
 ```
 
-Or through TypeScript (if `ts-node` is installed):
+</TabItem>
 
-```ts title="jest.config.ts"
-import type {Config} from '@jest/types';
+<TabItem value="ts" label="TypeScript">
 
-// Sync object
-const config: Config.InitialOptions = {
-  verbose: true,
+```ts
+import type {JestConfig} from 'jest';
+import {defaults} from 'jest-config';
+
+const config: JestConfig = {
+  moduleFileExtensions: [...defaults.moduleFileExtensions, 'mts'],
 };
+
 export default config;
-
-// Or async function
-export default async (): Promise<Config.InitialOptions> => {
-  return {
-    verbose: true,
-  };
-};
 ```
 
-Please keep in mind that the resulting configuration must be JSON-serializable.
-
-When using the `--config` option, the JSON file must not contain a "jest" key:
-
-```json
-{
-  "bail": 1,
-  "verbose": true
-}
-```
-
-## Options
-
-These options let you control Jest's behavior in your `package.json` file. The Jest philosophy is to work great by default, but sometimes you just need more configuration power.
-
-### Defaults
-
-You can retrieve Jest's default options to expand them if needed:
-
-```js title="jest.config.js"
-const {defaults} = require('jest-config');
-module.exports = {
-  // ...
-  moduleFileExtensions: [...defaults.moduleFileExtensions, 'ts', 'tsx'],
-  // ...
-};
-```
+</TabItem>
+</Tabs>
 
 import TOCInline from '@theme/TOCInline';
 
@@ -98,15 +127,12 @@ Example:
 
 ```js title="utils.js"
 export default {
-  authorize: () => {
-    return 'token';
-  },
+  authorize: () => 'token',
   isAuthorized: secret => secret === 'wizard',
 };
 ```
 
-```js
-//__tests__/automocking.test.js
+```js title="__tests__/automock.test.js"
 import utils from '../utils';
 
 test('if utils mocked automatically', () => {
@@ -172,17 +198,42 @@ Default: `undefined`
 
 An array of [glob patterns](https://github.com/micromatch/micromatch) indicating a set of files for which coverage information should be collected. If a file matches the specified glob pattern, coverage information will be collected for it even if no tests exist for this file and it's never required in the test suite.
 
-Example:
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
-```json
-{
-  "collectCoverageFrom": [
-    "**/*.{js,jsx}",
-    "!**/node_modules/**",
-    "!**/vendor/**"
-  ]
-}
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+  ],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  collectCoverageFrom: [
+    '**/*.{js,jsx}',
+    '!**/node_modules/**',
+    '!**/vendor/**',
+  ],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 This will collect coverage information for all the files inside the project's `rootDir`, except the ones that match `**/node_modules/**` or `**/vendor/**`.
 
@@ -250,11 +301,34 @@ Setting this option overwrites the default values. Add `"text"` or `"text-summar
 
 Additional options can be passed using the tuple form. For example, you may hide coverage report lines for all fully-covered files:
 
-```json
-{
-  "coverageReporters": ["clover", "json", "lcov", ["text", {"skipFull": true}]]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  coverageReporters: ['clover', 'json', 'lcov', ['text', {skipFull: true}]],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  coverageReporters: ['clover', 'json', 'lcov', ['text', {skipFull: true}]],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 For more information about the options object shape refer to `CoverageReporterWithOptions` type in the [type definitions](https://github.com/facebook/jest/tree/main/packages/jest-types/src/Config.ts).
 
@@ -266,54 +340,121 @@ This will be used to configure minimum threshold enforcement for coverage result
 
 For example, with the following configuration jest will fail if there is less than 80% branch, line, and function coverage, or if there are more than 10 uncovered statements:
 
-```json
-{
-  ...
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "branches": 80,
-        "functions": 80,
-        "lines": 80,
-        "statements": -10
-      }
-    }
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: -10,
+    },
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: -10,
+    },
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 If globs or paths are specified alongside `global`, coverage data for matching paths will be subtracted from overall coverage and thresholds will be applied independently. Thresholds for globs are applied to all files matching the glob. If the file specified by path is not found, an error is returned.
 
 For example, with the following configuration:
 
-```json
-{
-  ...
-  "jest": {
-    "coverageThreshold": {
-      "global": {
-        "branches": 50,
-        "functions": 50,
-        "lines": 50,
-        "statements": 50
-      },
-      "./src/components/": {
-        "branches": 40,
-        "statements": 40
-      },
-      "./src/reducers/**/*.js": {
-        "statements": 90
-      },
-      "./src/api/very-important-module.js": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100,
-        "statements": 100
-      }
-    }
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50,
+    },
+    './src/components/': {
+      branches: 40,
+      statements: 40,
+    },
+    './src/reducers/**/*.js': {
+      statements: 90,
+    },
+    './src/api/very-important-module.js': {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50,
+    },
+    './src/components/': {
+      branches: 40,
+      statements: 40,
+    },
+    './src/reducers/**/*.js': {
+      statements: 90,
+    },
+    './src/api/very-important-module.js': {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 Jest will fail if:
 
@@ -355,26 +496,73 @@ That module can also contain a `getCacheKey` function to generate a cache key to
 
 default: `undefined`
 
-Allows for a label to be printed alongside a test while it is running. This becomes more useful in multi-project repositories where there can be many jest configuration files. This visually tells which project a test belongs to. Here are sample valid values.
+Allows for a label to be printed alongside a test while it is running. This becomes more useful in multi-project repositories where there can be many jest configuration files. This visually tells which project a test belongs to.
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
 ```js
-module.exports = {
+/** @type {import('jest').JestConfig} */
+const config = {
   displayName: 'CLIENT',
 };
+
+module.exports = config;
 ```
 
-or
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  displayName: 'CLIENT',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
+
+Alternatively, an object with the properties `name` and `color` can be passed. This allows for a custom configuration of the background color of the displayName. `displayName` defaults to white when its value is a string. Jest uses [`chalk`](https://github.com/chalk/chalk) to provide the color. As such, all of the valid options for colors supported by `chalk` are also supported by Jest.
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
 ```js
-module.exports = {
+/** @type {import('jest').JestConfig} */
+const config = {
   displayName: {
     name: 'CLIENT',
     color: 'blue',
   },
 };
+
+module.exports = config;
 ```
 
-As a secondary option, an object with the properties `name` and `color` can be passed. This allows for a custom configuration of the background color of the displayName. `displayName` defaults to white when its value is a string. Jest uses [chalk](https://github.com/chalk/chalk) to provide the color. As such, all of the valid options for colors supported by chalk are also supported by jest.
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  displayName: {
+    name: 'CLIENT',
+    color: 'blue',
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `errorOnDeprecated` \[boolean]
 
@@ -388,20 +576,40 @@ Default: `[]`
 
 Jest will run `.mjs` and `.js` files with nearest `package.json`'s `type` field set to `module` as ECMAScript Modules. If you have any other files that should run with native ESM, you need to specify their file extension here.
 
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  extensionsToTreatAsEsm: ['.ts'],
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  extensionsToTreatAsEsm: ['.ts'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
+
 :::caution
 
 Jest's ESM support is still experimental, see [its docs for more details](ECMAScriptModules.md).
 
 :::
-
-```json
-{
-  ...
-  "jest": {
-    "extensionsToTreatAsEsm": [".ts"]
-  }
-}
-```
 
 ### `fakeTimers` \[object]
 
@@ -411,14 +619,40 @@ The fake timers may be useful when a piece of code sets a long timeout that we d
 
 This option provides the default configuration of fake timers for all tests. Calling `jest.useFakeTimers()` in a test file will use these options or will override them if a configuration object is passed. For example, you can tell Jest to keep the original implementation of `process.nextTick()` and adjust the limit of recursive timers that will be run:
 
-```json
-{
-  "fakeTimers": {
-    "doNotFake": ["nextTick"],
-    "timerLimit": 1000
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  fakeTimers: {
+    doNotFake: ['nextTick'],
+    timerLimit: 1000,
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  fakeTimers: {
+    doNotFake: ['nextTick'],
+    timerLimit: 1000,
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ```js title="fakeTime.test.js"
 // install fake timers for this file using the options from Jest configuration
@@ -432,15 +666,40 @@ test('increase the limit of recursive timers for this and following tests', () =
 
 :::tip
 
-Instead of including `jest.useFakeTimers()` in each test file, you can enable fake timers globally for all tests:
+Instead of including `jest.useFakeTimers()` in each test file, you can enable fake timers globally for all tests in your Jest configuration:
 
-```json
-{
-  "fakeTimers": {
-    "enableGlobally": true
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  fakeTimers: {
+    enableGlobally: true,
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  fakeTimers: {
+    enableGlobally: true,
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::
 
@@ -494,14 +753,40 @@ type ModernFakeTimersConfig = {
 
 For some reason you might have to use legacy implementation of fake timers. Here is how to enable it globally (additional options are not supported):
 
-```json
-{
-  "fakeTimers": {
-    "enableGlobally": true,
-    "legacyFakeTimers": true
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  fakeTimers: {
+    enableGlobally: true,
+    legacyFakeTimers: true,
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  fakeTimers: {
+    enableGlobally: true,
+    legacyFakeTimers: true,
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::
 
@@ -527,14 +812,34 @@ if (process.env.NODE_ENV === 'test') {
 
 You can collect coverage from those files with setting `forceCoverageMatch`.
 
-```json
-{
-  ...
-  "jest": {
-    "forceCoverageMatch": ["**/*.t.js"]
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  forceCoverageMatch: ['**/*.t.js'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  forceCoverageMatch: ['**/*.t.js'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `globals` \[object]
 
@@ -544,16 +849,38 @@ A set of global variables that need to be available in all test environments.
 
 For example, the following would create a global `__DEV__` variable set to `true` in all test environments:
 
-```json
-{
-  ...
-  "jest": {
-    "globals": {
-      "__DEV__": true
-    }
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  globals: {
+    __DEV__: true,
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  globals: {
+    __DEV__: true,
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 Note that, if you specify a global reference value (like an object or array) here, and some code mutates that value in the midst of running a test, that mutation will _not_ be persisted across test runs for other test files. In addition, the `globals` object must be json-serializable, so it can't be used to specify global functions. For that, you should use `setupFiles`.
 
@@ -671,13 +998,71 @@ A number limiting the number of tests that are allowed to run at the same time w
 
 Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
-For environments with variable CPUs available, you can use percentage based configuration: `"maxWorkers": "50%"`
+For environments with variable CPUs available, you can use percentage based configuration:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  maxWorkers: '50%',
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  maxWorkers: '50%',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `moduleDirectories` \[array&lt;string&gt;]
 
 Default: `["node_modules"]`
 
-An array of directory names to be searched recursively up from the requiring module's location. Setting this option will _override_ the default, if you wish to still search `node_modules` for packages include it along with any other options: `["node_modules", "bower_components"]`
+An array of directory names to be searched recursively up from the requiring module's location. Setting this option will _override_ the default, if you wish to still search `node_modules` for packages include it along with any other options:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  moduleDirectories: ['node_modules', 'bower_components'],
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  moduleDirectories: ['node_modules', 'bower_components'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `moduleFileExtensions` \[array&lt;string&gt;]
 
@@ -699,22 +1084,52 @@ Use `<rootDir>` string token to refer to [`rootDir`](#rootdir-string) value if y
 
 Additionally, you can substitute captured regex groups using numbered backreferences.
 
-Example:
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
-```json
-{
-  "moduleNameMapper": {
-    "^image![a-zA-Z0-9$_-]+$": "GlobalImageStub",
-    "^[./a-zA-Z0-9$_-]+\\.png$": "<rootDir>/RelativeImageStub.js",
-    "module_name_(.*)": "<rootDir>/substituted_module_$1.js",
-    "assets/(.*)": [
-      "<rootDir>/images/$1",
-      "<rootDir>/photos/$1",
-      "<rootDir>/recipes/$1"
-    ]
-  }
-}
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  moduleNameMapper: {
+    '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
+    '^[./a-zA-Z0-9$_-]+\\.png$': '<rootDir>/RelativeImageStub.js',
+    'module_name_(.*)': '<rootDir>/substituted_module_$1.js',
+    'assets/(.*)': [
+      '<rootDir>/images/$1',
+      '<rootDir>/photos/$1',
+      '<rootDir>/recipes/$1',
+    ],
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  moduleNameMapper: {
+    '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
+    '^[./a-zA-Z0-9$_-]+\\.png$': '<rootDir>/RelativeImageStub.js',
+    'module_name_(.*)': '<rootDir>/substituted_module_$1.js',
+    'assets/(.*)': [
+      '<rootDir>/images/$1',
+      '<rootDir>/photos/$1',
+      '<rootDir>/recipes/$1',
+    ],
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 The order in which the mappings are defined matters. Patterns are checked one by one until one fits. The most specific rule should be listed first. This is true for arrays of module names as well.
 
@@ -730,13 +1145,71 @@ Default: `[]`
 
 An array of regexp pattern strings that are matched against all module paths before those paths are to be considered 'visible' to the module loader. If a given module's path matches any of the patterns, it will not be `require()`-able in the test environment.
 
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/"]`.
+These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories.
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `modulePaths` \[array&lt;string&gt;]
 
 Default: `[]`
 
-An alternative API to setting the `NODE_PATH` env variable, `modulePaths` is an array of absolute paths to additional locations to search when resolving modules. Use the `<rootDir>` string token to include the path to your project's root directory. Example: `["<rootDir>/app/"]`.
+An alternative API to setting the `NODE_PATH` env variable, `modulePaths` is an array of absolute paths to additional locations to search when resolving modules. Use the `<rootDir>` string token to include the path to your project's root directory.
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  modulePaths: ['<rootDir>/app/'],
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  modulePaths: ['<rootDir>/app/'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `notify` \[boolean]
 
@@ -779,21 +1252,65 @@ A preset that is used as a base for Jest's configuration. A preset should point 
 
 For example, this preset `foo-bar/jest-preset.js` will be configured as follows:
 
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
 ```js
-/** @type { import('@jest/types').Config.InitialOptions } */
-module.exports = {
+/** @type {import('jest').JestConfig} */
+const config = {
   preset: 'foo-bar',
 };
+
+module.exports = config;
 ```
 
-Presets may also be relative to filesystem paths.
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  preset: 'foo-bar',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
+
+Presets may also be relative to filesystem paths:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
 ```js
-/** @type { import('@jest/types').Config.InitialOptions } */
-module.exports = {
+/** @type {import('jest').JestConfig} */
+const config = {
   preset: './node_modules/foo-bar/jest-preset.js',
 };
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  preset: './node_modules/foo-bar/jest-preset.js',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::info
 
@@ -813,30 +1330,85 @@ Default: `undefined`
 
 When the `projects` configuration is provided with an array of paths or glob patterns, Jest will run tests in all of the specified projects at the same time. This is great for monorepos or when working on multiple projects at the same time.
 
-```json
-{
-  "projects": ["<rootDir>", "<rootDir>/examples/*"]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  projects: ['<rootDir>', '<rootDir>/examples/*'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  projects: ['<rootDir>', '<rootDir>/examples/*'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 This example configuration will run Jest in the root directory as well as in every folder in the examples directory. You can have an unlimited amount of projects running in the same Jest instance.
 
 The projects feature can also be used to run multiple configurations or multiple [runners](#runner-string). For this purpose, you can pass an array of configuration objects. For example, to run both tests and ESLint (via [jest-runner-eslint](https://github.com/jest-community/jest-runner-eslint)) in the same invocation of Jest:
 
-```json
-{
-  "projects": [
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  projects: [
     {
-      "displayName": "test"
+      displayName: 'test',
     },
     {
-      "displayName": "lint",
-      "runner": "jest-runner-eslint",
-      "testMatch": ["<rootDir>/**/*.js"]
-    }
-  ]
-}
+      displayName: 'lint',
+      runner: 'jest-runner-eslint',
+      testMatch: ['<rootDir>/**/*.js'],
+    },
+  ],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  projects: [
+    {
+      displayName: 'test',
+    },
+    {
+      displayName: 'lint',
+      runner: 'jest-runner-eslint',
+      testMatch: ['<rootDir>/**/*.js'],
+    },
+  ],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::tip
 
@@ -850,47 +1422,145 @@ Default: `undefined`
 
 Use this configuration option to add reporters to Jest. It must be a list of reporter names, additional options can be passed to a reporter using the tuple form:
 
-```json
-{
-  "reporters": [
-    "default",
-    ["<rootDir>/custom-reporter.js", {"banana": "yes", "pineapple": "no"}]
-  ]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  reporters: [
+    'default',
+    ['<rootDir>/custom-reporter.js', {banana: 'yes', pineapple: 'no'}],
+  ],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  reporters: [
+    'default',
+    ['<rootDir>/custom-reporter.js', {banana: 'yes', pineapple: 'no'}],
+  ],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 #### Default Reporter
 
 If custom reporters are specified, the default Jest reporter will be overridden. If you wish to keep it, `'default'` must be passed as a reporters name:
 
-```json
-{
-  "reporters": [
-    "default",
-    ["jest-junit", {"outputDirectory": "reports", "outputName": "report.xml"}]
-  ]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  reporters: [
+    'default',
+    ['jest-junit', {outputDirectory: 'reports', outputName: 'report.xml'}],
+  ],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  reporters: [
+    'default',
+    ['jest-junit', {outputDirectory: 'reports', outputName: 'report.xml'}],
+  ],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 #### GitHub Actions Reporter
 
 If included in the list, the built-in GitHub Actions Reporter will annotate changed files with test failure messages:
 
-```json
-{
-  "reporters": ["default", "github-actions"]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  reporters: ['default', 'github-actions'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  reporters: ['default', 'github-actions'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 #### Summary Reporter
 
 Summary reporter prints out summary of all tests. It is a part of default reporter, hence it will be enabled if `'default'` is included in the list. For instance, you might want to use it as stand-alone reporter instead of the default one, or together with [Silent Reporter](https://github.com/rickhanlonii/jest-silent-reporter):
 
-```json
-{
-  "reporters": ["jest-silent-reporter", "summary"]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  reporters: ['jest-silent-reporter', 'summary'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  reporters: ['jest-silent-reporter', 'summary'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 #### Custom Reporters
 
@@ -981,19 +1651,44 @@ The `defaultResolver` passed as an option is the Jest default resolver which mig
 
 :::
 
-For example, if you want to respect Browserify's [`"browser"` field](https://github.com/browserify/browserify-handbook/blob/master/readme.markdown#browser-field), you can use the following configuration:
-
-```json
-{
-  "resolver": "<rootDir>/resolver.js"
-}
-```
+For example, if you want to respect Browserify's [`"browser"` field](https://github.com/browserify/browserify-handbook/blob/master/readme.markdown#browser-field), you can use the following resolver:
 
 ```js title="resolver.js"
 const browserResolve = require('browser-resolve');
 
 module.exports = browserResolve.sync;
 ```
+
+And add it to Jest configuration:
+
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  resolver: '<rootDir>/resolver.js',
+};
+
+module.exports = config;
+```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  resolver: '<rootDir>/resolver.js',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 By combining `defaultResolver` and `packageFilter` we can implement a `package.json` "pre-processor" that allows us to change how the default resolver will resolve modules. For example, imagine we want to use the field `"module"` if it is present, otherwise fallback to `"main"`:
 
@@ -1096,14 +1791,34 @@ Test files run inside a [vm](https://nodejs.org/api/vm.html), which slows calls 
 
 For example, if your tests call `Math` often, you can pass it by setting `sandboxInjectedGlobals`.
 
-```json
-{
-  ...
-  "jest": {
-    "sandboxInjectedGlobals": ["Math"]
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  sandboxInjectedGlobals: ['Math'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  sandboxInjectedGlobals: ['Math'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::note
 
@@ -1140,11 +1855,34 @@ afterEach(() => {
 });
 ```
 
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
 ```js
-module.exports = {
+/** @type {import('jest').JestConfig} */
+const config = {
   setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `slowTestThreshold` \[number]
 
@@ -1158,19 +1896,40 @@ Default: `undefined`
 
 Allows overriding specific snapshot formatting options documented in the [pretty-format readme](https://www.npmjs.com/package/pretty-format#usage-with-options), with the exceptions of `compareKeys` and `plugins`. For example, this config would have the snapshot formatter not print a prefix for "Object" and "Array":
 
-```json
-{
-  "jest": {
-    "snapshotFormat": {
-      "printBasicPrototype": false
-    }
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+};
+
+module.exports = config;
 ```
 
-```ts
-import {expect, test} from '@jest/globals';
+</TabItem>
 
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  snapshotFormat: {
+    printBasicPrototype: false,
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
+
+```js title="some.test.js"
 test('does not show prototypes for object and array inline', () => {
   const object = {
     array: [{hello: 'Danger'}],
@@ -1193,9 +1952,7 @@ Default: `undefined`
 
 The path to a module that can resolve test<->snapshot path. This config option lets you customize where Jest stores snapshot files on disk.
 
-Example snapshot resolver module:
-
-```js
+```js title="custom-resolver.js"
 module.exports = {
   // resolves from test to snapshot path
   resolveSnapshotPath: (testPath, snapshotExtension) =>
@@ -1220,10 +1977,7 @@ A list of paths to snapshot serializer modules Jest should use for snapshot test
 
 Jest has default serializers for built-in JavaScript types, HTML elements (Jest 20.0.0+), ImmutableJS (Jest 20.0.0+) and for React elements. See [snapshot test tutorial](TutorialReactNative.md#snapshot-test) for more information.
 
-Example serializer module:
-
-```js
-// my-serializer-module
+```js title="custom-serializer.js"
 module.exports = {
   serialize(val, config, indentation, depth, refs, printer) {
     return `Pretty foo: ${printer(val.foo)}`;
@@ -1237,16 +1991,36 @@ module.exports = {
 
 `printer` is a function that serializes a value using existing plugins.
 
-To use `my-serializer-module` as a serializer, configuration would be as follows:
+Add `custom-serializer` to your Jest configuration:
 
-```json
-{
-  ...
-  "jest": {
-    "snapshotSerializers": ["my-serializer-module"]
-  }
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  snapshotSerializers: ['path/to/custom-serializer.js'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  snapshotSerializers: ['path/to/custom-serializer.js'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 Finally tests would look as follows:
 
@@ -1544,11 +2318,9 @@ Both `sort` and `shard` may optionally return a `Promise`.
 
 :::
 
-Example:
+For example, you may sort test paths alphabetically:
 
-Sort test path alphabetically.
-
-```js title="testSequencer.js"
+```js title="custom-sequencer.js"
 const Sequencer = require('@jest/test-sequencer').default;
 
 class CustomSequencer extends Sequencer {
@@ -1581,13 +2353,36 @@ class CustomSequencer extends Sequencer {
 module.exports = CustomSequencer;
 ```
 
-Use it in your Jest config file like this:
+Add `custom-sequencer` to your Jest configuration:
 
-```json
-{
-  "testSequencer": "path/to/testSequencer.js"
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  testSequencer: 'path/to/custom-sequencer.js',
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  testSequencer: 'path/to/custom-sequencer.js',
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `testTimeout` \[number]
 
@@ -1611,12 +2406,40 @@ Keep in mind that a transformer only runs once per file unless the file has chan
 
 Remember to include the default `babel-jest` transformer explicitly, if you wish to use it alongside with additional code preprocessors:
 
-```json
-"transform": {
-  "\\.[jt]sx?$": "babel-jest",
-  "\\.css$": "some-css-transformer",
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+    '\\.css$': 'some-css-transformer',
+  },
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  transform: {
+    '\\.[jt]sx?$': 'babel-jest',
+    '\\.css$': 'some-css-transformer',
+  },
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 :::
 
@@ -1628,11 +2451,34 @@ An array of regexp pattern strings that are matched against all source file path
 
 Providing regexp patterns that overlap with each other may result in files not being transformed that you expected to be transformed. For example:
 
-```json
-{
-  "transformIgnorePatterns": ["/node_modules/(?!(foo|bar)/)", "/bar/"]
-}
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
+
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  transformIgnorePatterns: ['/node_modules/(?!(foo|bar)/)', '/bar/'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  transformIgnorePatterns: ['/node_modules/(?!(foo|bar)/)', '/bar/'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 The first pattern will match (and therefore not transform) files inside `/node_modules` except for those in `/node_modules/foo/` and `/node_modules/bar/`. The second pattern will match (and therefore not transform) files inside any path with `/bar/` in it. With the two together, files in `/node_modules/bar/` will not be transformed because it does match the second pattern, even though it was excluded by the first.
 
@@ -1640,16 +2486,40 @@ Sometimes it happens (especially in React Native or TypeScript projects) that 3r
 
 These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories.
 
-Example:
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
-```json
-{
-  "transformIgnorePatterns": [
-    "<rootDir>/bower_components/",
-    "<rootDir>/node_modules/"
-  ]
-}
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  transformIgnorePatterns: [
+    '<rootDir>/bower_components/',
+    '<rootDir>/node_modules/',
+  ],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  transformIgnorePatterns: [
+    '<rootDir>/bower_components/',
+    '<rootDir>/node_modules/',
+  ],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `unmockedModulePathPatterns` \[array&lt;string&gt;]
 
@@ -1677,13 +2547,34 @@ These patterns match against the full path. Use the `<rootDir>` string token to 
 
 Even if nothing is specified here, the watcher will ignore changes to the version control folders (.git, .hg). Other hidden files and directories, i.e. those that begin with a dot (`.`), are watched by default. Remember to escape the dot when you add them to `watchPathIgnorePatterns` as it is a special RegExp character.
 
-Example:
+<Tabs groupId="examples">
+<TabItem value="js" label="JavaScript">
 
-```json
-{
-  "watchPathIgnorePatterns": ["<rootDir>/\\.tmp/", "<rootDir>/bar/"]
-}
+```js
+/** @type {import('jest').JestConfig} */
+const config = {
+  watchPathIgnorePatterns: ['<rootDir>/\\.tmp/', '<rootDir>/bar/'],
+};
+
+module.exports = config;
 ```
+
+</TabItem>
+
+<TabItem value="ts" label="TypeScript">
+
+```ts
+import type {JestConfig} from 'jest';
+
+const config: JestConfig = {
+  watchPathIgnorePatterns: ['<rootDir>/\\.tmp/', '<rootDir>/bar/'],
+};
+
+export default config;
+```
+
+</TabItem>
+</Tabs>
 
 ### `watchPlugins` \[array&lt;string | \[string, Object]&gt;]
 
@@ -1713,13 +2604,9 @@ Whether to use [`watchman`](https://facebook.github.io/watchman/) for file crawl
 
 ### `//` \[string]
 
-No default
+This option allows comments in `package.json`. Include the comment text as the value of this key:
 
-This option allows comments in `package.json`. Include the comment text as the value of this key anywhere in `package.json`.
-
-Example:
-
-```json
+```json title="package.json"
 {
   "name": "my-project",
   "jest": {

--- a/e2e/__tests__/tsIntegration.test.ts
+++ b/e2e/__tests__/tsIntegration.test.ts
@@ -174,3 +174,163 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     });
   });
 });
+
+describe('when `JestConfig` type is imported from "jest"', () => {
+  test('with object config exported from TS file', () => {
+    writeFiles(DIR, {
+      '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
+      'jest.config.ts': `
+        import type {JestConfig} from 'jest';
+        const config: JestConfig = {displayName: 'ts-object-config', verbose: true};
+        export default config;
+        `,
+      'package.json': '{}',
+    });
+
+    const {configs, globalConfig} = getConfig(path.join(DIR));
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].displayName?.name).toBe('ts-object-config');
+    expect(globalConfig.verbose).toBe(true);
+  });
+
+  test('with function config exported from TS file', () => {
+    writeFiles(DIR, {
+      '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
+      'jest.config.ts': `
+        import type {JestConfig} from 'jest';
+        async function getVerbose() {return true;}
+        export default async (): Promise<JestConfig> => {
+          const verbose: JestConfig['verbose'] = await getVerbose();
+          return {displayName: 'ts-async-function-config', verbose};
+        };
+        `,
+      'package.json': '{}',
+    });
+
+    const {configs, globalConfig} = getConfig(path.join(DIR));
+
+    expect(configs).toHaveLength(1);
+    expect(configs[0].displayName?.name).toBe('ts-async-function-config');
+    expect(globalConfig.verbose).toBe(true);
+  });
+
+  test('throws if type errors are encountered', () => {
+    writeFiles(DIR, {
+      '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
+      'jest.config.ts': `
+        import type {JestConfig} from 'jest';
+        const config: JestConfig = {testTimeout: '10000'};
+        export default config;
+        `,
+      'package.json': '{}',
+    });
+
+    const {stderr, exitCode} = runJest(DIR);
+
+    expect(stderr).toMatch(
+      "jest.config.ts(2,29): error TS2322: Type 'string' is not assignable to type 'number'.",
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  test('throws if syntax errors are encountered', () => {
+    writeFiles(DIR, {
+      '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
+      'jest.config.ts': `
+        import type {JestConfig} from 'jest';
+        const config: JestConfig = {verbose: true};
+        export default get config;
+        `,
+      'package.json': '{}',
+    });
+
+    const {stderr, exitCode} = runJest(DIR);
+
+    expect(stderr).toMatch(
+      "jest.config.ts(3,16): error TS2304: Cannot find name 'get'.",
+    );
+    expect(exitCode).toBe(1);
+  });
+
+  // The versions where vm.Module exists and commonjs with "exports" is not broken
+  onNodeVersions('>=12.16.0', () => {
+    test('works with object config exported from TS file when package.json#type=module', () => {
+      writeFiles(DIR, {
+        '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
+        'jest.config.ts': `
+          import type {JestConfig} from 'jest';
+          const config: JestConfig = {displayName: 'ts-esm-object-config', verbose: true};
+          export default config;
+          `,
+        'package.json': '{"type": "module"}',
+      });
+
+      const {configs, globalConfig} = getConfig(path.join(DIR));
+
+      expect(configs).toHaveLength(1);
+      expect(configs[0].displayName?.name).toBe('ts-esm-object-config');
+      expect(globalConfig.verbose).toBe(true);
+    });
+
+    test('works with function config exported from TS file when package.json#type=module', () => {
+      writeFiles(DIR, {
+        '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
+        'jest.config.ts': `
+          import type {JestConfig} from 'jest';
+          async function getVerbose() {return true;}
+          export default async (): Promise<JestConfig> => {
+            const verbose: JestConfig['verbose'] = await getVerbose();
+            return {displayName: 'ts-esm-async-function-config', verbose};
+          };
+          `,
+        'package.json': '{"type": "module"}',
+      });
+
+      const {configs, globalConfig} = getConfig(path.join(DIR));
+
+      expect(configs).toHaveLength(1);
+      expect(configs[0].displayName?.name).toBe('ts-esm-async-function-config');
+      expect(globalConfig.verbose).toBe(true);
+    });
+
+    test('throws if type errors are encountered when package.json#type=module', () => {
+      writeFiles(DIR, {
+        '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
+        'jest.config.ts': `
+          import type {JestConfig} from 'jest';
+          const config: JestConfig = {testTimeout: '10000'};
+          export default config;
+          `,
+        'package.json': '{"type": "module"}',
+      });
+
+      const {stderr, exitCode} = runJest(DIR);
+
+      expect(stderr).toMatch(
+        "jest.config.ts(2,29): error TS2322: Type 'string' is not assignable to type 'number'.",
+      );
+      expect(exitCode).toBe(1);
+    });
+
+    test('throws if syntax errors are encountered when package.json#type=module', () => {
+      writeFiles(DIR, {
+        '__tests__/dummy.test.js':
+          "test('dummy', () => expect(123).toBe(123));",
+        'jest.config.ts': `
+          import type {JestConfig} from 'jest';
+          const config: JestConfig = {verbose: true};
+          export default get config;
+          `,
+        'package.json': '{}',
+      });
+
+      const {stderr, exitCode} = runJest(DIR);
+
+      expect(stderr).toMatch(
+        "jest.config.ts(3,16): error TS2304: Cannot find name 'get'.",
+      );
+      expect(exitCode).toBe(1);
+    });
+  });
+});

--- a/e2e/__tests__/tsIntegration.test.ts
+++ b/e2e/__tests__/tsIntegration.test.ts
@@ -175,13 +175,13 @@ describe('when `Config` type is imported from "@jest/types"', () => {
   });
 });
 
-describe('when `JestConfig` type is imported from "jest"', () => {
+describe('when `Config` type is imported from "jest"', () => {
   test('with object config exported from TS file', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
-        import type {JestConfig} from 'jest';
-        const config: JestConfig = {displayName: 'ts-object-config', verbose: true};
+        import type {Config} from 'jest';
+        const config: Config = {displayName: 'ts-object-config', verbose: true};
         export default config;
         `,
       'package.json': '{}',
@@ -198,10 +198,10 @@ describe('when `JestConfig` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
-        import type {JestConfig} from 'jest';
+        import type {Config} from 'jest';
         async function getVerbose() {return true;}
-        export default async (): Promise<JestConfig> => {
-          const verbose: JestConfig['verbose'] = await getVerbose();
+        export default async (): Promise<Config> => {
+          const verbose: Config['verbose'] = await getVerbose();
           return {displayName: 'ts-async-function-config', verbose};
         };
         `,
@@ -219,8 +219,8 @@ describe('when `JestConfig` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
-        import type {JestConfig} from 'jest';
-        const config: JestConfig = {testTimeout: '10000'};
+        import type {Config} from 'jest';
+        const config: Config = {testTimeout: '10000'};
         export default config;
         `,
       'package.json': '{}',
@@ -229,7 +229,7 @@ describe('when `JestConfig` type is imported from "jest"', () => {
     const {stderr, exitCode} = runJest(DIR);
 
     expect(stderr).toMatch(
-      "jest.config.ts(2,29): error TS2322: Type 'string' is not assignable to type 'number'.",
+      "jest.config.ts(2,25): error TS2322: Type 'string' is not assignable to type 'number'.",
     );
     expect(exitCode).toBe(1);
   });
@@ -238,8 +238,8 @@ describe('when `JestConfig` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
-        import type {JestConfig} from 'jest';
-        const config: JestConfig = {verbose: true};
+        import type {Config} from 'jest';
+        const config: Config = {verbose: true};
         export default get config;
         `,
       'package.json': '{}',
@@ -259,8 +259,8 @@ describe('when `JestConfig` type is imported from "jest"', () => {
       writeFiles(DIR, {
         '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
         'jest.config.ts': `
-          import type {JestConfig} from 'jest';
-          const config: JestConfig = {displayName: 'ts-esm-object-config', verbose: true};
+          import type {Config} from 'jest';
+          const config: Config = {displayName: 'ts-esm-object-config', verbose: true};
           export default config;
           `,
         'package.json': '{"type": "module"}',
@@ -277,10 +277,10 @@ describe('when `JestConfig` type is imported from "jest"', () => {
       writeFiles(DIR, {
         '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
         'jest.config.ts': `
-          import type {JestConfig} from 'jest';
+          import type {Config} from 'jest';
           async function getVerbose() {return true;}
-          export default async (): Promise<JestConfig> => {
-            const verbose: JestConfig['verbose'] = await getVerbose();
+          export default async (): Promise<Config> => {
+            const verbose: Config['verbose'] = await getVerbose();
             return {displayName: 'ts-esm-async-function-config', verbose};
           };
           `,
@@ -298,8 +298,8 @@ describe('when `JestConfig` type is imported from "jest"', () => {
       writeFiles(DIR, {
         '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
         'jest.config.ts': `
-          import type {JestConfig} from 'jest';
-          const config: JestConfig = {testTimeout: '10000'};
+          import type {Config} from 'jest';
+          const config: Config = {testTimeout: '10000'};
           export default config;
           `,
         'package.json': '{"type": "module"}',
@@ -308,7 +308,7 @@ describe('when `JestConfig` type is imported from "jest"', () => {
       const {stderr, exitCode} = runJest(DIR);
 
       expect(stderr).toMatch(
-        "jest.config.ts(2,29): error TS2322: Type 'string' is not assignable to type 'number'.",
+        "jest.config.ts(2,25): error TS2322: Type 'string' is not assignable to type 'number'.",
       );
       expect(exitCode).toBe(1);
     });
@@ -318,8 +318,8 @@ describe('when `JestConfig` type is imported from "jest"', () => {
         '__tests__/dummy.test.js':
           "test('dummy', () => expect(123).toBe(123));",
         'jest.config.ts': `
-          import type {JestConfig} from 'jest';
-          const config: JestConfig = {verbose: true};
+          import type {Config} from 'jest';
+          const config: Config = {verbose: true};
           export default get config;
           `,
         'package.json': '{}',

--- a/jest.config.ci.mjs
+++ b/jest.config.ci.mjs
@@ -7,7 +7,7 @@
 
 import jestConfigBase from './jest.config.mjs';
 
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 export default {
   ...jestConfigBase,
   coverageReporters: ['json'],

--- a/jest.config.ci.mjs
+++ b/jest.config.ci.mjs
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import jestConfigBase from './jest.config.mjs';
+import baseConfig from './jest.config.mjs';
 
 /** @type {import('jest').Config} */
 export default {
-  ...jestConfigBase,
+  ...baseConfig,
   coverageReporters: ['json'],
   reporters: [
     'github-actions',

--- a/jest.config.ci.mjs
+++ b/jest.config.ci.mjs
@@ -7,6 +7,7 @@
 
 import jestConfigBase from './jest.config.mjs';
 
+/** @type {import('jest').JestConfig} */
 export default {
   ...jestConfigBase,
   coverageReporters: ['json'],

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -8,7 +8,7 @@
 import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
 
-/** @type import('@jest/types').Config.InitialOptions */
+/** @type {import('jest').JestConfig} */
 export default {
   collectCoverageFrom: [
     '**/packages/*/**/*.js',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -8,7 +8,7 @@
 import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
 
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 export default {
   collectCoverageFrom: [
     '**/packages/*/**/*.js',

--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import jestConfigBase from './jest.config.mjs';
+import baseConfig from './jest.config.mjs';
 
 /** @type {import('jest').Config} */
 export default {
@@ -15,7 +15,7 @@ export default {
         color: 'blue',
         name: 'ts-integration',
       },
-      modulePathIgnorePatterns: jestConfigBase.modulePathIgnorePatterns,
+      modulePathIgnorePatterns: baseConfig.modulePathIgnorePatterns,
       roots: ['<rootDir>/e2e/__tests__'],
       testMatch: ['<rootDir>/e2e/__tests__/ts*'],
     },
@@ -24,7 +24,7 @@ export default {
         color: 'blue',
         name: 'type-tests',
       },
-      modulePathIgnorePatterns: jestConfigBase.modulePathIgnorePatterns,
+      modulePathIgnorePatterns: baseConfig.modulePathIgnorePatterns,
       roots: ['<rootDir>/packages'],
       runner: 'jest-runner-tsd',
       testMatch: ['**/__typetests__/**/*.ts'],

--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -7,7 +7,7 @@
 
 import jestConfigBase from './jest.config.mjs';
 
-/** @type {import('jest').JestConfig} */
+/** @type {import('jest').Config} */
 export default {
   projects: [
     {

--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -7,6 +7,7 @@
 
 import jestConfigBase from './jest.config.mjs';
 
+/** @type {import('jest').JestConfig} */
 export default {
   projects: [
     {

--- a/packages/jest/__typetests__/jest.test.ts
+++ b/packages/jest/__typetests__/jest.test.ts
@@ -6,9 +6,9 @@
  */
 
 import {expectType} from 'tsd-lite';
-import type {Config} from '@jest/types';
-import type {JestConfig} from 'jest';
+import type {Config as ConfigTypes} from '@jest/types';
+import type {Config} from 'jest';
 
-declare const config: JestConfig;
+declare const config: Config;
 
-expectType<Config.InitialOptions>(config);
+expectType<ConfigTypes.InitialOptions>(config);

--- a/packages/jest/__typetests__/jest.test.ts
+++ b/packages/jest/__typetests__/jest.test.ts
@@ -5,15 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {expectType} from 'tsd-lite';
 import type {Config} from '@jest/types';
+import type {JestConfig} from 'jest';
 
-export {
-  SearchSource,
-  createTestScheduler,
-  getVersion,
-  runCLI,
-} from '@jest/core';
+declare const config: JestConfig;
 
-export {run} from 'jest-cli';
-
-export type JestConfig = Config.InitialOptions;
+expectType<Config.InitialOptions>(config);

--- a/packages/jest/__typetests__/tsconfig.json
+++ b/packages/jest/__typetests__/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+
+    "types": []
+  },
+  "include": ["./**/*"]
+}

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -14,8 +14,13 @@
   },
   "dependencies": {
     "@jest/core": "^28.1.0",
+    "@jest/types": "^28.1.0",
     "import-local": "^3.0.2",
     "jest-cli": "^28.1.0"
+  },
+  "devDependencies": {
+    "@tsd/typescript": "~4.6.2",
+    "tsd-lite": "^0.5.1"
   },
   "peerDependencies": {
     "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -16,4 +16,4 @@ export {
 
 export {run} from 'jest-cli';
 
-export type JestConfig = Config.InitialOptions;
+export type Config = Config.InitialOptions;

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Config} from '@jest/types';
+import type {Config as ConfigTypes} from '@jest/types';
 
 export {
   SearchSource,
@@ -16,4 +16,4 @@ export {
 
 export {run} from 'jest-cli';
 
-export type Config = Config.InitialOptions;
+export type Config = ConfigTypes.InitialOptions;

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -5,5 +5,9 @@
     "outDir": "build"
   },
   "include": ["./src/**/*"],
-  "references": [{"path": "../jest-cli"}, {"path": "../jest-core"}]
+  "references": [
+    {"path": "../jest-cli"},
+    {"path": "../jest-core"},
+    {"path": "../jest-types"}
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13777,8 +13777,11 @@ __metadata:
   resolution: "jest@workspace:packages/jest"
   dependencies:
     "@jest/core": ^28.1.0
+    "@jest/types": ^28.1.0
+    "@tsd/typescript": ~4.6.2
     import-local: ^3.0.2
     jest-cli: ^28.1.0
+    tsd-lite: ^0.5.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:


### PR DESCRIPTION
Closes #12037
Closes #12801

## Summary

This second attempt to unify the style of configuration examples. Previously (in #12037) I was trying to refactor all config to JSON. That looked alright, but something was missing. This PR is based https://github.com/facebook/jest/pull/12817#discussion_r868080588 in which the user suggesting that the examples could be functioning copy-paste code.

Interesting. Made me think in that direction. In that PR only CJS syntax was covered, but it is possible to have JS, TS tabs. For instance, Playwright’s [config examples](https://playwright.dev/docs/test-configuration) are written in this way.

`JestConfig` type is borrowed from my other PR. This is simply a reexport of `Config.InitialOptions`. Just thinking out loud, I am fine to use either.

The motivation to add `JestConfig`:

- `Config.InitialOptions` is verbose and feels like an internal type.
- also exposing `JestConfig` from `jest` does not require to install additional package to pass stricter audit.

No feelings hurt is something looks unacceptable. In my projects Jest configs are mostly written in JSON, to be honest ;D

## Test plan

Tests are added. Lint should pass.