### PR TITLE
fix(expect-utils): Fix equalityof ImmutableJS OrderedSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedSets ([#12977](https://github.com/facebook/jest/pull/12977))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {List, OrderedMap} from 'immutable';
+import {List, OrderedMap, OrderedSet} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {
   arrayBufferEquality,
@@ -529,6 +529,12 @@ describe('iterableEquality', () => {
   test('returns true when given Immutable OrderedMaps without an OwnerID', () => {
     const a = OrderedMap().set('saving', true);
     const b = OrderedMap().merge({saving: true});
+    expect(iterableEquality(a, b)).toBe(true);
+  });
+
+  test('returns true when given Immutable OrderedSets without an OwnerID', () => {
+    const a = OrderedSet().add('newValue');
+    const b = List(['newValue']).toOrderedSet();
     expect(iterableEquality(a, b)).toBe(true);
   });
 });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -274,3 +274,12 @@ export function isImmutableOrderedKeyed(maybeKeyed: any) {
     maybeKeyed[IS_ORDERED_SENTINEL]
   );
 }
+
+
+export function isImmutableOrderedSet(maybeSet: any) {
+  return !!(
+    maybeSet &&
+    maybeSet[IS_SET_SENTINEL] &&
+    maybeSet[IS_ORDERED_SENTINEL]
+  );
+}

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -12,6 +12,7 @@ import {
   isA,
   isImmutableList,
   isImmutableOrderedKeyed,
+  isImmutableOrderedSet,
   isImmutableUnorderedKeyed,
   isImmutableUnorderedSet,
 } from './jasmineUtils';
@@ -256,7 +257,11 @@ export const iterableEquality = (
     return false;
   }
 
-  if (!isImmutableList(a) && !isImmutableOrderedKeyed(a)) {
+  if (
+    !isImmutableList(a) &&
+    !isImmutableOrderedKeyed(a) &&
+    !isImmutableOrderedSet(a)
+  ) {
     const aEntries = Object.entries(a);
     const bEntries = Object.entries(b);
     if (!equals(aEntries, bEntries)) {


### PR DESCRIPTION
## Summary

Fixes #12976

## Test plan

I added an `iterableEquality` test for two `OrderedSets` that have the same contents, but were not considered equal before this change. This PR follows the changes made in #12899 for a similar issue.
