### PR TITLE
docs: minor grammar correction from "as document" to "as documented"

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -7,7 +7,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';

--- a/docs/UpgradingToJest28.md
+++ b/docs/UpgradingToJest28.md
@@ -191,7 +191,7 @@ Known examples of packages that fails in Jest 28 are [`uuid`](https://npmjs.com/
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-28.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.0/MockFunctionAPI.md
@@ -7,7 +7,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-28.0/UpgradingToJest28.md
+++ b/website/versioned_docs/version-28.0/UpgradingToJest28.md
@@ -191,7 +191,7 @@ Known examples of packages that fails in Jest 28 are [`uuid`](https://npmjs.com/
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-28.1/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.1/MockFunctionAPI.md
@@ -7,7 +7,7 @@ Mock functions are also known as "spies", because they let you spy on the behavi
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-28.1/UpgradingToJest28.md
+++ b/website/versioned_docs/version-28.1/UpgradingToJest28.md
@@ -191,7 +191,7 @@ Known examples of packages that fails in Jest 28 are [`uuid`](https://npmjs.com/
 
 :::info
 
-The TypeScript examples from this page will only work as document if you import `jest` from `'@jest/globals'`:
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
 
 ```ts
 import {jest} from '@jest/globals';


### PR DESCRIPTION
## Summary

Minor grammar correction

## Test plan

N/A