### PR TITLE
chore(@jest/types): mark `collectCoverageOnlyFrom` and `coveragePathIgnorePatterns` options deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[docs]` Document the comments used by coverage providers [#12835](https://github.com/facebook/jest/issues/12835)
 - `[docs]` Use `docusaurus-remark-plugin-tab-blocks` to format tabs with code examples ([#12859](https://github.com/facebook/jest/pull/12859))
 - `[jest-haste-map]` Bump `walker` version ([#12324](https://github.com/facebook/jest/pull/12324))
+- `[@jest/types]` Mark `collectCoverageOnlyFrom` and `coveragePathIgnorePatterns` options as deprecated ([#12914](https://github.com/facebook/jest/pull/12914))
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -265,14 +265,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -194,9 +194,9 @@ If you use GitHub Actions, you can use [`github-actions-cpu-cores`](https://gith
 
 Another thing you can do is use the [`shard`](CLI.md#--shard) flag to parallelize the test run across multiple machines.
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/docs/WatchPlugins.md
+++ b/docs/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -231,10 +231,12 @@ export type InitialOptions = Partial<{
   changedSince: string;
   collectCoverage: boolean;
   collectCoverageFrom: Array<string>;
+  /** @deprecated Use `collectCoverageFrom` option instead */
   collectCoverageOnlyFrom: {
     [key: string]: boolean;
   };
   coverageDirectory: string;
+  /** @deprecated Use `collectCoverageFrom` option instead */
   coveragePathIgnorePatterns: Array<string>;
   coverageProvider: CoverageProvider;
   coverageReporters: CoverageReporters;

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -205,14 +205,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/website/versioned_docs/version-25.x/Troubleshooting.md
+++ b/website/versioned_docs/version-25.x/Troubleshooting.md
@@ -180,9 +180,9 @@ jest --maxWorkers=4
 yarn test --maxWorkers=4
 ```
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/website/versioned_docs/version-25.x/WatchPlugins.md
+++ b/website/versioned_docs/version-25.x/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -210,14 +210,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/website/versioned_docs/version-26.x/Troubleshooting.md
+++ b/website/versioned_docs/version-26.x/Troubleshooting.md
@@ -180,9 +180,9 @@ jest --maxWorkers=4
 yarn test --maxWorkers=4
 ```
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/website/versioned_docs/version-26.x/WatchPlugins.md
+++ b/website/versioned_docs/version-26.x/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -210,14 +210,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/website/versioned_docs/version-27.x/Troubleshooting.md
+++ b/website/versioned_docs/version-27.x/Troubleshooting.md
@@ -180,9 +180,9 @@ jest --maxWorkers=4
 yarn test --maxWorkers=4
 ```
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/website/versioned_docs/version-27.x/WatchPlugins.md
+++ b/website/versioned_docs/version-27.x/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)

--- a/website/versioned_docs/version-28.0/Configuration.md
+++ b/website/versioned_docs/version-28.0/Configuration.md
@@ -222,14 +222,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/website/versioned_docs/version-28.0/Troubleshooting.md
+++ b/website/versioned_docs/version-28.0/Troubleshooting.md
@@ -194,9 +194,9 @@ If you use GitHub Actions, you can use [`github-actions-cpu-cores`](https://gith
 
 Another thing you can do is use the [`shard`](CLI.md#--shard) flag to parallelize the test run across multiple machines.
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/website/versioned_docs/version-28.0/WatchPlugins.md
+++ b/website/versioned_docs/version-28.0/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)

--- a/website/versioned_docs/version-28.1/Configuration.md
+++ b/website/versioned_docs/version-28.1/Configuration.md
@@ -222,14 +222,6 @@ Default: `undefined`
 
 The directory where Jest should output its coverage files.
 
-### `coveragePathIgnorePatterns` \[array&lt;string&gt;]
-
-Default: `["/node_modules/"]`
-
-An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
-
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/", "<rootDir>/node_modules/"]`.
-
 ### `coverageProvider` \[string]
 
 Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.

--- a/website/versioned_docs/version-28.1/Troubleshooting.md
+++ b/website/versioned_docs/version-28.1/Troubleshooting.md
@@ -194,9 +194,9 @@ If you use GitHub Actions, you can use [`github-actions-cpu-cores`](https://gith
 
 Another thing you can do is use the [`shard`](CLI.md#--shard) flag to parallelize the test run across multiple machines.
 
-## `coveragePathIgnorePatterns` seems to not have any effect.
+## Negated glob patterns in the `collectCoverageFrom` list seem to not have any effect.
 
-Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by the negated glob patterns in the `collectCoverageFrom` list.
 
 ## Defining Tests
 

--- a/website/versioned_docs/version-28.1/WatchPlugins.md
+++ b/website/versioned_docs/version-28.1/WatchPlugins.md
@@ -157,7 +157,6 @@ For stability and safety reasons, only part of the global configuration keys can
 - [`changedSince`](cli#--changedsince)
 - [`collectCoverage`](configuration#collectcoverage-boolean)
 - [`collectCoverageFrom`](configuration#collectcoveragefrom-array)
-- [`collectCoverageOnlyFrom`](configuration#collectcoverageonlyfrom-array)
 - [`coverageDirectory`](configuration#coveragedirectory-string)
 - [`coverageReporters`](configuration#coveragereporters-arraystring)
 - [`notify`](configuration#notify-boolean)


### PR DESCRIPTION
Reference https://github.com/facebook/jest/pull/1349#issuecomment-236773488
Reference https://github.com/facebook/jest/issues/1536#issuecomment-247236563
Related to #7185

## Summary

Just thinking out loud. The documentation for `collectCoverageOnlyFrom` was removed in #1724. Looking at referenced comments, it seems like there was a plan to remove the option as well after adding `collectCoverageFrom`.

The regex / glob overlap between `coveragePathIgnorePatterns` and `collectCoverageFrom` was also questioned in the comments.

I am not against any of the options (; Only trying to understand: if they should be documented properly or should be marked `@deprecated` and removed with the next major?

## Test plan

Green CI.