### PR TITLE
feat(@jest/types): infer argument types passed to `test` and `describe` functions from `each` tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest]` Expose `Config` type ([#12848](https://github.com/facebook/jest/pull/12848))
 - `[@jest/reporters]` Improve `GitHubActionsReporter`s annotation format ([#12826](https://github.com/facebook/jest/pull/12826))
+- `[@jest/types]` Infer argument types passed to `test` and `describe` callback functions from `each` tables ([#12885](https://github.com/facebook/jest/pull/12885))
 
 ### Fixes
 

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -1,0 +1,667 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {expectError, expectType} from 'tsd-lite';
+import {describe, test} from '@jest/globals';
+
+const list = [1, 2, 3];
+const tupleList: [number, number, string] = [1, 2, 'three'];
+const table = [
+  [1, 2, 'three'],
+  [3, 4, 'seven'],
+];
+const tupleTable: Array<[number, number, string, boolean?]> = [
+  [1, 2, 'three', true],
+  [3, 4, 'seven', false],
+  [5, 6, 'eleven'],
+];
+const objectTable = [
+  {a: 1, b: 2, expected: 'three', extra: true},
+  {a: 3, b: 4, expected: 'seven', extra: false},
+  {a: 5, b: 6, expected: 'eleven'},
+];
+
+// test.each
+
+expectType<void>(
+  test.each(list)('some test', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  test.each(list)(
+    'some test',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each(tupleList)('some test', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  test.each(tupleList)(
+    'some test',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each([3, 4, 'seven'])('some test', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  test.each([3, 4, 'seven'])(
+    'some test',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each(table)('some test', (a, b, expected) => {
+    expectType<string | number>(a);
+    expectType<string | number>(b);
+    expectType<string | number>(expected);
+  }),
+);
+expectType<void>(
+  test.each(table)(
+    'some test',
+    (a, b, expected) => {
+      expectType<string | number>(a);
+      expectType<string | number>(b);
+      expectType<string | number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each(tupleTable)('some test', (a, b, expected, extra) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+    expectType<boolean | undefined>(extra);
+  }),
+);
+expectType<void>(
+  test.each(tupleTable)(
+    'some test',
+    (a, b, expected, extra) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each([
+    [1, 2, 'three'],
+    [3, 4, 'seven'],
+  ])('some test', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  test.each([
+    [1, 2, 'three'],
+    [3, 4, 'seven'],
+  ])(
+    'some test',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each(objectTable)('some test', ({a, b, expected, extra}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+    expectType<boolean | undefined>(extra);
+  }),
+);
+expectType<void>(
+  test.each([
+    {a: 1, b: 2, expected: 'three', extra: true},
+    {a: 3, b: 4, expected: 'seven', extra: false},
+    {a: 5, b: 6, expected: 'eleven'},
+  ])(
+    'some test',
+    ({a, b, expected, extra}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('some test', ({a, b, expected}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  test.each`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `('some test', ({item, expected}) => {
+    expectType<unknown>(item);
+    expectType<unknown>(expected);
+  }),
+);
+expectType<void>(
+  test.each<{item: string; expected: boolean}>`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `('some test', ({item, expected}) => {
+    expectType<string>(item);
+    expectType<boolean>(expected);
+  }),
+);
+expectType<void>(
+  test.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `(
+    'some test',
+    ({a, b, expected}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+expectType<void>(
+  test.each`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `(
+    'some test',
+    ({item, expected}) => {
+      expectType<unknown>(item);
+      expectType<unknown>(expected);
+    },
+    1000,
+  ),
+);
+expectType<void>(
+  test.each<{item: string; expected: boolean}>`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `(
+    'some test',
+    ({item, expected}) => {
+      expectType<string>(item);
+      expectType<boolean>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(test.each());
+expectError(test.each('abc'));
+expectError(test.each(() => {}));
+
+expectType<typeof test.each>(test.only.each);
+expectType<typeof test.each>(test.skip.each);
+
+// test.concurrent.each
+
+expectType<void>(
+  test.concurrent.each(list)('some test', async (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each(list)(
+    'some test',
+    async (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.concurrent.each(tupleList)('some test', async (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each(tupleList)(
+    'some test',
+    async (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.concurrent.each([3, 4, 'seven'])('some test', async (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each([3, 4, 'seven'])(
+    'some test',
+    async (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.concurrent.each(table)('some test', async (a, b, expected) => {
+    expectType<string | number>(a);
+    expectType<string | number>(b);
+    expectType<string | number>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each(table)(
+    'some test',
+    async (a, b, expected) => {
+      expectType<string | number>(a);
+      expectType<string | number>(b);
+      expectType<string | number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.concurrent.each(tupleTable)(
+    'some test',
+    async (a, b, expected, extra) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+  ),
+);
+expectType<void>(
+  test.concurrent.each(tupleTable)(
+    'some test',
+    async (a, b, expected, extra) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.concurrent.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('some test', async ({a, b, expected}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `('some test', async ({item, expected}) => {
+    expectType<unknown>(item);
+    expectType<unknown>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each<{item: string; expected: boolean}>`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `('some test', async ({item, expected}) => {
+    expectType<string>(item);
+    expectType<boolean>(expected);
+  }),
+);
+expectType<void>(
+  test.concurrent.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `(
+    'some test',
+    async ({a, b, expected}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  test.each`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `(
+    'some test',
+    ({item, expected}) => {
+      expectType<unknown>(item);
+      expectType<unknown>(expected);
+    },
+    1000,
+  ),
+);
+expectType<void>(
+  test.each<{item: string; expected: boolean}>`
+    item   | expected
+    ${'a'} | ${true}
+    ${'b'} | ${false}
+  `(
+    'some test',
+    ({item, expected}) => {
+      expectType<string>(item);
+      expectType<boolean>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(test.concurrent.each());
+expectError(test.concurrent.each('abc'));
+expectError(test.concurrent.each(() => {}));
+
+expectType<typeof test.concurrent.each>(test.concurrent.only.each);
+expectType<typeof test.concurrent.each>(test.concurrent.skip.each);
+
+// describe.each
+
+expectType<void>(
+  describe.each(list)('describe each', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  describe.each(list)(
+    'describe each',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each(tupleList)('describe each', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  describe.each(tupleList)(
+    'describe each',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each([3, 4, 'seven'])('describe each', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  describe.each([3, 4, 'seven'])(
+    'describe each',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each(table)('describe each', (a, b, expected) => {
+    expectType<string | number>(a);
+    expectType<string | number>(b);
+    expectType<string | number>(expected);
+  }),
+);
+expectType<void>(
+  describe.each(table)(
+    'describe each',
+    (a, b, expected) => {
+      expectType<string | number>(a);
+      expectType<string | number>(b);
+      expectType<string | number>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each(tupleTable)('describe each', (a, b, expected, extra) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+    expectType<boolean | undefined>(extra);
+  }),
+);
+expectType<void>(
+  describe.each(tupleTable)(
+    'describe each',
+    (a, b, expected, extra) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each([
+    [1, 2, 'three'],
+    [3, 4, 'seven'],
+  ])('describe each', (a, b, expected) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  describe.each([
+    [1, 2, 'three'],
+    [3, 4, 'seven'],
+  ])(
+    'describe each',
+    (a, b, expected) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each(objectTable)('describe each', ({a, b, expected, extra}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+    expectType<boolean | undefined>(extra);
+  }),
+);
+expectType<void>(
+  describe.each([
+    {a: 1, b: 2, expected: 'three', extra: true},
+    {a: 3, b: 4, expected: 'seven', extra: false},
+    {a: 5, b: 6, expected: 'eleven'},
+  ])(
+    'describe each',
+    ({a, b, expected, extra}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+      expectType<boolean | undefined>(extra);
+    },
+    1000,
+  ),
+);
+
+expectType<void>(
+  describe.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('describe each', ({a, b, expected}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<number>(expected);
+  }),
+);
+expectType<void>(
+  describe.each<{
+    a: number;
+    b: number;
+    expected: string;
+  }>`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `('describe each', ({a, b, expected}) => {
+    expectType<number>(a);
+    expectType<number>(b);
+    expectType<string>(expected);
+  }),
+);
+expectType<void>(
+  describe.each`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `(
+    'describe each',
+    ({a, b, expected}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<number>(expected);
+    },
+    1000,
+  ),
+);
+expectType<void>(
+  describe.each<{
+    a: number;
+    b: number;
+    expected: string;
+  }>`
+    a    | b    | expected
+    ${1} | ${1} | ${2}
+    ${1} | ${2} | ${3}
+    ${2} | ${1} | ${3}
+  `(
+    'describe each',
+    ({a, b, expected}) => {
+      expectType<number>(a);
+      expectType<number>(b);
+      expectType<string>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(describe.each());
+expectError(describe.each('abc'));
+expectError(describe.each(() => {}));
+
+expectType<typeof describe.each>(describe.only.each);
+expectType<typeof describe.each>(describe.skip.each);

--- a/packages/jest-types/__typetests__/globals.test.ts
+++ b/packages/jest-types/__typetests__/globals.test.ts
@@ -17,55 +17,198 @@ import {
 import type {Global} from '@jest/types';
 
 const fn = () => {};
-const doneFn: Global.DoneTakingTestFn = done => {
-  done();
-};
 const asyncFn = async () => {};
 const genFn = function* () {};
-const timeout = 5;
-const testName = 'Test name';
 
-const list = [1, 2, 3];
 const table = [
-  [1, 2],
-  [3, 4],
+  [1, 2, 3],
+  [4, 5, 6],
 ];
-const readonlyTable = [[1, 2], 'one'] as const;
 
-// https://jestjs.io/docs/api#methods
-expectType<void>(afterAll(fn));
-expectType<void>(afterAll(asyncFn));
-expectType<void>(afterAll(genFn));
-expectType<void>(afterAll(fn, timeout));
-expectType<void>(afterAll(asyncFn, timeout));
-expectType<void>(afterAll(genFn, timeout));
-expectType<void>(afterEach(fn));
-expectType<void>(afterEach(asyncFn));
-expectType<void>(afterEach(genFn));
-expectType<void>(afterEach(fn, timeout));
-expectType<void>(afterEach(asyncFn, timeout));
-expectType<void>(afterEach(genFn, timeout));
+const testName = 'Test name';
+const timeout = 5;
+
+// done
+
+test(testName, done => {
+  done();
+});
+
+test(testName, done => {
+  done('error message');
+});
+
+test(testName, done => {
+  done(new Error('message'));
+});
+
+test(testName, done => {
+  expectType<Global.DoneFn>(done);
+});
+
+test(testName, done => {
+  expectError(done(123));
+});
+
+// beforeAll
+
 expectType<void>(beforeAll(fn));
 expectType<void>(beforeAll(asyncFn));
 expectType<void>(beforeAll(genFn));
+expectType<void>(
+  beforeAll(done => {
+    expectType<Global.DoneFn>(done);
+  }),
+);
+
 expectType<void>(beforeAll(fn, timeout));
 expectType<void>(beforeAll(asyncFn, timeout));
 expectType<void>(beforeAll(genFn, timeout));
+expectType<void>(
+  beforeAll(done => {
+    expectType<Global.DoneFn>(done);
+  }, timeout),
+);
+
+expectError(beforeAll());
+expectError(beforeAll('abc'));
+
+expectError(
+  beforeAll(async done => {
+    done();
+  }),
+);
+expectError(
+  beforeAll(function* (done) {
+    done();
+  }),
+);
+
+// beforeEach
+
 expectType<void>(beforeEach(fn));
 expectType<void>(beforeEach(asyncFn));
 expectType<void>(beforeEach(genFn));
+expectType<void>(
+  beforeEach(done => {
+    expectType<Global.DoneFn>(done);
+  }),
+);
+
 expectType<void>(beforeEach(fn, timeout));
 expectType<void>(beforeEach(asyncFn, timeout));
 expectType<void>(beforeEach(genFn, timeout));
+expectType<void>(
+  beforeEach(done => {
+    expectType<Global.DoneFn>(done);
+  }, timeout),
+);
+
+expectError(beforeEach());
+expectError(beforeEach('abc'));
+
+expectError(
+  beforeEach(async done => {
+    done();
+  }),
+);
+expectError(
+  beforeEach(function* (done) {
+    done();
+  }),
+);
+
+// afterAll
+
+expectType<void>(afterAll(fn));
+expectType<void>(afterAll(asyncFn));
+expectType<void>(afterAll(genFn));
+expectType<void>(
+  afterAll(done => {
+    expectType<Global.DoneFn>(done);
+  }),
+);
+
+expectType<void>(afterAll(fn, timeout));
+expectType<void>(afterAll(asyncFn, timeout));
+expectType<void>(afterAll(genFn, timeout));
+expectType<void>(
+  afterAll(done => {
+    expectType<Global.DoneFn>(done);
+  }, timeout),
+);
+
+expectError(afterAll());
+expectError(afterAll('abc'));
+
+expectError(
+  afterAll(async done => {
+    done();
+  }),
+);
+expectError(
+  afterAll(function* (done) {
+    done();
+  }),
+);
+
+// afterEach
+
+expectType<void>(afterEach(fn));
+expectType<void>(afterEach(asyncFn));
+expectType<void>(afterEach(genFn));
+expectType<void>(
+  afterEach(done => {
+    expectType<Global.DoneFn>(done);
+  }),
+);
+
+expectType<void>(afterEach(fn, timeout));
+expectType<void>(afterEach(asyncFn, timeout));
+expectType<void>(afterEach(genFn, timeout));
+expectType<void>(
+  afterEach(done => {
+    expectType<Global.DoneFn>(done);
+  }, timeout),
+);
+
+expectError(afterEach());
+expectError(afterEach('abc'));
+
+expectError(
+  afterEach(async done => {
+    done();
+  }),
+);
+expectError(
+  afterEach(function* (done) {
+    done();
+  }),
+);
+
+// test
 
 expectType<void>(test(testName, fn));
 expectType<void>(test(testName, asyncFn));
-expectType<void>(test(testName, doneFn));
 expectType<void>(test(testName, genFn));
+expectType<void>(
+  test(testName, done => {
+    expectType<Global.DoneFn>(done);
+  }),
+);
+
 expectType<void>(test(testName, fn, timeout));
 expectType<void>(test(testName, asyncFn, timeout));
-expectType<void>(test(testName, doneFn, timeout));
 expectType<void>(test(testName, genFn, timeout));
+expectType<void>(
+  test(
+    testName,
+    done => {
+      expectType<Global.DoneFn>(done);
+    },
+    timeout,
+  ),
+);
 
 expectType<void>(test(123, fn));
 expectType<void>(test(() => {}, fn));
@@ -73,14 +216,11 @@ expectType<void>(test(function named() {}, fn));
 expectType<void>(test(class {}, fn));
 expectType<void>(test(class Named {}, fn));
 
-// wrong arguments
+expectError(test());
 expectError(test(testName));
 expectError(test(testName, timeout));
-
-// wrong return value
 expectError(test(testName, () => 42));
 
-// mixing done callback and promise/generator
 expectError(
   test(testName, async done => {
     done();
@@ -92,66 +232,36 @@ expectError(
   }),
 );
 
-expectType<void>(test(testName, fn));
-expectType<void>(test(testName, asyncFn));
-expectType<void>(test(testName, genFn));
+// test.concurrent
 
-expectType<void>(test.each(list)(testName, fn));
-expectType<void>(test.each(list)(testName, fn, timeout));
-expectType<void>(test.each(table)(testName, fn));
-expectType<void>(test.each(table)(testName, fn, timeout));
-expectType<void>(test.each(readonlyTable)(testName, fn));
-expectType<void>(test.each(readonlyTable)(testName, fn, timeout));
+expectType<void>(test.concurrent(testName, asyncFn));
+expectType<void>(test.concurrent(testName, asyncFn, timeout));
 
-expectType<void>(test.each(list)(123, fn));
-expectType<void>(test.each(list)(() => {}, fn));
-expectType<void>(test.each(list)(function named() {}, fn));
-expectType<void>(test.each(list)(class {}, fn));
-expectType<void>(test.each(list)(class Named {}, fn));
+expectType<void>(test.concurrent(123, asyncFn));
+expectType<void>(test.concurrent(() => {}, asyncFn));
+expectType<void>(test.concurrent(function named() {}, asyncFn));
+expectType<void>(test.concurrent(class {}, asyncFn));
+expectType<void>(test.concurrent(class Named {}, asyncFn));
 
-expectType<void>(test.only.each(list)(testName, fn));
-expectType<void>(test.only.each(list)(testName, fn, timeout));
-expectType<void>(test.only.each(table)(testName, fn));
-expectType<void>(test.only.each(table)(testName, fn, timeout));
-expectType<void>(test.only.each(readonlyTable)(testName, fn));
-expectType<void>(test.only.each(readonlyTable)(testName, fn, timeout));
+expectError(test.concurrent(testName, fn));
 
-expectType<void>(test.skip.each(list)(testName, fn));
-expectType<void>(test.skip.each(list)(testName, fn, timeout));
-expectType<void>(test.skip.each(table)(testName, fn));
-expectType<void>(test.skip.each(table)(testName, fn, timeout));
-expectType<void>(test.skip.each(readonlyTable)(testName, fn));
-expectType<void>(test.skip.each(readonlyTable)(testName, fn, timeout));
+// test.concurrent.each
 
-expectType<void>(test.skip(123, fn));
-expectType<void>(test.skip(() => {}, fn));
-expectType<void>(test.skip(function named() {}, fn));
-expectType<void>(test.skip(class {}, fn));
-expectType<void>(test.skip(class Named {}, fn));
+expectType<void>(test.concurrent.each(table)(testName, asyncFn));
+expectType<void>(test.concurrent.each(table)(testName, asyncFn, timeout));
 
-expectType<void>(test.skip.each(list)(123, fn));
-expectType<void>(test.skip.each(list)(() => {}, fn));
-expectType<void>(test.skip.each(list)(function named() {}, fn));
-expectType<void>(test.skip.each(list)(class {}, fn));
-expectType<void>(test.skip.each(list)(class Named {}, fn));
+expectType<void>(test.concurrent.each(table)(123, asyncFn));
+expectType<void>(test.concurrent.each(table)(() => {}, asyncFn));
+expectType<void>(test.concurrent.each(table)(function named() {}, asyncFn));
+expectType<void>(test.concurrent.each(table)(class {}, asyncFn));
+expectType<void>(test.concurrent.each(table)(class Named {}, asyncFn));
 
-expectType<void>(test.failing(123, fn));
-expectType<void>(test.failing(() => {}, fn));
-expectType<void>(test.failing(function named() {}, fn));
-expectType<void>(test.failing(class {}, fn));
-expectType<void>(test.failing(class Named {}, fn));
+expectError(test.concurrent.each(table)(testName, fn));
 
-expectType<void>(test.skip.failing(123, fn));
-expectType<void>(test.skip.failing(() => {}, fn));
-expectType<void>(test.skip.failing(function named() {}, fn));
-expectType<void>(test.skip.failing(class {}, fn));
-expectType<void>(test.skip.failing(class Named {}, fn));
+// test.concurrent.failing
 
-expectType<void>(test.only.failing(123, fn));
-expectType<void>(test.only.failing(() => {}, fn));
-expectType<void>(test.only.failing(function named() {}, fn));
-expectType<void>(test.only.failing(class {}, fn));
-expectType<void>(test.only.failing(class Named {}, fn));
+expectType<void>(test.concurrent.failing(testName, asyncFn));
+expectType<void>(test.concurrent.failing(testName, asyncFn, timeout));
 
 expectType<void>(test.concurrent.failing(123, asyncFn));
 expectType<void>(test.concurrent.failing(() => {}, asyncFn));
@@ -159,252 +269,132 @@ expectType<void>(test.concurrent.failing(function named() {}, asyncFn));
 expectType<void>(test.concurrent.failing(class {}, asyncFn));
 expectType<void>(test.concurrent.failing(class Named {}, asyncFn));
 
-expectType<void>(test.concurrent.skip.failing(123, asyncFn));
-expectType<void>(test.concurrent.skip.failing(() => {}, asyncFn));
-expectType<void>(test.concurrent.skip.failing(function named() {}, asyncFn));
-expectType<void>(test.concurrent.skip.failing(class {}, asyncFn));
-expectType<void>(test.concurrent.skip.failing(class Named {}, asyncFn));
+expectError(test.concurrent.failing(testName, fn));
 
-expectType<void>(test.concurrent.only.failing(123, asyncFn));
-expectType<void>(test.concurrent.only.failing(() => {}, asyncFn));
-expectType<void>(test.concurrent.only.failing(function named() {}, asyncFn));
-expectType<void>(test.concurrent.only.failing(class {}, asyncFn));
-expectType<void>(test.concurrent.only.failing(class Named {}, asyncFn));
+// test.concurrent.only
 
-expectType<void>(
-  test.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<typeof test.concurrent.each>(test.concurrent.only.each);
+expectType<typeof test.concurrent.failing>(test.concurrent.only.failing);
 
-expectType<void>(
-  test.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+// test.concurrent.skip
 
-expectType<void>(
-  test.only.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<typeof test.concurrent.each>(test.concurrent.skip.each);
+expectType<typeof test.concurrent.failing>(test.concurrent.skip.failing);
 
-expectType<void>(
-  test.only.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+// test.each
 
-expectType<void>(
-  test.skip.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<void>(test.each(table)(testName, fn));
+expectType<void>(test.each(table)(testName, fn, timeout));
 
-expectType<void>(
-  test.skip.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+expectType<void>(test.each(table)(123, fn));
+expectType<void>(test.each(table)(() => {}, fn));
+expectType<void>(test.each(table)(function named() {}, fn));
+expectType<void>(test.each(table)(class {}, fn));
+expectType<void>(test.each(table)(class Named {}, fn));
 
-expectType<void>(test.concurrent(testName, asyncFn));
-expectType<void>(test.concurrent(testName, asyncFn, timeout));
+// test.failing
 
-expectType<void>(test.concurrent.each(list)(testName, asyncFn));
-expectType<void>(test.concurrent.each(list)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.each(table)(testName, asyncFn));
-expectType<void>(test.concurrent.each(table)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.each(readonlyTable)(testName, asyncFn));
-expectType<void>(
-  test.concurrent.each(readonlyTable)(testName, asyncFn, timeout),
-);
+expectType<void>(test.failing(testName, fn));
+expectType<void>(test.failing(testName, fn, timeout));
 
-expectType<void>(test.concurrent.only.each(list)(testName, asyncFn));
-expectType<void>(test.concurrent.only.each(list)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.only.each(table)(testName, asyncFn));
-expectType<void>(test.concurrent.only.each(table)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.only.each(readonlyTable)(testName, asyncFn));
-expectType<void>(
-  test.concurrent.only.each(readonlyTable)(testName, asyncFn, timeout),
-);
+expectType<void>(test.failing(123, fn));
+expectType<void>(test.failing(() => {}, fn));
+expectType<void>(test.failing(function named() {}, fn));
+expectType<void>(test.failing(class {}, fn));
+expectType<void>(test.failing(class Named {}, fn));
 
-expectType<void>(test.concurrent.skip.each(list)(testName, asyncFn));
-expectType<void>(test.concurrent.skip.each(list)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.skip.each(table)(testName, asyncFn));
-expectType<void>(test.concurrent.skip.each(table)(testName, asyncFn, timeout));
-expectType<void>(test.concurrent.skip.each(readonlyTable)(testName, asyncFn));
-expectType<void>(
-  test.concurrent.skip.each(readonlyTable)(testName, asyncFn, timeout),
-);
+// test.only
 
-expectType<void>(
-  test.concurrent.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn),
-);
+expectType<void>(test.only(testName, fn));
+expectType<void>(test.only(testName, fn, timeout));
 
-expectType<void>(
-  test.concurrent.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn, timeout),
-);
+expectType<void>(test.only(123, fn));
+expectType<void>(test.only(() => {}, fn));
+expectType<void>(test.only(function named() {}, fn));
+expectType<void>(test.only(class {}, fn));
+expectType<void>(test.only(class Named {}, fn));
 
-expectType<void>(
-  test.concurrent.only.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn),
-);
+expectType<typeof test.each>(test.only.each);
+expectType<typeof test.failing>(test.only.failing);
 
-expectType<void>(
-  test.concurrent.only.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn, timeout),
-);
+// test.skip
 
-expectType<void>(
-  test.concurrent.skip.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn),
-);
+expectType<void>(test.skip(testName, fn));
+expectType<void>(test.skip(testName, fn, timeout));
 
-expectType<void>(
-  test.concurrent.skip.each`
-  a    | b    | expected
-  ${1} | ${1} | ${2}
-  ${1} | ${2} | ${3}
-  ${2} | ${1} | ${3}
-`(testName, asyncFn, timeout),
-);
+expectType<void>(test.skip(123, fn));
+expectType<void>(test.skip(() => {}, fn));
+expectType<void>(test.skip(function named() {}, fn));
+expectType<void>(test.skip(class {}, fn));
+expectType<void>(test.skip(class Named {}, fn));
+
+expectType<typeof test.each>(test.skip.each);
+expectType<typeof test.failing>(test.skip.failing);
+
+// test.todo
+
+expectType<void>(test.todo(testName));
+
+expectType<void>(test.todo(123));
+expectType<void>(test.todo(() => {}));
+expectType<void>(test.todo(function named() {}));
+expectType<void>(test.todo(class {}));
+expectType<void>(test.todo(class Named {}));
+
+expectError(test.todo());
+expectError(test.todo(testName, fn));
+
+// describe
 
 expectType<void>(describe(testName, fn));
+
+expectError(describe());
+expectError(describe(fn));
+expectError(describe(testName, fn, timeout));
+
 expectType<void>(describe(123, fn));
 expectType<void>(describe(() => {}, fn));
 expectType<void>(describe(function named() {}, fn));
 expectType<void>(describe(class {}, fn));
 expectType<void>(describe(class Named {}, fn));
 
-expectType<void>(describe.each(list)(testName, fn));
-expectType<void>(describe.each(list)(testName, fn, timeout));
 expectType<void>(describe.each(table)(testName, fn));
 expectType<void>(describe.each(table)(testName, fn, timeout));
-expectType<void>(describe.each(readonlyTable)(testName, fn));
-expectType<void>(describe.each(readonlyTable)(testName, fn, timeout));
 
-expectType<void>(describe.each(list)(testName, fn));
-expectType<void>(describe.each(list)(123, fn));
-expectType<void>(describe.each(list)(() => {}, fn));
-expectType<void>(describe.each(list)(function named() {}, fn));
-expectType<void>(describe.each(list)(class Named {}, fn));
+expectType<void>(describe.each(table)(testName, fn));
+expectType<void>(describe.each(table)(123, fn));
+expectType<void>(describe.each(table)(() => {}, fn));
+expectType<void>(describe.each(table)(function named() {}, fn));
+expectType<void>(describe.each(table)(class Named {}, fn));
 
-expectType<void>(describe.only.each(list)(testName, fn));
-expectType<void>(describe.only.each(list)(testName, fn, timeout));
-expectType<void>(describe.only.each(table)(testName, fn));
-expectType<void>(describe.only.each(table)(testName, fn, timeout));
-expectType<void>(describe.only.each(readonlyTable)(testName, fn));
-expectType<void>(describe.only.each(readonlyTable)(testName, fn, timeout));
+// describe.only
 
-expectType<void>(describe.only.each(list)(testName, fn));
-expectType<void>(describe.only.each(list)(123, fn));
-expectType<void>(describe.only.each(list)(() => {}, fn));
-expectType<void>(describe.only.each(list)(function named() {}, fn));
-expectType<void>(describe.only.each(list)(class Named {}, fn));
+expectType<void>(describe.only(testName, fn));
 
-expectType<void>(describe.skip.each(list)(testName, fn));
-expectType<void>(describe.skip.each(list)(testName, fn, timeout));
-expectType<void>(describe.skip.each(table)(testName, fn));
-expectType<void>(describe.skip.each(table)(testName, fn, timeout));
-expectType<void>(describe.skip.each(readonlyTable)(testName, fn));
-expectType<void>(describe.skip.each(readonlyTable)(testName, fn, timeout));
+expectError(describe.only());
+expectError(describe.only(fn));
+expectError(describe.only(testName, fn, timeout));
 
-expectType<void>(describe.skip.each(list)(testName, fn));
-expectType<void>(describe.skip.each(list)(123, fn));
-expectType<void>(describe.skip.each(list)(() => {}, fn));
-expectType<void>(describe.skip.each(list)(function named() {}, fn));
-expectType<void>(describe.skip.each(list)(class Named {}, fn));
+expectType<void>(describe.only(123, fn));
+expectType<void>(describe.only(() => {}, fn));
+expectType<void>(describe.only(function named() {}, fn));
+expectType<void>(describe.only(class {}, fn));
+expectType<void>(describe.only(class Named {}, fn));
 
-expectType<void>(
-  describe.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<typeof describe.each>(describe.only.each);
 
-expectType<void>(
-  describe.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+// describe.skip
 
-expectType<void>(
-  describe.only.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<void>(describe.skip(testName, fn));
 
-expectType<void>(
-  describe.only.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+expectError(describe.skip());
+expectError(describe.skip(fn));
+expectError(describe.skip(testName, fn, timeout));
 
-expectType<void>(
-  describe.skip.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn),
-);
+expectType<void>(describe.skip(123, fn));
+expectType<void>(describe.skip(() => {}, fn));
+expectType<void>(describe.skip(function named() {}, fn));
+expectType<void>(describe.skip(class {}, fn));
+expectType<void>(describe.skip(class Named {}, fn));
 
-expectType<void>(
-  describe.skip.each`
-    a    | b    | expected
-    ${1} | ${1} | ${2}
-    ${1} | ${2} | ${3}
-    ${2} | ${1} | ${3}
-  `(testName, fn, timeout),
-);
+expectType<typeof describe.each>(describe.skip.each);

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -55,12 +55,55 @@ export type EachTestFn<EachCallback extends TestCallback> = (
   ...args: ReadonlyArray<any>
 ) => ReturnType<EachCallback>;
 
-type Each<EachCallback extends TestCallback, Name> =
-  | ((
-      table: EachTable,
-      ...taggedTemplateData: TemplateData
-    ) => (name: Name, test: EachTestFn<EachCallback>, timeout?: number) => void)
-  | (() => () => void);
+interface Each<EachFn extends TestFn | BlockFn> {
+  <T extends Record<string, unknown>>(table: ReadonlyArray<T>): (
+    name: string | NameLike,
+    fn: (arg: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends readonly [unknown, ...Array<unknown>]>(table: ReadonlyArray<T>): (
+    name: string | NameLike,
+    fn: (...args: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends readonly [unknown, ...Array<unknown>]>(table: T): (
+    name: string | NameLike,
+    fn: (...args: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends ReadonlyArray<unknown>>(table: ReadonlyArray<T>): (
+    name: string | NameLike,
+    fn: (...args: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends ReadonlyArray<unknown>>(table: T): (
+    name: string | NameLike,
+    fn: (...args: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends unknown>(
+    strings: TemplateStringsArray,
+    ...expressions: Array<T>
+  ): (
+    name: string | NameLike,
+    fn: (arg: Record<string, T>) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+
+  <T extends Record<string, unknown>>(
+    strings: TemplateStringsArray,
+    ...expressions: Array<unknown>
+  ): (
+    name: string | NameLike,
+    fn: (arg: T) => ReturnType<EachFn>,
+    timeout?: number,
+  ) => void;
+}
 
 export interface HookBase {
   (fn: HookFn, timeout?: number): void;
@@ -68,7 +111,7 @@ export interface HookBase {
 
 export interface ItBase {
   (testName: TestNameLike, fn: TestFn, timeout?: number): void;
-  each: Each<TestFn, TestNameLike>;
+  each: Each<TestFn>;
   failing(testName: TestNameLike, fn: TestFn, timeout?: number): void;
 }
 
@@ -80,7 +123,7 @@ export interface It extends ItBase {
 
 export interface ItConcurrentBase {
   (testName: TestNameLike, testFn: ConcurrentTestFn, timeout?: number): void;
-  each: Each<ConcurrentTestFn, TestNameLike>;
+  each: Each<ConcurrentTestFn>;
   failing(testName: TestNameLike, fn: ConcurrentTestFn, timeout?: number): void;
 }
 
@@ -95,7 +138,7 @@ export interface ItConcurrent extends It {
 
 export interface DescribeBase {
   (blockName: BlockNameLike, blockFn: BlockFn): void;
-  each: Each<BlockFn, BlockNameLike | TestNameLike>;
+  each: Each<BlockFn>;
 }
 
 export interface Describe extends DescribeBase {


### PR DESCRIPTION
## Summary

This PR is filling one more gap of types. Currently types of arguments passed from `each` tables to `test` and `describe` functions are `any`. In this field, `@types/jest` does better job. I was playing with for some time. The solutions is different than the one from DT – somewhat better, but with some limitations. Documentation noting the caveats is included (by the way, types from DT has similar issues).

Probably I will have to revisit it later, but that is a strong start already.

## Test plan

The detailed type tests for `each` now live in a separate file. The type tests for global API were cleaned up and slightly extended. Could not leave them. Apologies for many tests. Just wanted to be sure that everything works.