### PR TITLE
feat(jest-circus): Allow retrying only certain test errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest]` Expose `Config` type ([#12848](https://github.com/facebook/jest/pull/12848))
+- `[jest-circus, jest-environment, jest-runtime, @jest/types]` Allow retrying only certain test errors ([#12848](https://github.com/facebook/jest/pull/12848))
 - `[@jest/reporters]` Improve `GitHubActionsReporter`s annotation format ([#12826](https://github.com/facebook/jest/pull/12826))
 
 ### Fixes

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -855,7 +855,7 @@ test('will fail', () => {
 });
 ```
 
-You can pass in a `retryFilter` function to filter which errors Jest should retry on. The `retryFilter` will receive an array of the exceptions/test errors for each run of the test, and should return `true` if we should retry on this error
+You can pass a `retryFilter` function to filter which errors Jest should retry on. The function will receive an array of the exceptions/test errors for each failing test and should return `true` to retry the test.
 
 By default, `jest.retryTimes()` will retry on all errors.
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -855,4 +855,25 @@ test('will fail', () => {
 });
 ```
 
+You can pass in a `retryFilter` function to filter which errors we should retry
+on. `retryFilter` is passed in an array of the exceptions/test errors for each
+run of the test.
+
+By default, jest.retryTimes will retry on all errors.
+
+```js
+jest.retryTimes(3, {
+  retryFilter: ({errors}) => 
+    errors.some(error => error.message.includes('Some flaky error')),
+});
+
+test('will get retried', () => {
+  throw new Error('Some flaky error');
+});
+
+test('will not get retried', () => {
+  throw new Error('Error that is not from flakiness');
+});
+```
+
 Returns the `jest` object for chaining.

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -855,11 +855,11 @@ test('will fail', () => {
 });
 ```
 
-You can pass in a `retryFilter` function to filter which errors we should retry
-on. `retryFilter` is passed in an array of the exceptions/test errors for each
+You can pass in a `retryFilter` function to filter which errors Jest should retry
+on. The `retryFilter` will receive an array of the exceptions/test errors for each
 run of the test.
 
-By default, jest.retryTimes will retry on all errors.
+By default, `jest.retryTimes()` will retry on all errors.
 
 ```js
 jest.retryTimes(3, {

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -855,9 +855,7 @@ test('will fail', () => {
 });
 ```
 
-You can pass in a `retryFilter` function to filter which errors Jest should retry
-on. The `retryFilter` will receive an array of the exceptions/test errors for each
-run of the test.
+You can pass in a `retryFilter` function to filter which errors Jest should retry on. The `retryFilter` will receive an array of the exceptions/test errors for each run of the test, and should return `true` if we should retry on this error
 
 By default, `jest.retryTimes()` will retry on all errors.
 

--- a/e2e/test-retries/__tests__/retryFilter.test.js
+++ b/e2e/test-retries/__tests__/retryFilter.test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+jest.retryTimes(3, {
+  retryFilter: ({errors}) =>
+    errors.some(error => error.message.includes('Should retry')),
+});
+
+it('matching retry', () => {
+  throw new Error('Should retry');
+});
+
+it('non-matching retry', () => {
+  throw new Error('Should not retry');
+});

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -65,7 +65,9 @@ const _runTestsForDescribeBlock = async (
   // Tests that fail and are retried we run after other tests
   // eslint-disable-next-line no-restricted-globals
   const retryTimes = parseInt(global[RETRY_TIMES], 10) || 0;
-  const retryFilter: Circus.TestRetryFilter = global[RETRY_FILTER] || (() => true);
+  const retryFilter: Circus.TestRetryFilter =
+    // eslint-disable-next-line no-restricted-globals
+    global[RETRY_FILTER] || (() => true);
   const deferredRetryTests = [];
 
   for (const child of describeBlock.children) {
@@ -81,7 +83,11 @@ const _runTestsForDescribeBlock = async (
         if (
           hasErrorsBeforeTestRun === false &&
           retryTimes > 0 &&
-          retryFilter({ errors: child.errors }) &&
+          retryFilter({
+            errors: child.errors
+              .flatMap(errors => (Array.isArray(errors) ? errors : [errors]))
+              .filter(error => error != null),
+          }) &&
           child.errors.length > 0
         ) {
           deferredRetryTests.push(child);

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -8,7 +8,7 @@
 import throat from 'throat';
 import type {Circus} from '@jest/types';
 import {dispatch, getState} from './state';
-import {RETRY_TIMES} from './types';
+import {RETRY_FILTER, RETRY_TIMES} from './types';
 import {
   callAsyncCircusFn,
   getAllHooksForDescribe,
@@ -65,6 +65,7 @@ const _runTestsForDescribeBlock = async (
   // Tests that fail and are retried we run after other tests
   // eslint-disable-next-line no-restricted-globals
   const retryTimes = parseInt(global[RETRY_TIMES], 10) || 0;
+  const retryFilter: Circus.TestRetryFilter = global[RETRY_FILTER] || (() => true);
   const deferredRetryTests = [];
 
   for (const child of describeBlock.children) {
@@ -80,6 +81,7 @@ const _runTestsForDescribeBlock = async (
         if (
           hasErrorsBeforeTestRun === false &&
           retryTimes > 0 &&
+          retryFilter({ errors: child.errors }) &&
           child.errors.length > 0
         ) {
           deferredRetryTests.push(child);

--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -9,6 +9,7 @@ import type {Circus} from '@jest/types';
 
 export const STATE_SYM = Symbol('JEST_STATE_SYMBOL');
 export const RETRY_TIMES = Symbol.for('RETRY_TIMES');
+export const RETRY_FILTER = Symbol.for('RETRY_FILTER');
 // To pass this value from Runtime object to state we need to use global[sym]
 export const TEST_TIMEOUT_SYMBOL = Symbol.for('TEST_TIMEOUT_SYMBOL');
 export const LOG_ERRORS_BEFORE_RETRY = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
@@ -18,6 +19,7 @@ declare global {
     interface Global {
       [STATE_SYM]: Circus.State;
       [RETRY_TIMES]: string;
+      [RETRY_FILTER]: Circus.TestRetryFilter;
       [TEST_TIMEOUT_SYMBOL]: number;
       [LOG_ERRORS_BEFORE_RETRY]: boolean;
     }

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -232,17 +232,24 @@ export interface Jest {
    * Runs failed tests n-times until they pass or until the max number of
    * retries is exhausted.
    *
-   * If `logErrorsBeforeRetry` is enabled, Jest will log the error(s) that caused
-   * the test to fail to the console, providing visibility on why a retry occurred.
-   * retries is exhausted.
-   *
    * @remarks
    * Only available with `jest-circus` runner.
    */
   retryTimes(
     numRetries: number,
     options?: {
+      /**
+       * If `logErrorsBeforeRetry` is true, Jest will log the error(s) that
+       * caused the test to fail to the console, providing visibility on why a
+       * retry occurred.
+       */
       logErrorsBeforeRetry?: boolean;
+      /**
+       * You can pass in a `retryFilter` function to filter which errors Jest
+       * should retry on. The `retryFilter` will receive an array of the
+       * exceptions/test errors for each run of the test, and should return
+       * `true` if we should retry on this error
+       */
       retryFilter?: Circus.TestRetryFilter;
     },
   ): Jest;

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -245,10 +245,9 @@ export interface Jest {
        */
       logErrorsBeforeRetry?: boolean;
       /**
-       * You can pass in a `retryFilter` function to filter which errors Jest
-       * should retry on. The `retryFilter` will receive an array of the
-       * exceptions/test errors for each run of the test, and should return
-       * `true` if we should retry on this error
+       * A function to filter which errors Jest should retry on. It will
+       * receive an array of the exceptions/test errors for each failing test
+       * and should return `true` to retry the test.
        */
       retryFilter?: Circus.TestRetryFilter;
     },

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -241,7 +241,10 @@ export interface Jest {
    */
   retryTimes(
     numRetries: number,
-    options?: {logErrorsBeforeRetry?: boolean},
+    options?: {
+      logErrorsBeforeRetry?: boolean;
+      retryFilter?: Circus.TestRetryFilter;
+    },
   ): Jest;
 
   /**

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -239,9 +239,8 @@ export interface Jest {
     numRetries: number,
     options?: {
       /**
-       * If `logErrorsBeforeRetry` is true, Jest will log the error(s) that
-       * caused the test to fail to the console, providing visibility on why a
-       * retry occurred.
+       * If set to `true`, Jest will log the error(s) that caused the test
+       * to fail to the console, providing visibility on why a retry occurred.
        */
       logErrorsBeforeRetry?: boolean;
       /**

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -119,6 +119,7 @@ type ResolveOptions = Parameters<typeof require.resolve>[1] & {
 
 const testTimeoutSymbol = Symbol.for('TEST_TIMEOUT_SYMBOL');
 const retryTimesSymbol = Symbol.for('RETRY_TIMES');
+const retryFilterSymbol = Symbol.for('RETRY_FILTER');
 const logErrorsBeforeRetrySymbol = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
 
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
@@ -2120,6 +2121,7 @@ export default class Runtime {
 
     const retryTimes: Jest['retryTimes'] = (numTestRetries, options) => {
       this._environment.global[retryTimesSymbol] = numTestRetries;
+      this._environment.global[retryFilterSymbol] = options?.retryFilter;
       this._environment.global[logErrorsBeforeRetrySymbol] =
         options?.logErrorsBeforeRetry;
 

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -117,7 +117,6 @@ expectError(jest.unmock());
 
 // Mock Functions
 
-expectType<typeof jest>(jest.retryTimes(3, {logErrorsBeforeRetry: true}));
 expectType<typeof jest>(jest.clearAllMocks());
 expectError(jest.clearAllMocks('moduleName'));
 
@@ -305,6 +304,7 @@ expectType<typeof jest>(jest.setTimeout(6000));
 expectError(jest.setTimeout());
 
 expectType<typeof jest>(jest.retryTimes(3));
+expectType<typeof jest>(jest.retryTimes(3, {logErrorsBeforeRetry: true}));
 expectType<typeof jest>(
   jest.retryTimes(3, {
     logErrorsBeforeRetry: true,

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -305,4 +305,15 @@ expectType<typeof jest>(jest.setTimeout(6000));
 expectError(jest.setTimeout());
 
 expectType<typeof jest>(jest.retryTimes(3));
+expectType<typeof jest>(
+  jest.retryTimes(3, {
+    logErrorsBeforeRetry: true,
+    retryFilter: ({errors}) => errors.length !== 0,
+  }),
+);
 expectError(jest.retryTimes());
+expectError(jest.retryTimes(3, {retryFilter: 1}));
+expectError(jest.retryTimes(3, {retryFilter: () => 1}));
+expectError(
+  jest.retryTimes(3, {retryFilter: ({someOtherKey}) => !!someOtherKey}),
+);

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -253,3 +253,5 @@ export type TestEntry = {
   timeout?: number;
   failing: boolean;
 };
+
+export type TestRetryFilter = (options: { errors: Array<TestError> }) => boolean;

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -254,4 +254,4 @@ export type TestEntry = {
   failing: boolean;
 };
 
-export type TestRetryFilter = (options: { errors: Array<TestError> }) => boolean;
+export type TestRetryFilter = (options: {errors: Array<Exception>}) => boolean;


### PR DESCRIPTION
## Summary

On our team, we had a certain category of failing tests that tended to be flaky due to external dependencies. These tests e.g., would fail with network errors (e.g., `ETIMEDOUT`).

We only wanted to retry these failures, and not other failures (which might be indicative of real inconsistencies in our logic or race conditions). Currently, to my knowledge, `jest.retryCount` can only retry all errors, rather than specific errors that are likely to be fine to retry.

## Test plan

Added an end-to-end test for using:

```ts
jest.retryCount(3, {
  retryFilter: (errors) =>
    errors.some(err => err.message.includes('ETIMEDOUT'),
});
```

Ran it using:

```sh
JEST_CIRCUS=1 yarn jest e2e/__tests__/testRetries.test.ts -t 'retryFilter'
```