### PR TITLE
chore: replace `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes`

### DIFF
--- a/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
@@ -1,18 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`can press "p" to filter by file name 1`] = `
-
+"<hideCursor>
+<clearTerminal>
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a filenames regex pattern.
 
- pattern › 
- pattern › b
- pattern › ba
- pattern › bar
+<showCursor>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › 
+<saveCursorPosition>
+<moveCursorToRow6Column12>
+<restoreCursorPosition>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › b
+<saveCursorPosition>
+<moveCursorToRow6Column13>
+<restoreCursorPosition>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › ba
+<saveCursorPosition>
+<moveCursorToRow6Column14>
+<restoreCursorPosition>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › bar
+<saveCursorPosition>
+<moveCursorToRow6Column15>
+<restoreCursorPosition>
 
-
-
+<moveCursorDownBy1Row>
+<eraseScreenDown>
+"
 `;
 
 exports[`can press "p" to filter by file name: test results 1`] = `
@@ -43,16 +70,31 @@ Ran all test suites matching /bar/i."
 `;
 
 exports[`can press "t" to filter by test name 1`] = `
-
+"<hideCursor>
+<clearTerminal>
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a tests regex pattern.
 
- pattern › 
- pattern › 2
+<showCursor>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › 
+<saveCursorPosition>
+<moveCursorToRow6Column12>
+<restoreCursorPosition>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
+ pattern › 2
+<saveCursorPosition>
+<moveCursorToRow6Column13>
+<restoreCursorPosition>
 
-
-
+<moveCursorDownBy1Row>
+<eraseScreenDown>
+"
 `;
 
 exports[`can press "t" to filter by test name: test results 1`] = `

--- a/e2e/__tests__/watchModeOnlyFailed.test.ts
+++ b/e2e/__tests__/watchModeOnlyFailed.test.ts
@@ -16,11 +16,6 @@ const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
-expect.addSnapshotSerializer({
-  print: val => (val as string).replace(/\[s\[u/g, '\n'),
-  test: val => typeof val === 'string' && val.includes('[s[u'),
-});
-
 const setupFiles = (input: Array<{keys: Array<string>}>) => {
   writeFiles(DIR, {
     '__tests__/bar.spec.js': `

--- a/e2e/__tests__/watchModePatterns.test.ts
+++ b/e2e/__tests__/watchModePatterns.test.ts
@@ -16,11 +16,6 @@ const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
-expect.addSnapshotSerializer({
-  print: val => (val as string).replace(/\[s\[u/g, '\n'),
-  test: val => typeof val === 'string' && val.includes('[s[u'),
-});
-
 const setupFiles = (input: Array<{keys: Array<string>}>) => {
   writeFiles(DIR, {
     '__tests__/bar.spec.js': `

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -35,7 +35,7 @@ export default {
   snapshotFormat: {
     escapeString: false,
   },
-  snapshotSerializers: [require.resolve('pretty-format/ConvertAnsi')],
+  snapshotSerializers: [require.resolve('jest-serializer-ansi-escapes')],
   testPathIgnorePatterns: [
     '/__arbitraries__/',
     '/__benchmarks__/',

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "jest-junit": "^13.0.0",
     "jest-mock": "workspace:*",
     "jest-runner-tsd": "^3.0.1",
+    "jest-serializer-ansi-escapes": "^1.0.0",
     "jest-silent-reporter": "^0.5.0",
     "jest-snapshot": "workspace:*",
     "jest-watch-typeahead": "^1.1.0",

--- a/packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js
+++ b/packages/jest-core/src/__tests__/SnapshotInteractiveMode.test.js
@@ -9,23 +9,6 @@ import chalk from 'chalk';
 import {KEYS} from 'jest-watcher';
 import SnapshotInteractiveMode from '../SnapshotInteractiveMode';
 
-jest
-  .mock('ansi-escapes', () => ({
-    cursorRestorePosition: '[MOCK - cursorRestorePosition]',
-    cursorSavePosition: '[MOCK - cursorSavePosition]',
-    cursorScrollDown: '[MOCK - cursorScrollDown]',
-    cursorTo: (x, y) => `[MOCK - cursorTo(${x}, ${y})]`,
-    cursorUp: () => '[MOCK - cursorUp]',
-    eraseDown: '[MOCK - eraseDown]',
-  }))
-  .mock('jest-util', () => {
-    const {specialChars, ...util} = jest.requireActual('jest-util');
-    return {
-      ...util,
-      specialChars: {...specialChars, CLEAR: '[MOCK - clear]'},
-    };
-  });
-
 jest.doMock('chalk', () =>
   Object.assign(new chalk.Instance({level: 0}), {
     stripColor: str => str,

--- a/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SnapshotInteractiveMode skip 1 test, then quit 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -16,7 +16,7 @@ exports[`SnapshotInteractiveMode skip 1 test, then quit 1`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then quit 2`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>1 snapshot reviewed</></>, <bold><yellow>1 snapshot skipped</></>
@@ -28,8 +28,8 @@ exports[`SnapshotInteractiveMode skip 1 test, then quit 2`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then restart 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -43,7 +43,7 @@ exports[`SnapshotInteractiveMode skip 1 test, then restart 1`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then restart 2`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>1 snapshot reviewed</></>, <bold><yellow>1 snapshot skipped</></>
@@ -55,8 +55,8 @@ exports[`SnapshotInteractiveMode skip 1 test, then restart 2`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then restart 3`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -70,8 +70,8 @@ exports[`SnapshotInteractiveMode skip 1 test, then restart 3`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and restart 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>2 snapshots remaining</></>
@@ -85,8 +85,8 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and restart 2`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>, <bold><yellow>1 snapshot skipped</></>
@@ -100,7 +100,7 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and restart 3`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>2 snapshots reviewed</></>, <bold><green>1 snapshot updated</></>, <bold><yellow>1 snapshot skipped</></>
@@ -112,8 +112,8 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and restart 4`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -127,8 +127,8 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>2 snapshots remaining</></>
@@ -142,8 +142,8 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 1`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 2`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>, <bold><yellow>1 snapshot skipped</></>
@@ -157,7 +157,7 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 2`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 3`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>2 snapshots reviewed</></>, <bold><yellow>2 snapshots skipped</></>
@@ -169,8 +169,8 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 3`] = `
 `;
 
 exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 4`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>2 snapshots remaining</></>
@@ -184,8 +184,8 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 4`] = `
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and restart 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>2 snapshots remaining</></>
@@ -199,8 +199,8 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and restart 2`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>, <bold><green>1 snapshot updated</></>
@@ -214,7 +214,7 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and restart 3`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>2 snapshots reviewed</></>, <bold><green>1 snapshot updated</></>, <bold><yellow>1 snapshot skipped</></>
@@ -226,8 +226,8 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and restart 4`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -241,8 +241,8 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, then finish and return 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>
@@ -256,7 +256,7 @@ exports[`SnapshotInteractiveMode update 1 test, then finish and return 1`] = `
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, then finish and return 2`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>1 snapshot reviewed</></>, <bold><green>1 snapshot updated</></>
@@ -267,8 +267,8 @@ exports[`SnapshotInteractiveMode update 1 test, then finish and return 2`] = `
 `;
 
 exports[`SnapshotInteractiveMode update 2 tests, then finish and return 1`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>2 snapshots remaining</></>
@@ -282,8 +282,8 @@ exports[`SnapshotInteractiveMode update 2 tests, then finish and return 1`] = `
 `;
 
 exports[`SnapshotInteractiveMode update 2 tests, then finish and return 2`] = `
-"[MOCK - cursorUp]
-[MOCK - eraseDown]
+"<moveCursorUpBy6Rows>
+<eraseScreenDown>
 
 <bold>Interactive Snapshot Progress</>
  › <bold><dim>1 snapshot remaining</></>, <bold><green>1 snapshot updated</></>
@@ -297,7 +297,7 @@ exports[`SnapshotInteractiveMode update 2 tests, then finish and return 2`] = `
 `;
 
 exports[`SnapshotInteractiveMode update 2 tests, then finish and return 3`] = `
-"[MOCK - clear]
+"<clearTerminal>
 
 <bold>Interactive Snapshot Result</>
  › <bold><dim>2 snapshots reviewed</></>, <bold><green>2 snapshots updated</></>

--- a/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
@@ -1,83 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 1`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(12, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column13>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 2`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(13, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column14>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 3`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(14, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column15>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 4`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*1
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(15, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column16>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 5`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*10
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(16, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column17>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 6`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*1
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(15, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column16>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 7`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(14, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column15>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 8`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › p.*3
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(15, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column16>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 9`] = `
@@ -91,20 +99,21 @@ Object {
 `;
 
 exports[`Watch mode flows Pressing "c" clears the filters 1`] = `
-"[MOCK - cursorHide]
-[MOCK - clear]
+"<hideCursor>
+<clearTerminal>
 
 <bold>Pattern Mode Usage</>
  <dim>› Press</> Esc <dim>to exit pattern mode.</>
  <dim>› Press</> Enter <dim>to filter by a filenames regex pattern.</>
 
 
-[MOCK - cursorShow]
-
-
-
+<showCursor>
+<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › 
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(11, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column12>
+<restoreCursorPosition>
+"
 `;

--- a/packages/jest-core/src/__tests__/__snapshots__/watchTestNamePatternMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watchTestNamePatternMode.test.js.snap
@@ -1,91 +1,100 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 1`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › c
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(12, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column13>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 2`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › co
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(13, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column14>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 3`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(14, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column15>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 4`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con 
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(15, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column16>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 5`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con 1
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(16, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column17>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 6`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con 12
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(17, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column18>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 7`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con 1
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(16, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column17>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 8`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con 
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(15, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column16>
+<restoreCursorPosition>
+"
 `;
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 9`] = `
-"
-
-
+"<eraseLine>
+<moveCursorToColumn1>
+<eraseScreenDown>
  pattern › con *
-[MOCK - cursorSavePosition]
-[MOCK - cursorTo(16, 5)]
-[MOCK - cursorRestorePosition]"
+<saveCursorPosition>
+<moveCursorToRow6Column17>
+<restoreCursorPosition>
+"
 `;

--- a/packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js
+++ b/packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js
@@ -12,23 +12,6 @@ import {KEYS} from 'jest-watcher';
 
 const runJestMock = jest.fn();
 
-jest
-  .mock('ansi-escapes', () => ({
-    cursorDown: (count = 1) => `[MOCK - cursorDown(${count})]`,
-    cursorHide: '[MOCK - cursorHide]',
-    cursorRestorePosition: '[MOCK - cursorRestorePosition]',
-    cursorSavePosition: '[MOCK - cursorSavePosition]',
-    cursorShow: '[MOCK - cursorShow]',
-    cursorTo: (x, y) => `[MOCK - cursorTo(${x}, ${y})]`,
-  }))
-  .mock('jest-util', () => {
-    const {specialChars, ...util} = jest.requireActual('jest-util');
-    return {
-      ...util,
-      specialChars: {...specialChars, CLEAR: '[MOCK - clear]'},
-    };
-  });
-
 jest.mock(
   '../SearchSource',
   () =>

--- a/packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js
+++ b/packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js
@@ -12,23 +12,6 @@ import {KEYS} from 'jest-watcher';
 
 const runJestMock = jest.fn();
 
-jest
-  .mock('ansi-escapes', () => ({
-    cursorDown: (count = 1) => `[MOCK - cursorDown(${count})]`,
-    cursorHide: '[MOCK - cursorHide]',
-    cursorRestorePosition: '[MOCK - cursorRestorePosition]',
-    cursorSavePosition: '[MOCK - cursorSavePosition]',
-    cursorShow: '[MOCK - cursorShow]',
-    cursorTo: (x, y) => `[MOCK - cursorTo(${x}, ${y})]`,
-  }))
-  .mock('jest-util', () => {
-    const {specialChars, ...util} = jest.requireActual('jest-util');
-    return {
-      ...util,
-      specialChars: {...specialChars, CLEAR: '[MOCK - clear]'},
-    };
-  });
-
 jest.mock(
   '../SearchSource',
   () =>

--- a/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
@@ -31,8 +31,8 @@ hththththt
 hthththtet
 etetetette
 tetetetete
-tetete<bold>stnh
-snthsnth</>ss
+tetete<underline><bold>stnh
+snthsnth</></>ss
 ot"
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2711,6 +2711,7 @@ __metadata:
     jest-junit: ^13.0.0
     jest-mock: "workspace:*"
     jest-runner-tsd: ^3.0.1
+    jest-serializer-ansi-escapes: ^1.0.0
     jest-silent-reporter: ^0.5.0
     jest-snapshot: "workspace:*"
     jest-watch-typeahead: ^1.1.0
@@ -13587,6 +13588,13 @@ __metadata:
     strip-bom: ^4.0.0
   languageName: unknown
   linkType: soft
+
+"jest-serializer-ansi-escapes@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "jest-serializer-ansi-escapes@npm:1.0.1"
+  checksum: 9cf71b090d27b45a7237247feebb556c474cafc52d12c0e5c49b08a5b871dec6046a83343e148eb607f2e6eb901513946347c08708ff35b0daf514085d599c65
+  languageName: node
+  linkType: hard
 
 "jest-serializer@npm:^27.5.1":
   version: 27.5.1


### PR DESCRIPTION
## Summary

For one project I needed to have snapshots with ANSI colors. `pretty-format/ConvertAnsi` serialiser was not working in this case, because it is only replacing ANSI escapes originating from `ansi-styles` (also used by `chalk`). In other words, in the project I have sequences like `'\u001b[1;31mSample text'` (bold and red), but in similar case `ansi-styles` would emit `\u001b[1m\u001b[31mSample text`.

After writing a serialiser for vanilla ANSI escapes, I wanted to tryout out on Jest repo. It did not work with cursor control sequences. Oh.. That’s niche case, but interesting one! So the serialiser is now replacing cursor controls as well: `<eraseLine>`, `<moveCursorToColumn1>`, etc. See the snapshots for more.

---

This is how `jest-serializer-ansi-escapes` was born. Looks useful. Opening a PR to hear some feedback (;

## Test plan

Green CI.