### PR TITLE
fix(scripts): also check for package.json

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,7 +16,8 @@ function getPackages() {
   const packages = fs
     .readdirSync(PACKAGES_DIR)
     .map(file => path.resolve(PACKAGES_DIR, file))
-    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
+    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory())
+    .filter(f => fs.existsSync(path.join(path.resolve(f), 'package.json')));
   return packages.map(packageDir => {
     const pkg = readPkg({cwd: packageDir});
     return pkg.name;

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -26,7 +26,8 @@ export function getPackages() {
   const packages = fs
     .readdirSync(PACKAGES_DIR)
     .map(file => path.resolve(PACKAGES_DIR, file))
-    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
+    .filter(f => fs.lstatSync(path.resolve(f)).isDirectory())
+    .filter(f => fs.existsSync(path.join(path.resolve(f), 'package.json')));
   const require = createRequire(import.meta.url);
   const rootPackage = require('../package.json');
 


### PR DESCRIPTION
when doing `yarn build` and `git checkout` for old versions
`getPackages` returns false positives, where the package folder exists, but `package.json` is missing