### PR TITLE
Replace "Facebook, Inc." with new name "Meta Platforms, Inc."

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ * Copyright (c) Meta Platforms, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
@@ -284,7 +284,7 @@ module.exports = {
         src: 'img/oss_logo.png',
         href: 'https://opensource.facebook.com',
       },
-      copyright: `Copyright © ${new Date().getFullYear()} Facebook, Inc. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Meta Platforms, Inc. Built with Docusaurus.`,
     },
     algolia: {
       indexName: 'jest-v2',


### PR DESCRIPTION
## Summary
This pull request is opened, to make use of new name "Meta Platforms, Inc.", over the previous name in Jest's website.

## Test plan

Test plan might not be necessary for this tiny text change.
