### PR TITLE
Update spyOn docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Chore & Maintenance
 
 - `[*]` Replace internal usage of `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes` ([#12935](https://github.com/facebook/jest/pull/12935))
+- `[docs]` Update spyOn docs  ([#4828](https://github.com/facebook/jest/pull/4828))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 ### Chore & Maintenance
 
 - `[*]` Replace internal usage of `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes` ([#12935](https://github.com/facebook/jest/pull/12935), [#13004](https://github.com/facebook/jest/pull/13004))
-- `[docs]` Update spyOn docs  ([#13000](https://github.com/facebook/jest/pull/13000))
+- `[docs]` Update spyOn docs ([#13000](https://github.com/facebook/jest/pull/13000))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Chore & Maintenance
 
 - `[*]` Replace internal usage of `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes` ([#12935](https://github.com/facebook/jest/pull/12935))
-- `[docs]` Update spyOn docs  ([#4828](https://github.com/facebook/jest/pull/4828))
+- `[docs]` Update spyOn docs  ([#13000](https://github.com/facebook/jest/pull/13000))
 
 ### Performance
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -481,7 +481,13 @@ Determines if the given function is a mocked function.
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::note
+ By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
+
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -500,14 +506,16 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
 
   expect(spy).toHaveBeenCalled();
-  expect(isPlaying).toBe(true);
-
-  spy.mockRestore();
+  expect(isPlaying).toBe(true);    
 });
 ```
 
@@ -547,14 +555,16 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
-  expect(isPlaying).toBe(true);
-
-  spy.mockRestore();
+  expect(isPlaying).toBe(true);    
 });
 
 test('plays audio', () => {
@@ -562,9 +572,7 @@ test('plays audio', () => {
   audio.volume = 100;
 
   expect(spy).toHaveBeenCalled();
-  expect(audio.volume).toBe(100);
-
-  spy.mockRestore();
+  expect(audio.volume).toBe(100);    
 });
 ```
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -507,6 +507,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -556,6 +557,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -482,11 +482,15 @@ Determines if the given function is a mocked function.
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
- By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -516,7 +520,7 @@ test('plays video', () => {
   const isPlaying = video.play();
 
   expect(spy).toHaveBeenCalled();
-  expect(isPlaying).toBe(true);    
+  expect(isPlaying).toBe(true);
 });
 ```
 
@@ -566,7 +570,7 @@ test('plays video', () => {
   const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
-  expect(isPlaying).toBe(true);    
+  expect(isPlaying).toBe(true);
 });
 
 test('plays audio', () => {
@@ -574,7 +578,7 @@ test('plays audio', () => {
   audio.volume = 100;
 
   expect(spy).toHaveBeenCalled();
-  expect(audio.volume).toBe(100);    
+  expect(audio.volume).toBe(100);
 });
 ```
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -496,6 +496,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -546,6 +547,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+// restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -469,7 +469,7 @@ Determines if the given function is a mocked function.
 
 ### `jest.spyOn(object, methodName)`
 
-Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md). 
+Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -469,13 +469,18 @@ Determines if the given function is a mocked function.
 
 ### `jest.spyOn(object, methodName)`
 
-Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
+Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md). 
+
 :::note
+
 By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -506,7 +511,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 ```
 
@@ -547,7 +551,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
-// restore the spy created with spyOn
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -557,7 +561,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 
 test('plays audio', () => {
@@ -566,7 +569,6 @@ test('plays audio', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
-
 });
 ```
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -470,8 +470,13 @@ Determines if the given function is a mocked function.
 ### `jest.spyOn(object, methodName)`
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
+:::note
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -490,6 +495,10 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
@@ -497,7 +506,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 ```
 
@@ -537,6 +545,10 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
@@ -544,7 +556,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 
 test('plays audio', () => {
@@ -554,7 +565,6 @@ test('plays audio', () => {
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
 
-  spy.mockRestore();
 });
 ```
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -476,11 +476,15 @@ Determines if the given function is a mocked function.
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
+
 By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -511,7 +515,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 ```
 
@@ -562,7 +565,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 
 test('plays audio', () => {
@@ -571,7 +573,6 @@ test('plays audio', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
-
 });
 ```
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -501,6 +501,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -551,6 +552,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -475,7 +475,13 @@ Determines if the given function is a mocked function.
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::note
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
+
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -494,6 +500,10 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
@@ -501,7 +511,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 ```
 
@@ -541,6 +550,10 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
@@ -548,7 +561,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 
 test('plays audio', () => {
@@ -558,7 +570,6 @@ test('plays audio', () => {
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
 
-  spy.mockRestore();
 });
 ```
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -476,11 +476,15 @@ Determines if the given function is a mocked function.
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
+
 By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -511,7 +515,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 ```
 
@@ -562,7 +565,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 
 test('plays audio', () => {
@@ -571,7 +573,6 @@ test('plays audio', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
-
 });
 ```
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -501,6 +501,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -551,6 +552,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -475,7 +475,13 @@ Determines if the given function is a mocked function.
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::note
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
+
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -494,6 +500,10 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
@@ -501,7 +511,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 ```
 
@@ -541,6 +550,10 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
@@ -548,7 +561,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 
 test('plays audio', () => {
@@ -558,7 +570,6 @@ test('plays audio', () => {
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
 
-  spy.mockRestore();
 });
 ```
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -481,7 +481,13 @@ Determines if the given function is a mocked function.
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::note
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
+
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -500,6 +506,10 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
@@ -507,7 +517,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 ```
 
@@ -547,6 +556,10 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
@@ -554,7 +567,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 
 test('plays audio', () => {
@@ -564,7 +576,6 @@ test('plays audio', () => {
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
 
-  spy.mockRestore();
 });
 ```
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -507,6 +507,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -557,6 +558,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/website/versioned_docs/version-28.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.0/JestObjectAPI.md
@@ -482,11 +482,15 @@ Determines if the given function is a mocked function.
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
+
 By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -517,7 +521,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 ```
 
@@ -568,7 +571,6 @@ test('plays video', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 
 test('plays audio', () => {
@@ -577,7 +579,6 @@ test('plays audio', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
-
 });
 ```
 

--- a/website/versioned_docs/version-28.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.1/JestObjectAPI.md
@@ -507,6 +507,7 @@ Example test:
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 
@@ -558,6 +559,7 @@ const audio = require('./audio');
 const video = require('./video');
 
 afterEach(() => {
+  // restore the spy created with spyOn
   jest.restoreAllMocks();
 });
 

--- a/website/versioned_docs/version-28.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.1/JestObjectAPI.md
@@ -481,7 +481,13 @@ Determines if the given function is a mocked function.
 
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
-_Note: By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`_
+:::note
+By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+:::
+
+:::tip
+Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+:::
 
 Example:
 
@@ -500,6 +506,11 @@ Example test:
 ```js
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
@@ -507,7 +518,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 ```
 
@@ -547,6 +557,11 @@ Example test:
 const audio = require('./audio');
 const video = require('./video');
 
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
@@ -554,7 +569,6 @@ test('plays video', () => {
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
 
-  spy.mockRestore();
 });
 
 test('plays audio', () => {
@@ -564,7 +578,6 @@ test('plays audio', () => {
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
 
-  spy.mockRestore();
 });
 ```
 

--- a/website/versioned_docs/version-28.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.1/JestObjectAPI.md
@@ -482,11 +482,15 @@ Determines if the given function is a mocked function.
 Creates a mock function similar to `jest.fn` but also tracks calls to `object[methodName]`. Returns a Jest [mock function](MockFunctionAPI.md).
 
 :::note
+
 By default, `jest.spyOn` also calls the **spied** method. This is different behavior from most other test libraries. If you want to overwrite the original function, you can use `jest.spyOn(object, methodName).mockImplementation(() => customImplementation)` or `object[methodName] = jest.fn(() => customImplementation);`
+
 :::
 
 :::tip
-Since `jest.spyOn` is a mock.  You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method. 
+
+Since `jest.spyOn` is a mock. You could restore the initial state calling [jest.restoreAllMocks](#jestrestoreallmocks) on [afterEach](GlobalAPI.md#aftereachfn-timeout) method.
+
 :::
 
 Example:
@@ -511,14 +515,12 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play');
   const isPlaying = video.play();
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 ```
 
@@ -563,14 +565,12 @@ afterEach(() => {
   jest.restoreAllMocks();
 });
 
-
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
   const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);
-
 });
 
 test('plays audio', () => {
@@ -579,7 +579,6 @@ test('plays audio', () => {
 
   expect(spy).toHaveBeenCalled();
   expect(audio.volume).toBe(100);
-
 });
 ```
 


### PR DESCRIPTION
Resolve #4828 

Update `jest.spyOn` documentation. 

Lemme know if this should be mirrored to the versioned doc as well.
Summary

This will help folks to understand how to restore the initial status of spies.

Test plan

Just doc, so probably preview pane in Github UI for now.