### PR TITLE
fix(expect-utils): Fix deep equality of ImmutableJS OrderedMaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
 - `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
+- `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedMaps ([#12763](https://github.com/facebook/jest/pull/12899))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### Fixes
 
-- `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
-- `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedMaps ([#12763](https://github.com/facebook/jest/pull/12899))
+- `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
+- `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
 
 ### Chore & Maintenance
 

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {List} from 'immutable';
+import {List,OrderedMap} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {
   arrayBufferEquality,
@@ -523,6 +523,12 @@ describe('iterableEquality', () => {
     const a = List([1, 2, 3]);
     const b = a.filter(v => v > 0);
 
+    expect(iterableEquality(a, b)).toBe(true);
+  });
+
+  test('returns true when given Immutable OrderedMaps without an OwnerID', () => {
+    const a = OrderedMap().set('saving', true);
+    const b = OrderedMap().merge({ saving: true });
     expect(iterableEquality(a, b)).toBe(true);
   });
 });

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {List,OrderedMap} from 'immutable';
+import {List, OrderedMap} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {
   arrayBufferEquality,
@@ -528,7 +528,7 @@ describe('iterableEquality', () => {
 
   test('returns true when given Immutable OrderedMaps without an OwnerID', () => {
     const a = OrderedMap().set('saving', true);
-    const b = OrderedMap().merge({ saving: true });
+    const b = OrderedMap().merge({saving: true});
     expect(iterableEquality(a, b)).toBe(true);
   });
 });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -266,3 +266,11 @@ export function isImmutableList(maybeList: any) {
     maybeList[IS_LIST_SENTINEL]
   );
 }
+
+export function isImmutableOrderedKeyed(maybeKeyed: any) {
+  return !!(
+    maybeKeyed &&
+    maybeKeyed[IS_KEYED_SENTINEL] &&
+    maybeKeyed[IS_ORDERED_SENTINEL]
+  );
+}

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -11,6 +11,7 @@ import {
   equals,
   isA,
   isImmutableList,
+  isImmutableOrderedKeyed,
   isImmutableUnorderedKeyed,
   isImmutableUnorderedSet,
 } from './jasmineUtils';
@@ -255,7 +256,7 @@ export const iterableEquality = (
     return false;
   }
 
-  if (!isImmutableList(a)) {
+  if (!isImmutableList(a) && !isImmutableOrderedKeyed(a)) {
     const aEntries = Object.entries(a);
     const bEntries = Object.entries(b);
     if (!equals(aEntries, bEntries)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #12860

## Test plan
I added an `iterableEquality` test for two `OrderedMaps` that have the same contents, but were not considered equal before this change. This PR follows the changes made in #12763 for a similar issue.
