### PR TITLE
feat(jest-leak-detector): use FinalizationRegistry when it exists to get rid of external dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-leak-detector]` Use native `FinalizationRegistry` when it exists to get rid of external C dependency ([#12973](https://github.com/facebook/jest/pull/12973))
+
 ### Fixes
 
 -`[jest-runtime]` Avoid star type import from `@jest/globals` ([#12949](https://github.com/facebook/jest/pull/12949))

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+/// <reference lib="es2021.WeakRef" />
 
 import {promisify} from 'util';
 import {setFlagsFromString} from 'v8';
@@ -15,6 +16,7 @@ const tick = promisify(setImmediate);
 
 export default class LeakDetector {
   private _isReferenceBeingHeld: boolean;
+  private _finalizationRegistry?: FinalizationRegistry<undefined>;
 
   constructor(value: unknown) {
     if (isPrimitive(value)) {
@@ -26,23 +28,36 @@ export default class LeakDetector {
       );
     }
 
-    let weak: typeof import('weak-napi');
+    // TODO: Remove the `if` and `weak-napi` when we drop node 12, as v14 supports FinalizationRegistry
+    if (globalThis.FinalizationRegistry) {
+      // When `_finalizationRegistry` is GCed the callback we set will no longer be called,
+      // so we need to assign it to `this` to keep it referenced
+      this._finalizationRegistry = new FinalizationRegistry(() => {
+        this._isReferenceBeingHeld = false;
+      });
 
-    try {
-      // eslint-disable-next-line import/no-extraneous-dependencies
-      weak = require('weak-napi');
-    } catch (err: any) {
-      if (!err || err.code !== 'MODULE_NOT_FOUND') {
-        throw err;
+      this._finalizationRegistry.register(value as object, undefined);
+    } else {
+      let weak: typeof import('weak-napi');
+
+      try {
+        // eslint-disable-next-line import/no-extraneous-dependencies
+        weak = require('weak-napi');
+      } catch (err: any) {
+        if (!err || err.code !== 'MODULE_NOT_FOUND') {
+          throw err;
+        }
+
+        throw new Error(
+          'The leaking detection mechanism requires newer version of node that supports ' +
+            'FinalizationRegistry, update your node or install the "weak-napi" package' +
+            'which support current node version as a dependency on your main project.',
+        );
       }
 
-      throw new Error(
-        'The leaking detection mechanism requires the "weak-napi" package to be installed and work. ' +
-          'Please install it as a dependency on your main project',
-      );
+      weak(value as object, () => (this._isReferenceBeingHeld = false));
     }
 
-    weak(value as object, () => (this._isReferenceBeingHeld = false));
     this._isReferenceBeingHeld = true;
 
     // Ensure value is not leaked by the closure created by the "weak" callback.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
In the past, the leak detector required external dependency 'weak-napi', a C module, to be installed and work. Now since node has supported the FinalizationRegistry from ECMA, we can use this native object when available to reduce external dependency.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Could keep using the existing unit test.
