### PR TITLE
fix typo/punctuation in MockFunctionAPI.md

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -586,7 +586,7 @@ Please consult the [Getting Started](GettingStarted.md#using-typescript) guide f
 
 ### `jest.fn(implementation?)`
 
-Correct mock typings will be inferred, if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases there the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
+Correct mock typings will be inferred if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases where the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
 
 ```ts
 import {expect, jest, test} from '@jest/globals';

--- a/website/versioned_docs/version-28.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.0/MockFunctionAPI.md
@@ -586,7 +586,7 @@ Please consult the [Getting Started](GettingStarted.md#using-typescript) guide f
 
 ### `jest.fn(implementation?)`
 
-Correct mock typings will be inferred, if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases there the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
+Correct mock typings will be inferred if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases where the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
 
 ```ts
 import {expect, jest, test} from '@jest/globals';

--- a/website/versioned_docs/version-28.1/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.1/MockFunctionAPI.md
@@ -586,7 +586,7 @@ Please consult the [Getting Started](GettingStarted.md#using-typescript) guide f
 
 ### `jest.fn(implementation?)`
 
-Correct mock typings will be inferred, if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases there the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
+Correct mock typings will be inferred if implementation is passed to [`jest.fn()`](JestObjectAPI.md#jestfnimplementation). There are many use cases where the implementation is omitted. To ensure type safety you may pass a generic type argument (also see the examples above for more reference):
 
 ```ts
 import {expect, jest, test} from '@jest/globals';


### PR DESCRIPTION
## Summary

Small fix typo and comma errors in website documentation [jest.fn(implementation?) section](https://jestjs.io/docs/mock-function-api#jestfnimplementation) in MockFunctionAPI.md.

## Test plan

No testing needed:
Simple 'there' -> 'where' typo fix.
No comma after 'if' when it begins a subordinate clause that follows the main clause.
