### PR TITLE
chore: bump `typescript` to v4.7.3

### DIFF
--- a/e2e/coverage-remapping/package.json
+++ b/e2e/coverage-remapping/package.json
@@ -7,6 +7,6 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/e2e/coverage-remapping/yarn.lock
+++ b/e2e/coverage-remapping/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
+"typescript@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
   languageName: node
   linkType: hard

--- a/e2e/stack-trace-source-maps-with-coverage/package.json
+++ b/e2e/stack-trace-source-maps-with-coverage/package.json
@@ -8,6 +8,6 @@
     "testRegex": "fails"
   },
   "dependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/e2e/stack-trace-source-maps-with-coverage/yarn.lock
+++ b/e2e/stack-trace-source-maps-with-coverage/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
+"typescript@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
   languageName: node
   linkType: hard

--- a/e2e/stack-trace-source-maps/package.json
+++ b/e2e/stack-trace-source-maps/package.json
@@ -8,6 +8,6 @@
     "testRegex": "fails"
   },
   "dependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/e2e/stack-trace-source-maps/yarn.lock
+++ b/e2e/stack-trace-source-maps/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
+"typescript@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
   languageName: node
   linkType: hard

--- a/e2e/typescript-coverage/package.json
+++ b/e2e/typescript-coverage/package.json
@@ -7,6 +7,6 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/e2e/typescript-coverage/yarn.lock
+++ b/e2e/typescript-coverage/yarn.lock
@@ -9,26 +9,26 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
-"typescript@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
+"typescript@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
   languageName: node
   linkType: hard

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,7 +15,7 @@
     "core-js": "^3.2.1",
     "rxjs": "^7.5.5",
     "tslib": "^2.0.0",
-    "typescript": "^4.7.2",
+    "typescript": "^4.7.3",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "^17.0.1",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "@crowdin/cli": "^3.5.2",
     "@jest/globals": "workspace:*",
     "@jest/test-utils": "workspace:*",
-    "@microsoft/api-extractor": "^7.23.0",
+    "@microsoft/api-extractor": "^7.24.0",
     "@tsconfig/node12": "^1.0.9",
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.0.0",
     "@types/babel__template": "^7.0.2",
@@ -81,7 +81,7 @@
     "throat": "^6.0.1",
     "ts-node": "^10.5.0",
     "type-fest": "^2.11.2",
-    "typescript": "^4.7.2",
+    "typescript": "^4.7.3",
     "which": "^2.0.1"
   },
   "scripts": {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "chalk": "^4.0.0",
     "fast-check": "^3.0.0",
     "immutable": "^4.0.0",

--- a/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dependencies/package.json
+++ b/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript_in_dev_dependencies",
   "devDependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dev-dependencies/package.json
+++ b/packages/jest-cli/src/init/__tests__/fixtures/typescript-in-dev-dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "only-package-json",
   "dependencies": {
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   }
 }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -58,7 +58,7 @@
     "@types/micromatch": "^4.0.1",
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
-    "typescript": "^4.7.2"
+    "typescript": "^4.7.3"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -21,7 +21,7 @@
     "jest-snapshot": "^28.1.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "tsd-lite": "^0.5.1"
   },
   "engines": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -21,7 +21,7 @@
     "@types/node": "*"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "tsd-lite": "^0.5.1"
   },
   "engines": {

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/exit": "^0.1.30",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -28,7 +28,7 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/graceful-fs": "^4.1.3",
     "@types/pnpapi": "^0.0.2",
     "@types/resolve": "^1.20.2",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -40,7 +40,7 @@
     "throat": "^6.0.1"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.3",
     "@types/source-map-support": "^0.5.0",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-flow": "^7.7.2",
     "@babel/preset-react": "^7.12.1",
     "@jest/test-utils": "^28.1.0",
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
     "@types/semver": "^7.1.0",

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "tsd-lite": "^0.5.1"
   },
   "publishConfig": {

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -22,7 +22,7 @@
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",
     "get-stream": "^6.0.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -19,7 +19,7 @@
     "jest-cli": "^28.1.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.2",
+    "@tsd/typescript": "~4.7.3",
     "tsd-lite": "^0.5.1"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,7 +2623,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect@workspace:packages/jest-expect"
   dependencies:
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     expect: ^28.1.0
     jest-snapshot: ^28.1.0
     tsd-lite: ^0.5.1
@@ -2668,9 +2668,9 @@ __metadata:
     "@crowdin/cli": ^3.5.2
     "@jest/globals": "workspace:*"
     "@jest/test-utils": "workspace:*"
-    "@microsoft/api-extractor": ^7.23.0
+    "@microsoft/api-extractor": ^7.24.0
     "@tsconfig/node12": ^1.0.9
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/babel__core": ^7.1.14
     "@types/babel__generator": ^7.0.0
     "@types/babel__template": ^7.0.2
@@ -2737,7 +2737,7 @@ __metadata:
     throat: ^6.0.1
     ts-node: ^10.5.0
     type-fest: ^2.11.2
-    typescript: ^4.7.2
+    typescript: ^4.7.3
     which: ^2.0.1
   languageName: unknown
   linkType: soft
@@ -2753,7 +2753,7 @@ __metadata:
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
     "@jridgewell/trace-mapping": ^0.3.7
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/exit": ^0.1.30
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.3
@@ -2885,7 +2885,7 @@ __metadata:
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
     "@jest/schemas": ^28.0.2
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
@@ -3823,7 +3823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor@npm:^7.23.0":
+"@microsoft/api-extractor@npm:^7.24.0":
   version: 7.24.2
   resolution: "@microsoft/api-extractor@npm:7.24.2"
   dependencies:
@@ -4753,13 +4753,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsd/typescript@npm:~4.7.2":
-  version: 4.7.2
-  resolution: "@tsd/typescript@npm:4.7.2"
+"@tsd/typescript@npm:~4.7.3":
+  version: 4.7.3
+  resolution: "@tsd/typescript@npm:4.7.3"
   bin:
     tsc: typescript/bin/tsc
     tsserver: typescript/bin/tsserver
-  checksum: 4629ebaec168063d2b148e4981807a90ee678c5255cc6d98cf03e954bb8cea67c8935c4630b0798dc3c98f51a5fc85c20c2cbad7617a403c8607f73fbf4a984b
+  checksum: 18f7537b883ee9ccf697938ff7cbc042cc6137c1b473d4d36dabf68eca1c6190fbfb6dad0f2b0f7f71bff66a1518295cb1e01731f8fbaf678cf5c3d6e363fdb9
   languageName: node
   linkType: hard
 
@@ -6176,7 +6176,7 @@ __metadata:
     jest-zone-patch: "*"
     rxjs: ^7.5.5
     tslib: ^2.0.0
-    typescript: ^4.7.2
+    typescript: ^4.7.3
     zone.js: ~0.11.3
   languageName: unknown
   linkType: soft
@@ -10241,7 +10241,7 @@ __metadata:
     jest: "workspace:*"
     react: 17.0.2
     react-dom: ^17.0.1
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   languageName: unknown
   linkType: soft
 
@@ -10305,7 +10305,7 @@ __metadata:
   dependencies:
     "@jest/expect-utils": ^28.1.0
     "@jest/test-utils": ^28.1.0
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     chalk: ^4.0.0
     fast-check: ^3.0.0
     immutable: ^4.0.0
@@ -13152,7 +13152,7 @@ __metadata:
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
-    typescript: ^4.7.2
+    typescript: ^4.7.3
   peerDependencies:
     "@types/node": "*"
     ts-node: ">=9.0.0"
@@ -13407,7 +13407,7 @@ __metadata:
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/node": "*"
     tsd-lite: ^0.5.1
   languageName: unknown
@@ -13489,7 +13489,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-resolve@workspace:packages/jest-resolve"
   dependencies:
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/graceful-fs": ^4.1.3
     "@types/pnpapi": ^0.0.2
     "@types/resolve": ^1.20.2
@@ -13529,7 +13529,7 @@ __metadata:
     "@jest/test-result": ^28.1.0
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/exit": ^0.1.30
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
@@ -13623,7 +13623,7 @@ __metadata:
     "@jest/test-utils": ^28.1.0
     "@jest/transform": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/babel__traverse": ^7.0.6
     "@types/graceful-fs": ^4.1.3
     "@types/natural-compare": ^1.4.0
@@ -13782,7 +13782,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-worker@workspace:packages/jest-worker"
   dependencies:
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"
     "@types/supports-color": ^8.1.0
@@ -13832,7 +13832,7 @@ __metadata:
   dependencies:
     "@jest/core": ^28.1.0
     "@jest/types": ^28.1.0
-    "@tsd/typescript": ~4.7.2
+    "@tsd/typescript": ~4.7.3
     import-local: ^3.0.2
     jest-cli: ^28.1.0
     tsd-lite: ^0.5.1
@@ -21646,13 +21646,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.2":
-  version: 4.7.2
-  resolution: "typescript@npm:4.7.2"
+"typescript@npm:^4.7.3":
+  version: 4.7.3
+  resolution: "typescript@npm:4.7.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 5163585e6b56410f77d5483b698d9489bbee8902c99029eb70cf6d21525a186530ce19a00951af84eefd4a131cc51d0959f5118e25e70ab61f45ac4057dbd1ef
+  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
   languageName: node
   linkType: hard
 
@@ -21666,13 +21666,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.2#~builtin<compat/typescript>":
-  version: 4.7.2
-  resolution: "typescript@patch:typescript@npm%3A4.7.2#~builtin<compat/typescript>::version=4.7.2&hash=7ad353"
+"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
+  version: 4.7.3
+  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7e2b9a9f4a70fb7616f1b0d986977f8e34a74f046202fa7f24fdee79589598277810fa216b3776c20c0683a9235872c73be34fdb93f67f98c1efaca40999422f
+  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Just a quick refresh. See https://github.com/microsoft/TypeScript/releases/tag/v4.7.3

## Test plan

Green CI.