### PR TITLE
fix(docs): fix typo in packageFilter code example

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1000,7 +1000,7 @@ By combining `defaultResolver` and `packageFilter` we can implement a `package.j
 ```js
 module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
-  return options.defaultResolver(request, {
+  return options.defaultResolver(path, {
     ...options,
     // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
     packageFilter: pkg => {

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -1000,7 +1000,7 @@ By combining `defaultResolver` and `packageFilter` we can implement a `package.j
 ```js
 module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
-  return options.defaultResolver(request, {
+  return options.defaultResolver(path, {
     ...options,
     // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
     packageFilter: pkg => {

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -1000,7 +1000,7 @@ By combining `defaultResolver` and `packageFilter` we can implement a `package.j
 ```js
 module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
-  return options.defaultResolver(request, {
+  return options.defaultResolver(path, {
     ...options,
     // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
     packageFilter: pkg => {


### PR DESCRIPTION
## Summary

The current code example of `packageFilter` usage is broken and catching the typo isn't trivial without TS.

## Test plan

No tests needed.