### PR TITLE
fix(jest-circus): reverse order of afterEach, afterAll hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
 - `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
+- `[jest-circus]` Run `afterAll` and `afterEach` hooks in the correct order ([#12861](https://github.com/facebook/jest/pull/12861))
 
 ### Chore & Maintenance
 

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`afterEach & afterAll run in reverse order 1`] = `
+"add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+start_describe_definition: Scoped / Nested block
+add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+finish_describe_definition: Scoped / Nested block
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+hook_start: beforeAll
+1 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+1 - test
+test_fn_success: 
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+run_describe_start: Scoped / Nested block
+hook_start: beforeAll
+2 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+hook_start: beforeEach
+2 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+2 - test
+test_fn_success: 
+hook_start: afterEach
+2 - afterEach
+hook_success: afterEach
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+hook_start: afterAll
+2 - afterAll
+hook_success: afterAll
+run_describe_finish: Scoped / Nested block
+hook_start: afterAll
+1 - afterAll
+hook_success: afterAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0"
+`;
+
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1
 add_hook: beforeAll

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -71,3 +71,22 @@ test('beforeAll is exectued correctly', () => {
 
   expect(stdout).toMatchSnapshot();
 });
+
+test('afterEach & afterAll run in reverse order', () => {
+  const {stdout} = runTest(`
+      beforeAll(() => console.log('1 - beforeAll'));
+      afterAll(() => console.log('1 - afterAll'));
+      beforeEach(() => console.log('1 - beforeEach'));
+      afterEach(() => console.log('1 - afterEach'));
+      test('', () => console.log('1 - test'));
+      describe('Scoped / Nested block', () => {
+        beforeAll(() => console.log('2 - beforeAll'));
+        afterAll(() => console.log('2 - afterAll'));
+        beforeEach(() => console.log('2 - beforeEach'));
+        afterEach(() => console.log('2 - afterEach'));
+        test('', () => console.log('2 - test'));
+      });
+    `);
+
+  expect(stdout).toMatchSnapshot();
+});


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

fixes https://github.com/facebook/jest/issues/12678

Currently, jest-circus runs `afterAll` and `afterEach` hooks in *declaration order*. However, both [the docs](https://jestjs.io/docs/setup-teardown#scoping) and jasmine2 show afterAll and afterEach hooks running in *reverse declaration order*. This makes intuitive sense when using `beforeEach` to set up resources, and `afterEach` to dispose of resources:

```typescript
let resource1: Resource
let resource2: Resource
beforeEach(() => { resource1 = new BaseResource() })
afterEach(() => { resource1.dispose() })

beforeEach(() => { resource2 = new ResourceConsumer(resource1) })
afterEach(() => { resource2.dispose() }) // May use resource1 after resource1 is disposed
```

This PR reverses the order of `afterAll` and `afterEach` hooks before they are executed.

## Test plan

I added a snapshot test to jest-circus that emits output in the order shown in the documentation: https://jestjs.io/docs/setup-teardown#scoping