### PR TITLE
chore: bump `typescript` to v4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[jest-worker]` Make `JestWorkerFarm` helper type to include methods of worker module that take more than one argument ([#12839](https://github.com/facebook/jest/pull/12839))
 - `[jest-docblock]` Handle multiline comments in parseWithComments ([#12845](https://github.com/facebook/jest/pull/12845))
+- `[jest-mock]` Improve `spyOn` error messages ([#12901](https://github.com/facebook/jest/pull/12901))
 
 ### Chore & Maintenance
 

--- a/e2e/coverage-remapping/package.json
+++ b/e2e/coverage-remapping/package.json
@@ -7,6 +7,6 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/e2e/coverage-remapping/yarn.lock
+++ b/e2e/coverage-remapping/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.6.2":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
   languageName: node
   linkType: hard

--- a/e2e/stack-trace-source-maps-with-coverage/package.json
+++ b/e2e/stack-trace-source-maps-with-coverage/package.json
@@ -8,6 +8,6 @@
     "testRegex": "fails"
   },
   "dependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/e2e/stack-trace-source-maps-with-coverage/yarn.lock
+++ b/e2e/stack-trace-source-maps-with-coverage/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.6.2":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
   languageName: node
   linkType: hard

--- a/e2e/stack-trace-source-maps/package.json
+++ b/e2e/stack-trace-source-maps/package.json
@@ -8,6 +8,6 @@
     "testRegex": "fails"
   },
   "dependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/e2e/stack-trace-source-maps/yarn.lock
+++ b/e2e/stack-trace-source-maps/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.6.2":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
   languageName: node
   linkType: hard

--- a/e2e/typescript-coverage/package.json
+++ b/e2e/typescript-coverage/package.json
@@ -7,6 +7,6 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/e2e/typescript-coverage/yarn.lock
+++ b/e2e/typescript-coverage/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.6.2":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>":
-  version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
   languageName: node
   linkType: hard

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,7 +15,7 @@
     "core-js": "^3.2.1",
     "rxjs": "^7.5.5",
     "tslib": "^2.0.0",
-    "typescript": "^4.6.2",
+    "typescript": "^4.7.2",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "^17.0.1",
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@jest/test-utils": "workspace:*",
     "@microsoft/api-extractor": "^7.23.0",
     "@tsconfig/node12": "^1.0.9",
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.0.0",
     "@types/babel__template": "^7.0.2",
@@ -81,7 +81,7 @@
     "throat": "^6.0.1",
     "ts-node": "^10.5.0",
     "type-fest": "^2.11.2",
-    "typescript": "^4.6.2",
+    "typescript": "^4.7.2",
     "which": "^2.0.1"
   },
   "scripts": {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "chalk": "^4.0.0",
     "fast-check": "^2.0.0",
     "immutable": "^4.0.0",

--- a/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dependencies/package.json
+++ b/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript_in_dev_dependencies",
   "devDependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dev-dependencies/package.json
+++ b/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dev-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "only-package-json",
   "dependencies": {
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   }
 }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -58,7 +58,7 @@
     "@types/micromatch": "^4.0.1",
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
-    "typescript": "^4.6.2"
+    "typescript": "^4.7.2"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -21,7 +21,7 @@
     "jest-snapshot": "^28.1.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "tsd-lite": "^0.5.1"
   },
   "engines": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -21,7 +21,7 @@
     "@types/node": "*"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "tsd-lite": "^0.5.1"
   },
   "engines": {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1087,7 +1087,9 @@ export class ModuleMocker {
     if (!this.isMockFunction(original)) {
       if (typeof original !== 'function') {
         throw new Error(
-          `Cannot spy the ${methodName} property because it is not a function; ${this._typeOf(
+          `Cannot spy the ${String(
+            methodName,
+          )} property because it is not a function; ${this._typeOf(
             original,
           )} given instead`,
         );
@@ -1149,7 +1151,9 @@ export class ModuleMocker {
 
     if (!obj) {
       throw new Error(
-        `spyOn could not find an object to spy upon for ${propertyName}`,
+        `spyOn could not find an object to spy upon for ${String(
+          propertyName,
+        )}`,
       );
     }
 
@@ -1166,16 +1170,18 @@ export class ModuleMocker {
     }
 
     if (!descriptor) {
-      throw new Error(`${propertyName} property does not exist`);
+      throw new Error(`${String(propertyName)} property does not exist`);
     }
 
     if (!descriptor.configurable) {
-      throw new Error(`${propertyName} is not declared configurable`);
+      throw new Error(`${String(propertyName)} is not declared configurable`);
     }
 
     if (!descriptor[accessType]) {
       throw new Error(
-        `Property ${propertyName} does not have access type ${accessType}`,
+        `Property ${String(
+          propertyName,
+        )} does not have access type ${accessType}`,
       );
     }
 
@@ -1184,7 +1190,9 @@ export class ModuleMocker {
     if (!this.isMockFunction(original)) {
       if (typeof original !== 'function') {
         throw new Error(
-          `Cannot spy the ${propertyName} property because it is not a function; ${this._typeOf(
+          `Cannot spy the ${String(
+            propertyName,
+          )} property because it is not a function; ${this._typeOf(
             original,
           )} given instead`,
         );

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/exit": "^0.1.30",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -28,7 +28,7 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/graceful-fs": "^4.1.3",
     "@types/pnpapi": "^0.0.2",
     "@types/resolve": "^1.20.2",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -40,7 +40,7 @@
     "throat": "^6.0.1"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.3",
     "@types/source-map-support": "^0.5.0",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-flow": "^7.7.2",
     "@babel/preset-react": "^7.12.1",
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
     "@types/semver": "^7.1.0",

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "tsd-lite": "^0.5.1"
   },
   "publishConfig": {

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -22,7 +22,7 @@
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",
     "get-stream": "^6.0.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -19,7 +19,7 @@
     "jest-cli": "^28.1.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.6.2",
+    "@tsd/typescript": "~4.7.2",
     "tsd-lite": "^0.5.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6176,7 +6176,7 @@ __metadata:
     jest-zone-patch: "*"
     rxjs: ^7.5.5
     tslib: ^2.0.0
-    typescript: ^4.6.2
+    typescript: ^4.7.2
     zone.js: ~0.11.3
   languageName: unknown
   linkType: soft
@@ -10241,7 +10241,7 @@ __metadata:
     jest: "workspace:*"
     react: 17.0.2
     react-dom: ^17.0.1
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   languageName: unknown
   linkType: soft
 
@@ -13152,7 +13152,7 @@ __metadata:
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
-    typescript: ^4.6.2
+    typescript: ^4.7.2
   peerDependencies:
     "@types/node": "*"
     ts-node: ">=9.0.0"
@@ -21646,16 +21646,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.2, typescript@npm:~4.6.3":
-  version: 4.6.3
-  resolution: "typescript@npm:4.6.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^4.7.2":
   version: 4.7.2
   resolution: "typescript@npm:4.7.2"
@@ -21666,13 +21656,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>, typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
+"typescript@npm:~4.6.3":
   version: 4.6.3
-  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+  resolution: "typescript@npm:4.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  checksum: 255bb26c8cb846ca689dd1c3a56587af4f69055907aa2c154796ea28ee0dea871535b1c78f85a6212c77f2657843a269c3a742d09d81495b97b914bf7920415b
   languageName: node
   linkType: hard
 
@@ -21683,6 +21673,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
+  version: 4.6.3
+  resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2630,7 +2630,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect@workspace:packages/jest-expect"
   dependencies:
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     expect: ^28.1.0
     jest-snapshot: ^28.1.0
     tsd-lite: ^0.5.1
@@ -2677,7 +2677,7 @@ __metadata:
     "@jest/test-utils": "workspace:*"
     "@microsoft/api-extractor": ^7.23.0
     "@tsconfig/node12": ^1.0.9
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/babel__core": ^7.1.14
     "@types/babel__generator": ^7.0.0
     "@types/babel__template": ^7.0.2
@@ -2744,7 +2744,7 @@ __metadata:
     throat: ^6.0.1
     ts-node: ^10.5.0
     type-fest: ^2.11.2
-    typescript: ^4.6.2
+    typescript: ^4.7.2
     which: ^2.0.1
   languageName: unknown
   linkType: soft
@@ -2760,7 +2760,7 @@ __metadata:
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
     "@jridgewell/trace-mapping": ^0.3.7
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/exit": ^0.1.30
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.3
@@ -2892,7 +2892,7 @@ __metadata:
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
     "@jest/schemas": ^28.0.2
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
@@ -4750,13 +4750,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsd/typescript@npm:~4.6.2":
-  version: 4.6.3
-  resolution: "@tsd/typescript@npm:4.6.3"
+"@tsd/typescript@npm:~4.7.2":
+  version: 4.7.2
+  resolution: "@tsd/typescript@npm:4.7.2"
   bin:
     tsc: typescript/bin/tsc
     tsserver: typescript/bin/tsserver
-  checksum: 8a8d570bd4cd392c8bf33bd5a9516a4bc06964d5e98754a346f2dfd051a7c8a44d33d1f449e17a696a7d6b5f81ceb36e8a7b473d9aee077bd7138f0ed252a7f6
+  checksum: 4629ebaec168063d2b148e4981807a90ee678c5255cc6d98cf03e954bb8cea67c8935c4630b0798dc3c98f51a5fc85c20c2cbad7617a403c8607f73fbf4a984b
   languageName: node
   linkType: hard
 
@@ -10302,7 +10302,7 @@ __metadata:
   dependencies:
     "@jest/expect-utils": ^28.1.0
     "@jest/test-utils": ^28.1.0
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     chalk: ^4.0.0
     fast-check: ^2.0.0
     immutable: ^4.0.0
@@ -13404,7 +13404,7 @@ __metadata:
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/node": "*"
     tsd-lite: ^0.5.1
   languageName: unknown
@@ -13486,7 +13486,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-resolve@workspace:packages/jest-resolve"
   dependencies:
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/graceful-fs": ^4.1.3
     "@types/pnpapi": ^0.0.2
     "@types/resolve": ^1.20.2
@@ -13526,7 +13526,7 @@ __metadata:
     "@jest/test-result": ^28.1.0
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/exit": ^0.1.30
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
@@ -13620,7 +13620,7 @@ __metadata:
     "@jest/test-utils": ^28.1.0
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/babel__traverse": ^7.0.6
     "@types/graceful-fs": ^4.1.3
     "@types/natural-compare": ^1.4.0
@@ -13779,7 +13779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-worker@workspace:packages/jest-worker"
   dependencies:
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"
     "@types/supports-color": ^8.1.0
@@ -13829,7 +13829,7 @@ __metadata:
   dependencies:
     "@jest/core": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.6.2
+    "@tsd/typescript": ~4.7.2
     import-local: ^3.0.2
     jest-cli: ^28.1.0
     tsd-lite: ^0.5.1
@@ -21660,6 +21660,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^4.7.2":
+  version: 4.7.2
+  resolution: "typescript@npm:4.7.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>, typescript@patch:typescript@~4.6.3#~builtin<compat/typescript>":
   version: 4.6.3
   resolution: "typescript@patch:typescript@npm%3A4.6.3#~builtin<compat/typescript>::version=4.6.3&hash=7ad353"
@@ -21667,6 +21677,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 6bf45caf847062420592e711bc9c28bf5f9a9a7fa8245343b81493e4ededae33f1774009d1234d911422d1646a2c839f44e1a23ecb111b40a60ac2ea4c1482a8
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
+  version: 4.7.2
+  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #12877

## Summary

This should fix TypeScript upgrade issue. Interesting thing was caught by TS. For example, this:

```js
jest.spyOn({}, 'ups');
```

Will throw: "Error: Cannot spy the ups property because it is not a function".

But here:

```js
jest.spyOn({}, Symbol('ups'));
```

It throws: "TypeError: Cannot convert a Symbol value to a string". This is what TS was suggesting to fix. After this fix, the error message becomes: "Error: Cannot spy the Symbol(ups) property because it is not a function". Much better.

---

Also I spend some time trying out if `jest.spyOn` accepts keys as symbols. It does, all works. Only error messages is the issue. Would be nice to have tests for these, of course. Started working, refactoring some details and here I got stuck ;D Wait.. But that is another story already. Better I will make separate PR later.

## Test plan

Green CI.