### PR TITLE
Correct await inline snapshot indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[jest-changed-files]` Fix a lock-up after repeated invocations ([#12757](https://github.com/facebook/jest/issues/12757))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedSets ([#12977](https://github.com/facebook/jest/pull/12977))
+- `[jest-snapshot]` Fix indendation of awaited inline snapshots (TBD)
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -7,7 +7,12 @@
 
 import * as path from 'path';
 import type {PluginItem} from '@babel/core';
-import type {Expression, File, Program} from '@babel/types';
+import {
+  type Expression,
+  type File,
+  type Program,
+  isAwaitExpression,
+} from '@babel/types';
 import * as fs from 'graceful-fs';
 import type {
   CustomParser as PrettierCustomParser,
@@ -312,7 +317,7 @@ const createFormattingParser =
 
     const ast = resolveAst(parsers[inferredParser](text, options));
     babelTraverse(ast, {
-      CallExpression({node: {arguments: args, callee}}) {
+      CallExpression({node: {arguments: args, callee}, parent}) {
         if (
           callee.type !== 'MemberExpression' ||
           callee.property.type !== 'Identifier' ||
@@ -336,13 +341,19 @@ const createFormattingParser =
           return;
         }
 
+        const startColumn =
+          isAwaitExpression(parent) && parent.loc
+            ? parent.loc.start.column
+            : callee.loc.start.column;
+
         const useSpaces = !options.useTabs;
         snapshot = indent(
           snapshot,
           Math.ceil(
             useSpaces
-              ? callee.loc.start.column / (options.tabWidth ?? 1)
-              : callee.loc.start.column / 2, // Each tab is 2 characters.
+              ? startColumn / (options.tabWidth ?? 1)
+              : // Each tab is 2 characters.
+                startColumn / 2,
           ),
           useSpaces ? ' '.repeat(options.tabWidth ?? 1) : '\t',
         );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When testing [asynchronous code](https://jestjs.io/docs/asynchronous#asyncawait) using `.resolves`/`.rejects` it is mandatory to `await` the expect. When combined with an inline snapshot, the snapshot is not indented correctly. It is aligned to the `expect` not the `await`.

### Example

```ts
it('is a test', async () => {
  await expect(Promise.resolve({ a: 'a' })).resolves.toMatchInlineSnapshot();
});
```

Currently becomes:

```ts
it('is a test', async () => {
  await expect(Promise.resolve({ a: 'a' })).resolves.toMatchInlineSnapshot(`
          Object {
            "a": "a",
          }
        `);
});
```

After the change:

```ts
it('is a test', async () => {
  await expect(Promise.resolve({ a: 'a' })).resolves.toMatchInlineSnapshot(`
    Object {
      "a": "a",
    }
  `);
});
```

## Test plan

See the unit test in [packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts:633](https://github.com/robinpokorny/jest/blob/correct-await-inline-snapshot-indentation/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts#L633)
