### PR TITLE
feat(expect): add toBeTrue and toBeFalse matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+`[expect]` Include `.toBeTrue` and `.toBeFalse` matchers. ([#12970](https://github.com/facebook/jest/pull/12970))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1031,6 +1031,24 @@ test('there is a new flavor idea', () => {
 
 You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeFalse()`
+
+Use `.toBeFalse` when you need to verify if some value is false (deep equality). For example, let's say you have some application code that looks like:
+
+```js
+function isGreatherThanEleven(a, b) {
+  return a + b > 11;
+}
+```
+
+You could write the test like this:
+
+```js
+test('4 + 8 is not greather than eleven', () => {
+  expect(isGreatherThanEleven(4, 4)).toBeFalse();
+});
+```
+
 ### `.toBeFalsy()`
 
 Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
@@ -1116,6 +1134,24 @@ function bloop() {
 
 test('bloop returns null', () => {
   expect(bloop()).toBeNull();
+});
+```
+
+### `.toBeTrue()`
+
+Use `.toBeTrue` when you need to verify if some value is true (deep equality). For example, let's say you have some application code that looks like:
+
+```js
+function isGreatherThanEleven(a, b) {
+  return a + b > 11;
+}
+```
+
+You could write the test like this:
+
+```js
+test('4 + 8 is greather than eleven', () => {
+  expect(isGreatherThanEleven(4, 8)).toBeTrue();
 });
 ```
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1596,6 +1596,36 @@ exports[`.toBeNull() fails for null with .not 1`] = `
 Received: <r>null</>
 `;
 
+exports[`.toBeTrue(), .toBeFalse does not accept arguments 1`] = `
+<d>expect(</><r>received</><d>).</>toBeTrue<d>()</>
+
+<b>Matcher error</>: this matcher must not have an expected argument
+
+Expected has type:  boolean
+Expected has value: <g>true</>
+`;
+
+exports[`.toBeTrue(), .toBeFalse does not accept arguments 2`] = `
+<d>expect(</><r>received</><d>).</>toBeFalse<d>()</>
+
+<b>Matcher error</>: this matcher must not have an expected argument
+
+Expected has type:  boolean
+Expected has value: <g>false</>
+`;
+
+exports[`.toBeTrue(), .toBeFalse fails for false with .not 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalse<d>()</>
+
+Received: <r>false</>
+`;
+
+exports[`.toBeTrue(), .toBeFalse fails for true with .not 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTrue<d>()</>
+
+Received: <r>true</>
+`;
+
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 1`] = `
 <d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
@@ -1618,6 +1648,18 @@ exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 2`] = `
 <d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
 Received: <r>"a"</>
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() '"teste"' is truthy 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
+
+Received: <r>"teste"</>
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() '"teste"' is truthy 2`] = `
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
+
+Received: <r>"teste"</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1138,6 +1138,36 @@ describe('.toBeInstanceOf()', () => {
   });
 });
 
+describe('.toBeTrue(), .toBeFalse', () => {
+  it('does not accept arguments', () => {
+    expect(() => jestExpect(0).toBeTrue(true)).toThrowErrorMatchingSnapshot();
+
+    expect(() => jestExpect(0).toBeFalse(false)).toThrowErrorMatchingSnapshot();
+  });
+
+  it(`${stringify(true)} is true`, () => {
+    jestExpect(true).toBeTrue();
+    jestExpect(true).not.toBeFalse();
+  });
+
+  it(`${stringify(false)} is false`, () => {
+    jestExpect(false).toBeFalse();
+    jestExpect(false).not.toBeTrue();
+  });
+
+  it('fails for true with .not', () => {
+    expect(() =>
+      jestExpect(true).not.toBeTrue(),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('fails for false with .not', () => {
+    expect(() =>
+      jestExpect(false).not.toBeFalse(),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
 describe('.toBeTruthy(), .toBeFalsy()', () => {
   it('does not accept arguments', () => {
     expect(() => jestExpect(0).toBeTruthy(null)).toThrowErrorMatchingSnapshot();

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -215,6 +215,25 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
+  toBeFalse(received: unknown, expected: unknown) {
+    const matcherName = 'toBeFalse';
+    const options: MatcherHintOptions = {
+      isNot: this.isNot,
+      promise: this.promise,
+    };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = received === false;
+
+    const message = () =>
+      // eslint-disable-next-line prefer-template
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return {message, pass};
+  },
+
   toBeFalsy(received: unknown, expected: void) {
     const matcherName = 'toBeFalsy';
     const options: MatcherHintOptions = {
@@ -398,6 +417,25 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, matcherName, options);
 
     const pass = received === null;
+
+    const message = () =>
+      // eslint-disable-next-line prefer-template
+      matcherHint(matcherName, undefined, '', options) +
+      '\n\n' +
+      `Received: ${printReceived(received)}`;
+
+    return {message, pass};
+  },
+
+  toBeTrue(received: unknown, expected: unknown) {
+    const matcherName = 'toBeTrue';
+    const options: MatcherHintOptions = {
+      isNot: this.isNot,
+      promise: this.promise,
+    };
+    ensureNoExpected(expected, matcherName, options);
+
+    const pass = received === true;
 
     const message = () =>
       // eslint-disable-next-line prefer-template

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -167,6 +167,11 @@ export interface Matchers<R extends void | Promise<void>> {
    */
   toBeDefined(): R;
   /**
+   * This is the same as `.toBe(false)` but the error messages are a bit nicer.
+   * So use `.toBeFalse()` when you want to check that something is false.
+   */
+  toBeFalse(): R;
+  /**
    * When you don't care what a value is, you just want to
    * ensure a value is false in a boolean context.
    */
@@ -201,6 +206,11 @@ export interface Matchers<R extends void | Promise<void>> {
    * So use `.toBeNull()` when you want to check that something is null.
    */
   toBeNull(): R;
+  /**
+   * This is the same as `.toBe(true)` but the error messages are a bit nicer.
+   * So use `.toBeTrue()` when you want to check that something is true.
+   */
+  toBeTrue(): R;
   /**
    * Use when you don't care what a value is, you just want to ensure a value
    * is true in a boolean context. In JavaScript, there are six falsy values:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I've been working with Jest at about 1 year, and some projects that i worked, i could see some tests that people are writing tests with "unsafe" asserts, for example:

```js
function hasNameProperty(obj) {
    return obj.hasOwnProperty('name')
}
```

And the test: 

```js
test('if the object has name property', {
    const obj = { name: 'Hugo', age: 20 }

    expect(hasNameProperty(obj)).toBeTruthy();
})
```

In this example, we've a simple scenario, but basically it need to check if the `hasNameProperty` function return a boolean value `true`. But with the test above, if the function returns an other true value in a boolean context (everything, except `false`, `0`, `''`, `null`, `undefined`, and `NaN`), then test will pass even with wrong value that was returned.

At the moment, to ensure that a function or value is true or false (deep equality), users need to use `.toBe` matcher and provide a value as argument.

Now, with `.toBeTrue` and `.toBeFalse` matchers, i think it will help people to ensure correctly the statements, in a more explicit way and avoid "false positive" tests.