### PR TITLE
docs: correct spelling of "latter"

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -280,7 +280,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-25.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-25.x/SnapshotTesting.md
@@ -269,7 +269,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-26.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-26.x/SnapshotTesting.md
@@ -269,7 +269,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-27.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-27.x/SnapshotTesting.md
@@ -265,7 +265,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-28.0/SnapshotTesting.md
+++ b/website/versioned_docs/version-28.0/SnapshotTesting.md
@@ -280,7 +280,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-28.1/SnapshotTesting.md
+++ b/website/versioned_docs/version-28.1/SnapshotTesting.md
@@ -280,7 +280,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
+Since the latter describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `


### PR DESCRIPTION
## Summary

Correct spelling of "latter" (was "later").

## Test plan

N/A