### PR TITLE
fix(@jest/types): replace constrain with default type in one of `each` overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[jest]` Expose `Config` type ([#12848](https://github.com/facebook/jest/pull/12848))
 - `[@jest/reporters]` Improve `GitHubActionsReporter`s annotation format ([#12826](https://github.com/facebook/jest/pull/12826))
-- `[@jest/types]` Infer argument types passed to `test` and `describe` callback functions from `each` tables ([#12885](https://github.com/facebook/jest/pull/12885))
+- `[@jest/types]` Infer argument types passed to `test` and `describe` callback functions from `each` tables ([#12885](https://github.com/facebook/jest/pull/12885), [#12905](https://github.com/facebook/jest/pull/12905))
 
 ### Fixes
 

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -86,11 +86,7 @@ interface Each<EachFn extends TestFn | BlockFn> {
     timeout?: number,
   ) => void;
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-constraint
-  <T extends unknown>(
-    strings: TemplateStringsArray,
-    ...expressions: Array<T>
-  ): (
+  <T = unknown>(strings: TemplateStringsArray, ...expressions: Array<T>): (
     name: string | NameLike,
     fn: (arg: Record<string, T>) => ReturnType<EachFn>,
     timeout?: number,


### PR DESCRIPTION
Following up #12902

## Summary

Feels like ESLint is right – I this case default type is better idea than a constrain, which actually does not constrain anything. Also nice to have `eslint-disable` line less.

## Test plan

Same type tests should pass.