### PR TITLE
Example : Added esmoudle in partial mock example

### DIFF
--- a/examples/module-mock/__tests__/partial_mock.js
+++ b/examples/module-mock/__tests__/partial_mock.js
@@ -9,11 +9,10 @@ import defaultExport, {apple, strawberry} from '../fruit';
 
 jest.mock('../fruit', () => {
   const originalModule = jest.requireActual('../fruit');
-  const mockedModule = jest.createMockFromModule('../fruit');
 
   //Mock the default export and named export 'apple'.
   return {
-    ...mockedModule,
+    _esModule: true,
     ...originalModule,
     apple: 'mocked apple',
     default: jest.fn(() => 'mocked fruit'),


### PR DESCRIPTION
Currently in the Example, we have used `createMockfromModule` which further  serves the only purpose of adding _esModule: true to the object.

I feel we can make this more clear by replacing the jest.createMockFromModule with __esModule: true.