### PR TITLE
chore: update `vscode` config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,9 @@
 {
   "editor.rulers": [80],
-  "files.exclude": {
-    "**/.git": true
-  },
-  "javascript.validate.enable": false,
-  "jest.pathToJest": "yarn jest --",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
+  "javascript.validate.enable": false,
+  "jest.jestCommandLine": "yarn jest",
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Summary

The `vscode-jest` [docs](https://github.com/jest-community/vscode-jest#settings) note that `pathToJest` option is deprecated in favour of `jestCommandLine`. I changed this, but somehow it did not work. Had to remove `--` from the command. (The dashes do not work with `pathToJest` as well.)

I tried out `vscode-jest` for the first today. Pure curiosity. It does great job! Not sure why config was broken.

## Test plan

Tested locally. It works as expected.