### PR TITLE
chore: bump `jest-serialiser-ansi-escapes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@
 
 - `[jest-changed-files]` Fix a lock-up after repeated invocations ([#12757](https://github.com/facebook/jest/issues/12757))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedSets ([#12977](https://github.com/facebook/jest/pull/12977))
-- `[jest-snapshot]` Fix indendation of awaited inline snapshots ([#12986](https://github.com/facebook/jest/pull/12986))
+- `[jest-snapshot]` Fix indentation of awaited inline snapshots ([#12986](https://github.com/facebook/jest/pull/12986))
 
 ### Chore & Maintenance
 
-- `[*]` Replace internal usage of `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes` ([#12935](https://github.com/facebook/jest/pull/12935))
+- `[*]` Replace internal usage of `pretty-format/ConvertAnsi` with `jest-serializer-ansi-escapes` ([#12935](https://github.com/facebook/jest/pull/12935), [#13004](https://github.com/facebook/jest/pull/13004))
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jest-junit": "^13.0.0",
     "jest-mock": "workspace:*",
     "jest-runner-tsd": "^3.1.0",
-    "jest-serializer-ansi-escapes": "^1.0.0",
+    "jest-serializer-ansi-escapes": "^2.0.1",
     "jest-silent-reporter": "^0.5.0",
     "jest-snapshot": "workspace:*",
     "jest-watch-typeahead": "^1.1.0",

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
@@ -11,121 +11,121 @@ exports[`displayName generates a default color for the runner jest-runner-tslint
 exports[`displayName generates a default color for the runner undefined 1`] = `"white"`;
 
 exports[`displayName should throw an error when displayName is is an empty object 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option "<bold>displayName</>" must be of type:</>
-<red></>
-<red>  {</>
-<red>    name: string;</>
-<red>    color: string;</>
-<red>  }</>
-<red></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option "<bold>displayName</intensity>" must be of type:</color>
+<red></color>
+<red>  {</color>
+<red>    name: string;</color>
+<red>    color: string;</color>
+<red>  }</color>
+<red></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`displayName should throw an error when displayName is missing color 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option "<bold>displayName</>" must be of type:</>
-<red></>
-<red>  {</>
-<red>    name: string;</>
-<red>    color: string;</>
-<red>  }</>
-<red></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option "<bold>displayName</intensity>" must be of type:</color>
+<red></color>
+<red>  {</color>
+<red>    name: string;</color>
+<red>    color: string;</color>
+<red>  }</color>
+<red></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`displayName should throw an error when displayName is missing name 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option "<bold>displayName</>" must be of type:</>
-<red></>
-<red>  {</>
-<red>    name: string;</>
-<red>    color: string;</>
-<red>  }</>
-<red></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option "<bold>displayName</intensity>" must be of type:</color>
+<red></color>
+<red>  {</color>
+<red>    name: string;</color>
+<red>    color: string;</color>
+<red>  }</color>
+<red></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`displayName should throw an error when displayName is using invalid values 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option "<bold>displayName</>" must be of type:</>
-<red></>
-<red>  {</>
-<red>    name: string;</>
-<red>    color: string;</>
-<red>  }</>
-<red></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option "<bold>displayName</intensity>" must be of type:</color>
+<red></color>
+<red>  {</color>
+<red>    name: string;</color>
+<red>    color: string;</color>
+<red>  }</color>
+<red></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`extensionsToTreatAsEsm should enforce leading dots 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option: <bold>extensionsToTreatAsEsm: ['ts']</> includes a string that does not start with a period (<bold>.</>).</>
-<red>  Please change your configuration to <bold>extensionsToTreatAsEsm: ['.ts']</>.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option: <bold>extensionsToTreatAsEsm: ['ts']</intensity> includes a string that does not start with a period (<bold>.</intensity>).</color>
+<red>  Please change your configuration to <bold>extensionsToTreatAsEsm: ['.ts']</intensity>.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`extensionsToTreatAsEsm throws on .cjs 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option: <bold>extensionsToTreatAsEsm: ['.cjs']</> includes <bold>'.cjs'</> which is always treated as CommonJS.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option: <bold>extensionsToTreatAsEsm: ['.cjs']</intensity> includes <bold>'.cjs'</intensity> which is always treated as CommonJS.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`extensionsToTreatAsEsm throws on .js 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option: <bold>extensionsToTreatAsEsm: ['.js']</> includes <bold>'.js'</> which is always inferred based on <bold>type</> in its nearest <bold>package.json</>.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option: <bold>extensionsToTreatAsEsm: ['.js']</intensity> includes <bold>'.js'</intensity> which is always inferred based on <bold>type</intensity> in its nearest <bold>package.json</intensity>.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`extensionsToTreatAsEsm throws on .mjs 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option: <bold>extensionsToTreatAsEsm: ['.mjs']</> includes <bold>'.mjs'</> which is always treated as an ECMAScript Module.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option: <bold>extensionsToTreatAsEsm: ['.mjs']</intensity> includes <bold>'.mjs'</intensity> which is always treated as an ECMAScript Module.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`logs a deprecation warning when 'browser' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"browser"</> has been deprecated. Please install "browser-resolve" and use the "resolver" option in Jest configuration as shown in the documentation: https://jestjs.io/docs/configuration#resolver-string</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"browser"</intensity> has been deprecated. Please install "browser-resolve" and use the "resolver" option in Jest configuration as shown in the documentation: https://jestjs.io/docs/configuration#resolver-string</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -141,15 +141,15 @@ exports[`logs a deprecation warning when 'extraGlobals' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"extraGlobals"</> was replaced by <bold>"sandboxInjectedGlobals"</>.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"extraGlobals"</intensity> was replaced by <bold>"sandboxInjectedGlobals"</intensity>.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -165,15 +165,15 @@ exports[`logs a deprecation warning when 'moduleLoader' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"moduleLoader"</> was replaced by <bold>"runtime"</>.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"moduleLoader"</intensity> was replaced by <bold>"runtime"</intensity>.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -189,15 +189,15 @@ exports[`logs a deprecation warning when 'preprocessorIgnorePatterns' option is 
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"preprocessorIgnorePatterns"</> was replaced by <bold>"transformIgnorePatterns"</>, which support multiple preprocessors.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"preprocessorIgnorePatterns"</intensity> was replaced by <bold>"transformIgnorePatterns"</intensity>, which support multiple preprocessors.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -213,15 +213,15 @@ exports[`logs a deprecation warning when 'scriptPreprocessor' option is passed 1
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"scriptPreprocessor"</> was replaced by <bold>"transform"</>, which support multiple preprocessors.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"scriptPreprocessor"</intensity> was replaced by <bold>"transform"</intensity>, which support multiple preprocessors.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -237,15 +237,15 @@ exports[`logs a deprecation warning when 'setupTestFrameworkScriptFile' option i
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"setupTestFrameworkScriptFile"</> was replaced by configuration <bold>"setupFilesAfterEnv"</>, which supports multiple paths.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"setupTestFrameworkScriptFile"</intensity> was replaced by configuration <bold>"setupFilesAfterEnv"</intensity>, which supports multiple paths.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -261,16 +261,16 @@ exports[`logs a deprecation warning when 'testPathDirs' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"testPathDirs"</> was replaced by <bold>"roots"</>.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow>  </>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"testPathDirs"</intensity> was replaced by <bold>"roots"</intensity>.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow>  </color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -286,15 +286,15 @@ exports[`logs a deprecation warning when 'testURL' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"testURL"</> was replaced by passing the URL via <bold>"testEnvironmentOptions.url"</>.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"testURL"</intensity> was replaced by passing the URL via <bold>"testEnvironmentOptions.url"</intensity>.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -310,15 +310,15 @@ exports[`logs a deprecation warning when 'timers' option is passed 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>"timers"</> was replaced by <bold>"fakeTimers"</>.</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>  <bold>Configuration Documentation:</></>
-<yellow>  https://jestjs.io/docs/configuration</>
-<yellow></>",
+      "<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>"timers"</intensity> was replaced by <bold>"fakeTimers"</intensity>.</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>  <bold>Configuration Documentation:</intensity></color>
+<yellow>  https://jestjs.io/docs/configuration</color>
+<yellow></color>",
     ],
   ],
   "results": Array [
@@ -331,153 +331,153 @@ exports[`logs a deprecation warning when 'timers' option is passed 1`] = `
 `;
 
 exports[`preset throws when module was found but no "jest-preset.js" or "jest-preset.json" files 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Module <bold>exist-but-no-jest-preset</> should have "jest-preset.js" or "jest-preset.json" file at the root.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Module <bold>exist-but-no-jest-preset</intensity> should have "jest-preset.js" or "jest-preset.json" file at the root.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`preset throws when preset not found 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Preset <bold>doesnt-exist</> not found.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Preset <bold>doesnt-exist</intensity> not found.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`reporters throws an error if first value in the tuple is not a string 1`] = `
-"<red><bold><bold>● </><bold>Reporter Validation Error</>:</>
-<red></>
-<red>  Unexpected value for Path at index 0 of reporter at index 0</>
-<red>  Expected:</>
-<red>    <bold><red>string</><red></></>
-<red>  Got:</>
-<red>    <bold><green>number</><red></></>
-<red>  Reporter configuration:</>
-<red>    <bold><green>[</><red></></>
-<red><bold><green>      123</><red></></>
-<red><bold><green>    ]</><red></></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Reporter Validation Error</intensity>:</color>
+<red></color>
+<red>  Unexpected value for Path at index 0 of reporter at index 0</color>
+<red>  Expected:</color>
+<red>    <bold><red>string</color><red></intensity></color>
+<red>  Got:</color>
+<red>    <bold><green>number</color><red></intensity></color>
+<red>  Reporter configuration:</color>
+<red>    <bold><green>[</color><red></intensity></color>
+<red><bold><green>      123</color><red></intensity></color>
+<red><bold><green>    ]</color><red></intensity></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`reporters throws an error if second value in the tuple is not an object 1`] = `
-"<red><bold><bold>● </><bold>Reporter Validation Error</>:</>
-<red></>
-<red>  Unexpected value for Reporter Configuration at index 1 of reporter at index 0</>
-<red>  Expected:</>
-<red>    <bold><red>object</><red></></>
-<red>  Got:</>
-<red>    <bold><green>boolean</><red></></>
-<red>  Reporter configuration:</>
-<red>    <bold><green>[</><red></></>
-<red><bold><green>      "some-reporter",</><red></></>
-<red><bold><green>      true</><red></></>
-<red><bold><green>    ]</><red></></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Reporter Validation Error</intensity>:</color>
+<red></color>
+<red>  Unexpected value for Reporter Configuration at index 1 of reporter at index 0</color>
+<red>  Expected:</color>
+<red>    <bold><red>object</color><red></intensity></color>
+<red>  Got:</color>
+<red>    <bold><green>boolean</color><red></intensity></color>
+<red>  Reporter configuration:</color>
+<red>    <bold><green>[</color><red></intensity></color>
+<red><bold><green>      "some-reporter",</color><red></intensity></color>
+<red><bold><green>      true</color><red></intensity></color>
+<red><bold><green>    ]</color><red></intensity></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`reporters throws an error if second value is missing in the tuple 1`] = `
-"<red><bold><bold>● </><bold>Reporter Validation Error</>:</>
-<red></>
-<red>  Unexpected value for Reporter Configuration at index 1 of reporter at index 0</>
-<red>  Expected:</>
-<red>    <bold><red>object</><red></></>
-<red>  Got:</>
-<red>    <bold><green>undefined</><red></></>
-<red>  Reporter configuration:</>
-<red>    <bold><green>[</><red></></>
-<red><bold><green>      "some-reporter"</><red></></>
-<red><bold><green>    ]</><red></></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Reporter Validation Error</intensity>:</color>
+<red></color>
+<red>  Unexpected value for Reporter Configuration at index 1 of reporter at index 0</color>
+<red>  Expected:</color>
+<red>    <bold><red>object</color><red></intensity></color>
+<red>  Got:</color>
+<red>    <bold><green>undefined</color><red></intensity></color>
+<red>  Reporter configuration:</color>
+<red>    <bold><green>[</color><red></intensity></color>
+<red><bold><green>      "some-reporter"</color><red></intensity></color>
+<red><bold><green>    ]</color><red></intensity></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`reporters throws an error if value is neither string nor array 1`] = `
-"<red><bold><bold>● </><bold>Reporter Validation Error</>:</>
-<red></>
-<red>  Reporter at index 0 must be of type:</>
-<red>    <bold><green>array or string</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>number</><red></></>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Reporter Validation Error</intensity>:</color>
+<red></color>
+<red>  Reporter at index 0 must be of type:</color>
+<red>    <bold><green>array or string</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>number</color><red></intensity></color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`rootDir throws if the options is missing a rootDir property 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Configuration option <bold>rootDir</> must be specified.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Configuration option <bold>rootDir</intensity> must be specified.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`runner throw error when a runner is not found 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Jest Runner <bold>missing-runner</> cannot be found. Make sure the <bold>runner</> configuration option points to an existing node module.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Jest Runner <bold>missing-runner</intensity> cannot be found. Make sure the <bold>runner</intensity> configuration option points to an existing node module.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`testEnvironment throws on invalid environment names 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Test environment <bold>phantom</> cannot be found. Make sure the <bold>testEnvironment</> configuration option points to an existing node module.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Test environment <bold>phantom</intensity> cannot be found. Make sure the <bold>testEnvironment</intensity> configuration option points to an existing node module.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`testMatch throws if testRegex and testMatch are both specified 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Configuration options <bold>testMatch</> and <bold>testRegex</> cannot be used together.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Configuration options <bold>testMatch</intensity> and <bold>testRegex</intensity> cannot be used together.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
-exports[`testPathPattern <regexForTestFiles> ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</>"`;
+exports[`testPathPattern <regexForTestFiles> ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</color>"`;
 
-exports[`testPathPattern --testPathPattern ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</>"`;
+exports[`testPathPattern --testPathPattern ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</color>"`;
 
 exports[`testTimeout should throw an error if timeout is a negative number 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Option "<bold>testTimeout</>" must be a natural number.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Option "<bold>testTimeout</intensity>" must be a natural number.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;
 
 exports[`watchPlugins throw error when a watch plugin is not found 1`] = `
-"<red><bold><bold>● </><bold>Validation Error</>:</>
-<red></>
-<red>  Watch plugin <bold>missing-plugin</> cannot be found. Make sure the <bold>watchPlugins</> configuration option points to an existing node module.</>
-<red></>
-<red>  <bold>Configuration Documentation:</></>
-<red>  https://jestjs.io/docs/configuration</>
-<red></>"
+"<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
+<red></color>
+<red>  Watch plugin <bold>missing-plugin</intensity> cannot be found. Make sure the <bold>watchPlugins</intensity> configuration option points to an existing node module.</color>
+<red></color>
+<red>  <bold>Configuration Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/configuration</color>
+<red></color>"
 `;

--- a/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
@@ -4,26 +4,26 @@ exports[`SnapshotInteractiveMode skip 1 test, then quit 1`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then quit 2`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>1 snapshot reviewed</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>1 snapshot reviewed</intensity></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>r<dim> to restart Interactive Snapshot Mode.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>r<dim> to restart Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
 "
 `;
 
@@ -31,26 +31,26 @@ exports[`SnapshotInteractiveMode skip 1 test, then restart 1`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, then restart 2`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>1 snapshot reviewed</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>1 snapshot reviewed</intensity></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>r<dim> to restart Interactive Snapshot Mode.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>r<dim> to restart Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
 "
 `;
 
@@ -58,14 +58,14 @@ exports[`SnapshotInteractiveMode skip 1 test, then restart 3`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -73,14 +73,14 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>2 snapshots remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>2 snapshots remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -88,26 +88,26 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and restart 3`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>2 snapshots reviewed</></>, <bold><green>1 snapshot updated</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>2 snapshots reviewed</intensity></intensity>, <bold><green>1 snapshot updated</color></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>r<dim> to restart Interactive Snapshot Mode.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>r<dim> to restart Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
 "
 `;
 
@@ -115,14 +115,14 @@ exports[`SnapshotInteractiveMode skip 1 test, update 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -130,14 +130,14 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 1`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>2 snapshots remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>2 snapshots remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -145,26 +145,26 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 2`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 3`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>2 snapshots reviewed</></>, <bold><yellow>2 snapshots skipped</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>2 snapshots reviewed</intensity></intensity>, <bold><yellow>2 snapshots skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>r<dim> to restart Interactive Snapshot Mode.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>r<dim> to restart Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
 "
 `;
 
@@ -172,14 +172,14 @@ exports[`SnapshotInteractiveMode skip 2 tests, then finish and restart 4`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>2 snapshots remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>2 snapshots remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -187,14 +187,14 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>2 snapshots remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>2 snapshots remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -202,26 +202,26 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>, <bold><green>1 snapshot updated</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>, <bold><green>1 snapshot updated</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and restart 3`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>2 snapshots reviewed</></>, <bold><green>1 snapshot updated</></>, <bold><yellow>1 snapshot skipped</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>2 snapshots reviewed</intensity></intensity>, <bold><green>1 snapshot updated</color></intensity>, <bold><yellow>1 snapshot skipped</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>r<dim> to restart Interactive Snapshot Mode.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>r<dim> to restart Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
 "
 `;
 
@@ -229,14 +229,14 @@ exports[`SnapshotInteractiveMode update 1 test, skip 1 test, then finish and res
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -244,25 +244,25 @@ exports[`SnapshotInteractiveMode update 1 test, then finish and return 1`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode update 1 test, then finish and return 2`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>1 snapshot reviewed</></>, <bold><green>1 snapshot updated</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>1 snapshot reviewed</intensity></intensity>, <bold><green>1 snapshot updated</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>Enter<dim> to return to watch mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>Enter<dim> to return to watch mode.</intensity>
 "
 `;
 
@@ -270,14 +270,14 @@ exports[`SnapshotInteractiveMode update 2 tests, then finish and return 1`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>2 snapshots remaining</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>2 snapshots remaining</intensity></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
@@ -285,24 +285,24 @@ exports[`SnapshotInteractiveMode update 2 tests, then finish and return 2`] = `
 "<moveCursorUpBy6Rows>
 <eraseScreenDown>
 
-<bold>Interactive Snapshot Progress</>
- › <bold><dim>1 snapshot remaining</></>, <bold><green>1 snapshot updated</></>
+<bold>Interactive Snapshot Progress</intensity>
+ › <bold><dim>1 snapshot remaining</intensity></intensity>, <bold><green>1 snapshot updated</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>u<dim> to update failing snapshots for this test.</>
-<dim> › Press </>s<dim> to skip the current test.</>
-<dim> › Press </>q<dim> to quit Interactive Snapshot Mode.</>
-<dim> › Press </>Enter<dim> to trigger a test run.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>u<dim> to update failing snapshots for this test.</intensity>
+<dim> › Press </intensity>s<dim> to skip the current test.</intensity>
+<dim> › Press </intensity>q<dim> to quit Interactive Snapshot Mode.</intensity>
+<dim> › Press </intensity>Enter<dim> to trigger a test run.</intensity>
 "
 `;
 
 exports[`SnapshotInteractiveMode update 2 tests, then finish and return 3`] = `
 "<clearTerminal>
 
-<bold>Interactive Snapshot Result</>
- › <bold><dim>2 snapshots reviewed</></>, <bold><green>2 snapshots updated</></>
+<bold>Interactive Snapshot Result</intensity>
+ › <bold><dim>2 snapshots reviewed</intensity></intensity>, <bold><green>2 snapshots updated</color></intensity>
 
-<bold>Watch Usage</>
-<dim> › Press </>Enter<dim> to return to watch mode.</>
+<bold>Watch Usage</intensity>
+<dim> › Press </intensity>Enter<dim> to return to watch mode.</intensity>
 "
 `;

--- a/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.ts.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.ts.snap
@@ -3,61 +3,61 @@
 exports[`getNoTestsFoundMessage returns correct message when monitoring only changed 1`] = `
 Object {
   "exitWith0": true,
-  "message": "<bold>No tests found related to files changed since last commit.</><dim></>
-<dim>Run Jest without \`-o\` or with \`--all\` to run all tests.</>",
+  "message": "<bold>No tests found related to files changed since last commit.</intensity><dim></intensity>
+<dim>Run Jest without \`-o\` or with \`--all\` to run all tests.</intensity>",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message when monitoring only failures 1`] = `
 Object {
   "exitWith0": false,
-  "message": "<bold>No failed test found.</><dim></>
-<dim>Run Jest without \`--onlyFailures\` or with \`--all\` to run all tests.</>",
+  "message": "<bold>No failed test found.</intensity><dim></intensity>
+<dim>Run Jest without \`--onlyFailures\` or with \`--all\` to run all tests.</intensity>",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message with findRelatedTests 1`] = `
 Object {
   "exitWith0": false,
-  "message": "<bold>No tests found, exiting with code 1</>
+  "message": "<bold>No tests found, exiting with code 1</intensity>
 Run with \`--passWithNoTests\` to exit with code 0
-In <bold>/root/dir</>
+In <bold>/root/dir</intensity>
   0 files checked across 0 projects. Run with \`--verbose\` for more details.
-Pattern: <yellow>/path/pattern</> - 0 matches",
+Pattern: <yellow>/path/pattern</color> - 0 matches",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message with findRelatedTests 2`] = `
 Object {
   "exitWith0": true,
-  "message": "<bold>No tests found, exiting with code 0</>",
+  "message": "<bold>No tests found, exiting with code 0</intensity>",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message with passWithNoTests 1`] = `
 Object {
   "exitWith0": true,
-  "message": "<bold>No tests found, exiting with code 0</>",
+  "message": "<bold>No tests found, exiting with code 0</intensity>",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message with verbose option 1`] = `
 Object {
   "exitWith0": false,
-  "message": "<bold>No tests found, exiting with code 1</>
+  "message": "<bold>No tests found, exiting with code 1</intensity>
 Run with \`--passWithNoTests\` to exit with code 0
 
-Pattern: <yellow>/path/pattern</> - 0 matches",
+Pattern: <yellow>/path/pattern</color> - 0 matches",
 }
 `;
 
 exports[`getNoTestsFoundMessage returns correct message without options 1`] = `
 Object {
   "exitWith0": false,
-  "message": "<bold>No tests found, exiting with code 1</>
+  "message": "<bold>No tests found, exiting with code 1</intensity>
 Run with \`--passWithNoTests\` to exit with code 0
-In <bold>/root/dir</>
+In <bold>/root/dir</intensity>
   0 files checked across 0 projects. Run with \`--verbose\` for more details.
-Pattern: <yellow>/path/pattern</> - 0 matches",
+Pattern: <yellow>/path/pattern</color> - 0 matches",
 }
 `;

--- a/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
@@ -102,9 +102,9 @@ exports[`Watch mode flows Pressing "c" clears the filters 1`] = `
 "<hideCursor>
 <clearTerminal>
 
-<bold>Pattern Mode Usage</>
- <dim>› Press</> Esc <dim>to exit pattern mode.</>
- <dim>› Press</> Enter <dim>to filter by a filenames regex pattern.</>
+<bold>Pattern Mode Usage</intensity>
+ <dim>› Press</intensity> Esc <dim>to exit pattern mode.</intensity>
+ <dim>› Press</intensity> Enter <dim>to filter by a filenames regex pattern.</intensity>
 
 
 <showCursor>

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
@@ -8,66 +8,66 @@ exports[`jest-each .describe throws an error when called with an empty string 1`
 exports[`jest-each .describe throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .describe throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .describe throws error when there are no arguments for given headings 1`] = `
@@ -83,66 +83,66 @@ exports[`jest-each .describe.only throws an error when called with an empty stri
 exports[`jest-each .describe.only throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe.only throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe.only throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .describe.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .describe.only throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .describe.only throws error when there are no arguments for given headings 1`] = `
@@ -158,66 +158,66 @@ exports[`jest-each .fdescribe throws an error when called with an empty string 1
 exports[`jest-each .fdescribe throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fdescribe throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fdescribe throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fdescribe throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .fdescribe throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .fdescribe throws error when there are no arguments for given headings 1`] = `
@@ -233,66 +233,66 @@ exports[`jest-each .fit throws an error when called with an empty string 1`] = `
 exports[`jest-each .fit throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fit throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fit throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .fit throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .fit throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .fit throws error when there are no arguments for given headings 1`] = `
@@ -308,66 +308,66 @@ exports[`jest-each .it throws an error when called with an empty string 1`] = `
 exports[`jest-each .it throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .it throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .it throws error when there are no arguments for given headings 1`] = `
@@ -383,66 +383,66 @@ exports[`jest-each .it.only throws an error when called with an empty string 1`]
 exports[`jest-each .it.only throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it.only throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it.only throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .it.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .it.only throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .it.only throws error when there are no arguments for given headings 1`] = `
@@ -458,66 +458,66 @@ exports[`jest-each .test throws an error when called with an empty string 1`] = 
 exports[`jest-each .test throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test throws error when there are no arguments for given headings 1`] = `
@@ -533,66 +533,66 @@ exports[`jest-each .test.concurrent throws an error when called with an empty st
 exports[`jest-each .test.concurrent throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent throws error when there are no arguments for given headings 1`] = `
@@ -608,66 +608,66 @@ exports[`jest-each .test.concurrent.only throws an error when called with an emp
 exports[`jest-each .test.concurrent.only throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.only throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.only throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent.only throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent.only throws error when there are no arguments for given headings 1`] = `
@@ -683,66 +683,66 @@ exports[`jest-each .test.concurrent.skip throws an error when called with an emp
 exports[`jest-each .test.concurrent.skip throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.skip throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.skip throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.concurrent.skip throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent.skip throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.concurrent.skip throws error when there are no arguments for given headings 1`] = `
@@ -758,66 +758,66 @@ exports[`jest-each .test.only throws an error when called with an empty string 1
 exports[`jest-each .test.only throws error when there are additional words in first column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a is the left | b    | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a is the left | b    | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.only throws error when there are additional words in last column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b    | expected value</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b    | expected value</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.only throws error when there are additional words in second column heading 1`] = `
 "Table headings do not conform to expected format:
 
-<green>heading1 | headingN</>
+<green>heading1 | headingN</color>
 
 Received:
 
-<red>"</>
-<red>          a    | b is the right | expected</>
-<red>          "</>"
+<red>"</color>
+<red>          a    | b is the right | expected</color>
+<red>          "</color>"
 `;
 
 exports[`jest-each .test.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.only throws error when there are fewer arguments than headings when given one row 1`] = `
 "Not enough arguments supplied for given headings:
-<green>a | b | expected</>
+<green>a | b | expected</color>
 
 Received:
-<red>Array [</>
-<red>  0,</>
-<red>  1,</>
-<red>]</>
+<red>Array [</color>
+<red>  0,</color>
+<red>  1,</color>
+<red>]</color>
 
-Missing <red>1</> argument"
+Missing <red>1</color> argument"
 `;
 
 exports[`jest-each .test.only throws error when there are no arguments for given headings 1`] = `

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -1,47 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.formatExecError() 1`] = `
-"  <bold>● </>Test suite failed to run
+"  <bold>● </intensity>Test suite failed to run
 
     Whoops!
 "
 `;
 
 exports[`codeframe 1`] = `
-"  <bold>● </>Test suite failed to run
+"  <bold>● </intensity>Test suite failed to run
 
     Whoops!
 
-    </><red><bold>></></><gray> 1 |</> <cyan>throw</> <cyan>new</> <yellow>Error</>(<green>"Whoops!"</>)<yellow>;</></>
-    </> <gray>   |</>       <red><bold>^</></></>
+    </><red><bold>></intensity></color><gray> 1 |</color> <cyan>throw</color> <cyan>new</color> <yellow>Error</color>(<green>"Whoops!"</color>)<yellow>;</color></>
+    </> <gray>   |</color>       <red><bold>^</intensity></color></>
 
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+      <dim>at Object.<anonymous> (</intensity>file.js<dim>:1:7)</intensity>
 "
 `;
 
 exports[`formatStackTrace does not print code frame when noCodeFrame = true 1`] = `
 "
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+      <dim>at Object.<anonymous> (</intensity>file.js<dim>:1:7)</intensity>
         "
 `;
 
 exports[`formatStackTrace does not print codeframe when noStackTrace = true 1`] = `
 "
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+      <dim>at Object.<anonymous> (</intensity>file.js<dim>:1:7)</intensity>
         "
 `;
 
 exports[`formatStackTrace prints code frame and stacktrace 1`] = `
 "
-    </><red><bold>></></><gray> 1 |</> <cyan>throw</> <cyan>new</> <yellow>Error</>(<green>"Whoops!"</>)<yellow>;</></>
-    </> <gray>   |</>       <red><bold>^</></></>
+    </><red><bold>></intensity></color><gray> 1 |</color> <cyan>throw</color> <cyan>new</color> <yellow>Error</color>(<green>"Whoops!"</color>)<yellow>;</color></>
+    </> <gray>   |</color>       <red><bold>^</intensity></color></>
 
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+      <dim>at Object.<anonymous> (</intensity>file.js<dim>:1:7)</intensity>
         "
 `;
 
 exports[`formatStackTrace should strip node internals 1`] = `
-"<bold><red>  <bold>● </><bold>Unix test</></>
+"<bold><red>  <bold>● </intensity><bold>Unix test</color></intensity>
 
       
         Expected value to be of type:
@@ -50,55 +50,55 @@ exports[`formatStackTrace should strip node internals 1`] = `
           ""
         type:
           "string"
-<dim></>
-<dim>      <dim>at Object.it (</><dim>__tests__/test.js<dim>:8:14)</><dim></>
+<dim></intensity>
+<dim>      <dim>at Object.it (</intensity><dim>__tests__/test.js<dim>:8:14)</intensity><dim></intensity>
 "
 `;
 
 exports[`no codeframe 1`] = `
-"  <bold>● </>Test suite failed to run
+"  <bold>● </intensity>Test suite failed to run
 
     Whoops!
 
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+      <dim>at Object.<anonymous> (</intensity>file.js<dim>:1:7)</intensity>
 "
 `;
 
 exports[`no stack 1`] = `
-"  <bold>● </>Test suite failed to run
+"  <bold>● </intensity>Test suite failed to run
 
     Whoops!
 "
 `;
 
 exports[`retains message in babel code frame error 1`] = `
-"<bold><red>  <bold>● </><bold>Babel test</></>
+"<bold><red>  <bold>● </intensity><bold>Babel test</color></intensity>
 
       
         packages/react/src/forwardRef.js: Unexpected token, expected , (20:10)
-<dim></>
-<dim>          </> <gray> 18 | </>        <cyan>false</><yellow>,</></>
-<dim>           <gray> 19 | </>        <green>'forwardRef requires a render function but received a \`memo\` '</></>
-<dim>          <red><bold>></><dim></><gray> 20 | </>          <green>'component. Instead of forwardRef(memo(...)), use '</> <yellow>+</></>
-<dim>           <gray>    | </>          <red><bold>^</><dim></></>
-<dim>           <gray> 21 | </>          <green>'memo(forwardRef(...)).'</><yellow>,</></>
-<dim>           <gray> 22 | </>      )<yellow>;</></>
-<dim>           <gray> 23 | </>    } <cyan>else</> <cyan>if</> (<cyan>typeof</> render <yellow>!==</> <green>'function'</>) {</></>
+<dim></intensity>
+<dim>          </> <gray> 18 | </color>        <cyan>false</color><yellow>,</color></intensity>
+<dim>           <gray> 19 | </color>        <green>'forwardRef requires a render function but received a \`memo\` '</color></intensity>
+<dim>          <red><bold>></intensity><dim></color><gray> 20 | </color>          <green>'component. Instead of forwardRef(memo(...)), use '</color> <yellow>+</color></intensity>
+<dim>           <gray>    | </color>          <red><bold>^</intensity><dim></color></intensity>
+<dim>           <gray> 21 | </color>          <green>'memo(forwardRef(...)).'</color><yellow>,</color></intensity>
+<dim>           <gray> 22 | </color>      )<yellow>;</color></intensity>
+<dim>           <gray> 23 | </color>    } <cyan>else</color> <cyan>if</color> (<cyan>typeof</color> render <yellow>!==</color> <green>'function'</color>) {</></intensity>
 "
 `;
 
 exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
-"<bold><red>  <bold>● </><bold>Unix test</></>
+"<bold><red>  <bold>● </intensity><bold>Unix test</color></intensity>
 
       at stack (../jest-jasmine2/build/jasmine-2.4.1.js:1580:17)
-<dim></>
-<dim>      <dim>at Object.addResult (</><dim>../jest-jasmine2/build/jasmine-2.4.1.js<dim>:1550:14)</><dim></>
-<dim>      <dim>at Object.it (</><dim>build/__tests__/messages-test.js<dim>:45:41)</><dim></>
+<dim></intensity>
+<dim>      <dim>at Object.addResult (</intensity><dim>../jest-jasmine2/build/jasmine-2.4.1.js<dim>:1550:14)</intensity><dim></intensity>
+<dim>      <dim>at Object.it (</intensity><dim>build/__tests__/messages-test.js<dim>:45:41)</intensity><dim></intensity>
 "
 `;
 
 exports[`should not exclude vendor from stack trace 1`] = `
-"<bold><red>  <bold>● </><bold>Vendor test</></>
+"<bold><red>  <bold>● </intensity><bold>Vendor test</color></intensity>
 
       
         Expected value to be of type:
@@ -107,8 +107,8 @@ exports[`should not exclude vendor from stack trace 1`] = `
           ""
         type:
           "string"
-<dim></>
-<dim>      <dim>at Object.it (</><dim>__tests__/vendor/cool_test.js<dim>:6:666)</><dim></>
-<dim>      <dim>at Object.asyncFn (</><dim>__tests__/vendor/sulu/node_modules/sulu-content-bundle/best_component.js<dim>:1:5)</><dim></>
+<dim></intensity>
+<dim>      <dim>at Object.it (</intensity><dim>__tests__/vendor/cool_test.js<dim>:6:666)</intensity><dim></intensity>
+<dim>      <dim>at Object.asyncFn (</intensity><dim>__tests__/vendor/sulu/node_modules/sulu-content-bundle/best_component.js<dim>:1:5)</intensity><dim></intensity>
 "
 `;

--- a/packages/jest-reporters/src/__tests__/__snapshots__/SummaryReporter.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/SummaryReporter.test.js.snap
@@ -1,61 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshots all have results (after update) 1`] = `
-"<bold>Snapshot Summary</>
-<bold><green> › 1 snapshot written </></>from 1 test suite.
-<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
-<bold><green> › 1 snapshot updated </></>from 1 test suite.
-<bold><green> › 1 snapshot file removed </></>from 1 test suite.
-<bold><green> › 1 snapshot removed </></>from 1 test suite.
-   ↳ <dim>../path/to/</><bold>suite_one</>
+"<bold>Snapshot Summary</intensity>
+<bold><green> › 1 snapshot written </color></intensity>from 1 test suite.
+<bold><red> › 1 snapshot failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</intensity>
+<bold><green> › 1 snapshot updated </color></intensity>from 1 test suite.
+<bold><green> › 1 snapshot file removed </color></intensity>from 1 test suite.
+<bold><green> › 1 snapshot removed </color></intensity>from 1 test suite.
+   ↳ <dim>../path/to/</intensity><bold>suite_one</intensity>
        • unchecked snapshot 1
 
-<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
-<bold>Tests:       </><bold><red>1 failed</></>, 1 total
-<bold>Snapshots:   </><bold><red>1 failed</></>, <bold><green>1 removed</></>, <bold><green>1 file removed</></>, <bold><green>1 updated</></>, <bold><green>1 written</></>, <bold><green>2 passed</></>, 2 total
-<bold>Time:</>        0.01 s
-<dim>Ran all test suites</><dim>.</>
+<bold>Test Suites: </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Tests:       </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Snapshots:   </intensity><bold><red>1 failed</color></intensity>, <bold><green>1 removed</color></intensity>, <bold><green>1 file removed</color></intensity>, <bold><green>1 updated</color></intensity>, <bold><green>1 written</color></intensity>, <bold><green>2 passed</color></intensity>, 2 total
+<bold>Time:</intensity>        0.01 s
+<dim>Ran all test suites</intensity><dim>.</intensity>
 "
 `;
 
 exports[`snapshots all have results (no update) 1`] = `
-"<bold>Snapshot Summary</>
-<bold><green> › 1 snapshot written </></>from 1 test suite.
-<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
-<bold><green> › 1 snapshot updated </></>from 1 test suite.
-<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</>
-<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</>
-   ↳ <dim>../path/to/</><bold>suite_one</>
+"<bold>Snapshot Summary</intensity>
+<bold><green> › 1 snapshot written </color></intensity>from 1 test suite.
+<bold><red> › 1 snapshot failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</intensity>
+<bold><green> › 1 snapshot updated </color></intensity>from 1 test suite.
+<bold><yellow> › 1 snapshot file obsolete </color></intensity>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</intensity>
+<bold><yellow> › 1 snapshot obsolete </color></intensity>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</intensity>
+   ↳ <dim>../path/to/</intensity><bold>suite_one</intensity>
        • unchecked snapshot 1
 
-<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
-<bold>Tests:       </><bold><red>1 failed</></>, 1 total
-<bold>Snapshots:   </><bold><red>1 failed</></>, <bold><yellow>1 obsolete</></>, <bold><yellow>1 file obsolete</></>, <bold><green>1 updated</></>, <bold><green>1 written</></>, <bold><green>2 passed</></>, 2 total
-<bold>Time:</>        0.01 s
-<dim>Ran all test suites</><dim>.</>
+<bold>Test Suites: </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Tests:       </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Snapshots:   </intensity><bold><red>1 failed</color></intensity>, <bold><yellow>1 obsolete</color></intensity>, <bold><yellow>1 file obsolete</color></intensity>, <bold><green>1 updated</color></intensity>, <bold><green>1 written</color></intensity>, <bold><green>2 passed</color></intensity>, 2 total
+<bold>Time:</intensity>        0.01 s
+<dim>Ran all test suites</intensity><dim>.</intensity>
 "
 `;
 
 exports[`snapshots needs update with npm test 1`] = `
-"<bold>Snapshot Summary</>
-<bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`npm test -- -u\` to update them.</>
+"<bold>Snapshot Summary</intensity>
+<bold><red> › 2 snapshots failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or run \`npm test -- -u\` to update them.</intensity>
 
-<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
-<bold>Tests:       </><bold><red>1 failed</></>, 1 total
-<bold>Snapshots:   </><bold><red>2 failed</></>, 2 total
-<bold>Time:</>        0.01 s
-<dim>Ran all test suites</><dim>.</>
+<bold>Test Suites: </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Tests:       </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Snapshots:   </intensity><bold><red>2 failed</color></intensity>, 2 total
+<bold>Time:</intensity>        0.01 s
+<dim>Ran all test suites</intensity><dim>.</intensity>
 "
 `;
 
 exports[`snapshots needs update with yarn test 1`] = `
-"<bold>Snapshot Summary</>
-<bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
+"<bold>Snapshot Summary</intensity>
+<bold><red> › 2 snapshots failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</intensity>
 
-<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
-<bold>Tests:       </><bold><red>1 failed</></>, 1 total
-<bold>Snapshots:   </><bold><red>2 failed</></>, 2 total
-<bold>Time:</>        0.01 s
-<dim>Ran all test suites</><dim>.</>
+<bold>Test Suites: </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Tests:       </intensity><bold><red>1 failed</color></intensity>, 1 total
+<bold>Snapshots:   </intensity><bold><red>2 failed</color></intensity>, 2 total
+<bold>Time:</intensity>        0.01 s
+<dim>Ran all test suites</intensity><dim>.</intensity>
 "
 `;

--- a/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotStatus.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotStatus.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`Retrieves the snapshot status 1`] = `
 Array [
-  "<bold><green> › 1 snapshot written.</></>",
-  "<bold><green> › 1 snapshot updated.</></>",
-  "<bold><red> › 1 snapshot failed.</></>",
-  "<bold><yellow> › 1 snapshot obsolete</></>.",
+  "<bold><green> › 1 snapshot written.</color></intensity>",
+  "<bold><green> › 1 snapshot updated.</color></intensity>",
+  "<bold><red> › 1 snapshot failed.</color></intensity>",
+  "<bold><yellow> › 1 snapshot obsolete</color></intensity>.",
   "   • test suite with unchecked snapshot",
 ]
 `;
 
 exports[`Retrieves the snapshot status after a snapshot update 1`] = `
 Array [
-  "<bold><green> › 2 snapshots written.</></>",
-  "<bold><green> › 2 snapshots updated.</></>",
-  "<bold><red> › 2 snapshots failed.</></>",
-  "<bold><green> › 2 snapshots removed.</></>",
+  "<bold><green> › 2 snapshots written.</color></intensity>",
+  "<bold><green> › 2 snapshots updated.</color></intensity>",
+  "<bold><red> › 2 snapshots failed.</color></intensity>",
+  "<bold><green> › 2 snapshots removed.</color></intensity>",
   "   • first test suite with unchecked snapshot",
   "   • second test suite with unchecked snapshot",
-  "<bold><green> › snapshot file removed.</></>",
+  "<bold><green> › snapshot file removed.</color></intensity>",
 ]
 `;
 

--- a/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotSummary.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotSummary.test.js.snap
@@ -1,38 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`creates a snapshot summary 1`] = `
-"<bold>Snapshot Summary</>
-<bold><green> › 1 snapshot written </></>from 1 test suite.
-<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>
-<bold><green> › 1 snapshot updated </></>from 1 test suite.
-<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>
-<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>
-   ↳ <dim>../path/to/</><bold>suite_one</>
+"<bold>Snapshot Summary</intensity>
+<bold><green> › 1 snapshot written </color></intensity>from 1 test suite.
+<bold><red> › 1 snapshot failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</intensity>
+<bold><green> › 1 snapshot updated </color></intensity>from 1 test suite.
+<bold><yellow> › 1 snapshot file obsolete </color></intensity>from 1 test suite. <dim>To remove it, press --u.</intensity>
+<bold><yellow> › 1 snapshot obsolete </color></intensity>from 1 test suite. <dim>To remove it, press --u.</intensity>
+   ↳ <dim>../path/to/</intensity><bold>suite_one</intensity>
        • unchecked snapshot 1"
 `;
 
 exports[`creates a snapshot summary after an update 1`] = `
-"<bold>Snapshot Summary</>
-<bold><green> › 1 snapshot written </></>from 1 test suite.
-<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>
-<bold><green> › 1 snapshot updated </></>from 1 test suite.
-<bold><green> › 1 snapshot file removed </></>from 1 test suite.
-<bold><green> › 1 snapshot removed </></>from 1 test suite.
-   ↳ <dim>../path/to/</><bold>suite_one</>
+"<bold>Snapshot Summary</intensity>
+<bold><green> › 1 snapshot written </color></intensity>from 1 test suite.
+<bold><red> › 1 snapshot failed</color></intensity> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</intensity>
+<bold><green> › 1 snapshot updated </color></intensity>from 1 test suite.
+<bold><green> › 1 snapshot file removed </color></intensity>from 1 test suite.
+<bold><green> › 1 snapshot removed </color></intensity>from 1 test suite.
+   ↳ <dim>../path/to/</intensity><bold>suite_one</intensity>
        • unchecked snapshot 1"
 `;
 
 exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
-"<bold>Snapshot Summary</>
-<bold><green> › 2 snapshots written </></>from 2 test suites.
-<bold><red> › 2 snapshots failed</></> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</>
-<bold><green> › 2 snapshots updated </></>from 2 test suites.
-<bold><yellow> › 2 snapshot files obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>
-<bold><yellow> › 2 snapshots obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>
-   ↳ <dim>../path/to/</><bold>suite_one</>
+"<bold>Snapshot Summary</intensity>
+<bold><green> › 2 snapshots written </color></intensity>from 2 test suites.
+<bold><red> › 2 snapshots failed</color></intensity> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</intensity>
+<bold><green> › 2 snapshots updated </color></intensity>from 2 test suites.
+<bold><yellow> › 2 snapshot files obsolete </color></intensity>from 2 test suites. <dim>To remove them all, press --u.</intensity>
+<bold><yellow> › 2 snapshots obsolete </color></intensity>from 2 test suites. <dim>To remove them all, press --u.</intensity>
+   ↳ <dim>../path/to/</intensity><bold>suite_one</intensity>
        • unchecked snapshot 1
-   ↳ <dim>../path/to/</><bold>suite_two</>
+   ↳ <dim>../path/to/</intensity><bold>suite_two</intensity>
        • unchecked snapshot 2"
 `;
 
-exports[`returns nothing if there are no updates 1`] = `"<bold>Snapshot Summary</>"`;
+exports[`returns nothing if there are no updates 1`] = `"<bold>Snapshot Summary</intensity>"`;

--- a/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`printDisplayName should correctly print the displayName when color and name are valid values 1`] = `"</><inverse><green> hello </></></>"`;
+exports[`printDisplayName should correctly print the displayName when color and name are valid values 1`] = `"</><inverse><green> hello </color></inverse></>"`;
 
-exports[`printDisplayName should default displayName color to white when color is not a valid value 1`] = `"</><inverse><white> hello </></></>"`;
+exports[`printDisplayName should default displayName color to white when color is not a valid value 1`] = `"</><inverse><white> hello </color></inverse></>"`;
 
-exports[`printDisplayName should default displayName color to white when displayName is a string 1`] = `"</><inverse><white> hello </></></>"`;
+exports[`printDisplayName should default displayName color to white when displayName is a string 1`] = `"</><inverse><white> hello </color></inverse></>"`;
 
-exports[`trimAndFormatPath() does not trim anything 1`] = `"<dim>1234567890/1234567890/</><bold>1234.js</>"`;
+exports[`trimAndFormatPath() does not trim anything 1`] = `"<dim>1234567890/1234567890/</intensity><bold>1234.js</intensity>"`;
 
-exports[`trimAndFormatPath() split at the path.sep index 1`] = `"<dim>.../</><bold>1234.js</>"`;
+exports[`trimAndFormatPath() split at the path.sep index 1`] = `"<dim>.../</intensity><bold>1234.js</intensity>"`;
 
-exports[`trimAndFormatPath() trims dirname (longer line width) 1`] = `"<dim>...890/1234567890/</><bold>1234.js</>"`;
+exports[`trimAndFormatPath() trims dirname (longer line width) 1`] = `"<dim>...890/1234567890/</intensity><bold>1234.js</intensity>"`;
 
-exports[`trimAndFormatPath() trims dirname 1`] = `"<dim>...234567890/</><bold>1234.js</>"`;
+exports[`trimAndFormatPath() trims dirname 1`] = `"<dim>...234567890/</intensity><bold>1234.js</intensity>"`;
 
-exports[`trimAndFormatPath() trims dirname and basename 1`] = `"<bold>...1234.js</>"`;
+exports[`trimAndFormatPath() trims dirname and basename 1`] = `"<bold>...1234.js</intensity>"`;
 
 exports[`wrapAnsiString() returns the string unaltered if given a terminal width of zero 1`] = `"This string shouldn't cause you any trouble"`;
 
@@ -22,8 +22,8 @@ exports[`wrapAnsiString() returns the string unaltered if given a terminal width
 
 exports[`wrapAnsiString() wraps a long string containing ansi chars 1`] = `
 "abcde <red><bold>red-
-bold</></> 12344
-56<dim>bcd</> 123t
+bold</intensity></color> 12344
+56<dim>bcd</intensity> 123t
 tttttththt
 hththththt
 hththththt
@@ -32,7 +32,7 @@ hthththtet
 etetetette
 tetetetete
 tetete<underline><bold>stnh
-snthsnth</></>ss
+snthsnth</intensity></underline>ss
 ot"
 `;
 

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/SnapshotResolver.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/SnapshotResolver.test.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`malformed custom resolver in project config inconsistent functions throws  1`] = `"<bold>Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('foo/__tests__/bar.test.js')) === foo/__SPECS__/bar.test.js</>"`;
+exports[`malformed custom resolver in project config inconsistent functions throws  1`] = `"<bold>Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('foo/__tests__/bar.test.js')) === foo/__SPECS__/bar.test.js</intensity>"`;
 
 exports[`malformed custom resolver in project config missing resolveSnapshotPath throws  1`] = `
-"<bold>Custom snapshot resolver must implement a \`resolveSnapshotPath\` as a function.</>
+"<bold>Custom snapshot resolver must implement a \`resolveSnapshotPath\` as a function.</intensity>
 Documentation: https://jestjs.io/docs/configuration#snapshotresolver-string"
 `;
 
 exports[`malformed custom resolver in project config missing resolveTestPath throws  1`] = `
-"<bold>Custom snapshot resolver must implement a \`resolveTestPath\` as a function.</>
+"<bold>Custom snapshot resolver must implement a \`resolveTestPath\` as a function.</intensity>
 Documentation: https://jestjs.io/docs/configuration#snapshotresolver-string"
 `;
 
 exports[`malformed custom resolver in project config missing testPathForConsistencyCheck throws  1`] = `
-"<bold>Custom snapshot resolver must implement a \`testPathForConsistencyCheck\` as a string.</>
+"<bold>Custom snapshot resolver must implement a \`testPathForConsistencyCheck\` as a string.</intensity>
 Documentation: https://jestjs.io/docs/configuration#snapshotresolver-string"
 `;

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ScriptTransformer (in sync mode) throws an error if \`process\` isn't defined 1`] = `
-"<red><bold>● Invalid synchronous transformer module:</></>
-<red>  "skipped-required-props-preprocessor-only-async" specified in the "transform" object of Jest configuration</>
-<red>  must export a \`process\` function.</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid synchronous transformer module:</intensity></color>
+<red>  "skipped-required-props-preprocessor-only-async" specified in the "transform" object of Jest configuration</color>
+<red>  must export a \`process\` function.</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer in async mode, passes expected transform options to getCacheKey 1`] = `
@@ -137,9 +137,9 @@ exports[`ScriptTransformer in async mode, uses the supplied preprocessor 1`] = `
 exports[`ScriptTransformer in async mode, uses the supplied preprocessor 2`] = `"module.exports = "react";"`;
 
 exports[`ScriptTransformer in async mode, warns of unparseable inlined source maps from the preprocessor 1`] = `
-"<yellow><bold>● Invalid source map:</></>
-<yellow>  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.</>
-<yellow>  Proceeding without source mapping for that file.</>"
+"<yellow><bold>● Invalid source map:</intensity></color>
+<yellow>  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.</color>
+<yellow>  Proceeding without source mapping for that file.</color>"
 `;
 
 exports[`ScriptTransformer passes expected transform options to getCacheKey 1`] = `
@@ -357,125 +357,125 @@ exports[`ScriptTransformer passes expected transform options to getCacheKeyAsync
 `;
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 1`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 2`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 3`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`process\` doesn't return an object containing \`code\` key with processed string 4`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 1`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor-fruits-banana-js" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor-fruits-banana-js" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 2`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor-fruits-avocado-js" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor-fruits-avocado-js" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 3`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor-fruits-kiwi-js" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor-fruits-kiwi-js" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a promise of object containing \`code\` key with processed string 4`] = `
-"<red><bold>● Invalid return value:</></>
-<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </>
-<red>  "passthrough-preprocessor-fruits-grapefruit-js" </>
-<red>  should return an object or a Promise resolving to an object. The object </>
-<red>  must have \`code\` property with a string of processed code.</>
-<red>  <bold>This error may be caused by a breaking change in Jest 28:</></>
-<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid return value:</intensity></color>
+<red>  \`process()\` or/and \`processAsync()\` method of code transformer found at </color>
+<red>  "passthrough-preprocessor-fruits-grapefruit-js" </color>
+<red>  should return an object or a Promise resolving to an object. The object </color>
+<red>  must have \`code\` property with a string of processed code.</color>
+<red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
+<red>  https://jestjs.io/docs/upgrading-to-jest28#transformer</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if createTransformer returns object without \`process\` method 1`] = `
-"<red><bold>● Invalid transformer module:</></>
-<red>  "skipped-required-create-transformer-props-preprocessor" specified in the "transform" object of Jest configuration</>
-<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid transformer module:</intensity></color>
+<red>  "skipped-required-create-transformer-props-preprocessor" specified in the "transform" object of Jest configuration</color>
+<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer throws an error if neither \`process\` nor \`processAsync\` is defined 1`] = `
-"<red><bold>● Invalid transformer module:</></>
-<red>  "skipped-required-props-preprocessor" specified in the "transform" object of Jest configuration</>
-<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</>
-<red>  <bold>Code Transformation Documentation:</></>
-<red>  https://jestjs.io/docs/code-transformation</>
-<red></>"
+"<red><bold>● Invalid transformer module:</intensity></color>
+<red>  "skipped-required-props-preprocessor" specified in the "transform" object of Jest configuration</color>
+<red>  must export a \`process\` or \`processAsync\` or \`createTransformer\` function.</color>
+<red>  <bold>Code Transformation Documentation:</intensity></color>
+<red>  https://jestjs.io/docs/code-transformation</color>
+<red></color>"
 `;
 
 exports[`ScriptTransformer transforms a file async properly 1`] = `
@@ -827,13 +827,13 @@ exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
 exports[`ScriptTransformer uses the supplied preprocessor 2`] = `"module.exports = "react";"`;
 
 exports[`ScriptTransformer warns of unparseable inlined source maps from the async preprocessor 1`] = `
-"<yellow><bold>● Invalid source map:</></>
-<yellow>  The source map for "/fruits/banana.js" returned by "async-preprocessor-with-sourcemaps" is invalid.</>
-<yellow>  Proceeding without source mapping for that file.</>"
+"<yellow><bold>● Invalid source map:</intensity></color>
+<yellow>  The source map for "/fruits/banana.js" returned by "async-preprocessor-with-sourcemaps" is invalid.</color>
+<yellow>  Proceeding without source mapping for that file.</color>"
 `;
 
 exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `
-"<yellow><bold>● Invalid source map:</></>
-<yellow>  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.</>
-<yellow>  Proceeding without source mapping for that file.</>"
+"<yellow><bold>● Invalid source map:</intensity></color>
+<yellow>  The source map for "/fruits/banana.js" returned by "preprocessor-with-sourcemaps" is invalid.</color>
+<yellow>  Proceeding without source mapping for that file.</color>"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.ts.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.ts.snap
@@ -1,196 +1,196 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Repeated types within multiple valid examples are coalesced in error report 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"foo"</> must be of type:</>
-<red>    <bold><green>string</><red></> or <bold><green>number</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>boolean</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"foo"</>: <bold>"foo"</></>
-<red>  }</>
-<red></>
-<red>  or</>
-<red></>
-<red>  {</>
-<red>    <bold>"foo"</>: <bold>"bar"</></>
-<red>  }</>
-<red></>
-<red>  or</>
-<red></>
-<red>  {</>
-<red>    <bold>"foo"</>: <bold>2</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"foo"</intensity> must be of type:</color>
+<red>    <bold><green>string</color><red></intensity> or <bold><green>number</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>boolean</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"foo"</intensity>: <bold>"foo"</intensity></color>
+<red>  }</color>
+<red></color>
+<red>  or</color>
+<red></color>
+<red>  {</color>
+<red>    <bold>"foo"</intensity>: <bold>"bar"</intensity></color>
+<red>  }</color>
+<red></color>
+<red>  or</color>
+<red></color>
+<red>  {</color>
+<red>    <bold>"foo"</intensity>: <bold>2</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`displays warning for deprecated config options 1`] = `
-"<yellow><bold><bold>●</><bold> Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
-<yellow></>
-<yellow>  Jest now treats your current configuration as:</>
-<yellow>  {</>
-<yellow>    <bold>"transform"</>: <bold>{".*": "test"}</></>
-<yellow>  }</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>"
+"<yellow><bold><bold>●</intensity><bold> Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>scriptPreprocessor</intensity> was replaced by <bold>transform</intensity>, which support multiple preprocessors.</color>
+<yellow></color>
+<yellow>  Jest now treats your current configuration as:</color>
+<yellow>  {</color>
+<yellow>    <bold>"transform"</intensity>: <bold>{".*": "test"}</intensity></color>
+<yellow>  }</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>"
 `;
 
 exports[`displays warning for unknown config options 1`] = `
-"<yellow><bold><bold>●</><bold> Validation Warning</>:</>
-<yellow></>
-<yellow>  Unknown option <bold>"unkwon"</> with value <bold>{}</> was found. Did you mean <bold>"unknown"</>?</>
-<yellow>  This is probably a typing mistake. Fixing it will remove this message.</>
-<yellow></>"
+"<yellow><bold><bold>●</intensity><bold> Validation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Unknown option <bold>"unkwon"</intensity> with value <bold>{}</intensity> was found. Did you mean <bold>"unknown"</intensity>?</color>
+<yellow>  This is probably a typing mistake. Fixing it will remove this message.</color>
+<yellow></color>"
 `;
 
 exports[`pretty prints valid config for Array 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"coverageReporters"</> must be of type:</>
-<red>    <bold><green>array</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>object</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"coverageReporters"</>: <bold>[</></>
-<red><bold>      "json",</></>
-<red><bold>      "text",</></>
-<red><bold>      "lcov",</></>
-<red><bold>      "clover"</></>
-<red><bold>    ]</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"coverageReporters"</intensity> must be of type:</color>
+<red>    <bold><green>array</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>object</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"coverageReporters"</intensity>: <bold>[</intensity></color>
+<red><bold>      "json",</intensity></color>
+<red><bold>      "text",</intensity></color>
+<red><bold>      "lcov",</intensity></color>
+<red><bold>      "clover"</intensity></color>
+<red><bold>    ]</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`pretty prints valid config for Boolean 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"automock"</> must be of type:</>
-<red>    <bold><green>boolean</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>array</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"automock"</>: <bold>false</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"automock"</intensity> must be of type:</color>
+<red>    <bold><green>boolean</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>array</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"automock"</intensity>: <bold>false</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`pretty prints valid config for Function 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"fn"</> must be of type:</>
-<red>    <bold><green>function</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>string</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"fn"</>: <bold>(_config, _option, _deprecatedOptions) => true</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"fn"</intensity> must be of type:</color>
+<red>    <bold><green>function</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>string</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"fn"</intensity>: <bold>(_config, _option, _deprecatedOptions) => true</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`pretty prints valid config for Object 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"haste"</> must be of type:</>
-<red>    <bold><green>object</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>number</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"haste"</>: <bold>{}</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"haste"</intensity> must be of type:</color>
+<red>    <bold><green>object</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>number</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"haste"</intensity>: <bold>{}</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`pretty prints valid config for String 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"preset"</> must be of type:</>
-<red>    <bold><green>string</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>number</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"preset"</>: <bold>"react-native"</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"preset"</intensity> must be of type:</color>
+<red>    <bold><green>string</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>number</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"preset"</intensity>: <bold>"react-native"</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`reports errors nicely when failing with multiple valid options 1`] = `
-"<red><bold><bold>●</><bold> Validation Error</>:</>
-<red></>
-<red>  Option <bold>"foo"</> must be of type:</>
-<red>    <bold><green>string</><red></> or <bold><green>array</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>number</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"foo"</>: <bold>"text"</></>
-<red>  }</>
-<red></>
-<red>  or</>
-<red></>
-<red>  {</>
-<red>    <bold>"foo"</>: <bold>[</></>
-<red><bold>      "text"</></>
-<red><bold>    ]</></>
-<red>  }</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"foo"</intensity> must be of type:</color>
+<red>    <bold><green>string</color><red></intensity> or <bold><green>array</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>number</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"foo"</intensity>: <bold>"text"</intensity></color>
+<red>  }</color>
+<red></color>
+<red>  or</color>
+<red></color>
+<red>  {</color>
+<red>    <bold>"foo"</intensity>: <bold>[</intensity></color>
+<red><bold>      "text"</intensity></color>
+<red><bold>    ]</intensity></color>
+<red>  }</color>
+<red></color>"
 `;
 
 exports[`works with custom deprecations 1`] = `
-"<yellow><bold>My Custom Deprecation Warning</>:</>
-<yellow></>
-<yellow>  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
-<yellow></>
-<yellow>  Jest now treats your current configuration as:</>
-<yellow>  {</>
-<yellow>    <bold>"transform"</>: <bold>{".*": "test"}</></>
-<yellow>  }</>
-<yellow></>
-<yellow>  Please update your configuration.</>
-<yellow></>
-<yellow>My custom comment</>"
+"<yellow><bold>My Custom Deprecation Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Option <bold>scriptPreprocessor</intensity> was replaced by <bold>transform</intensity>, which support multiple preprocessors.</color>
+<yellow></color>
+<yellow>  Jest now treats your current configuration as:</color>
+<yellow>  {</color>
+<yellow>    <bold>"transform"</intensity>: <bold>{".*": "test"}</intensity></color>
+<yellow>  }</color>
+<yellow></color>
+<yellow>  Please update your configuration.</color>
+<yellow></color>
+<yellow>My custom comment</color>"
 `;
 
 exports[`works with custom errors 1`] = `
-"<red><bold>My Custom Error</>:</>
-<red></>
-<red>  Option <bold>"test"</> must be of type:</>
-<red>    <bold><green>array</><red></></>
-<red>  but instead received:</>
-<red>    <bold><red>string</><red></></>
-<red></>
-<red>  Example:</>
-<red>  {</>
-<red>    <bold>"test"</>: <bold>[</></>
-<red><bold>      1,</></>
-<red><bold>      2</></>
-<red><bold>    ]</></>
-<red>  }</>
-<red></>
-<red>My custom comment</>"
+"<red><bold>My Custom Error</intensity>:</color>
+<red></color>
+<red>  Option <bold>"test"</intensity> must be of type:</color>
+<red>    <bold><green>array</color><red></intensity></color>
+<red>  but instead received:</color>
+<red>    <bold><red>string</color><red></intensity></color>
+<red></color>
+<red>  Example:</color>
+<red>  {</color>
+<red>    <bold>"test"</intensity>: <bold>[</intensity></color>
+<red><bold>      1,</intensity></color>
+<red><bold>      2</intensity></color>
+<red><bold>    ]</intensity></color>
+<red>  }</color>
+<red></color>
+<red>My custom comment</color>"
 `;
 
 exports[`works with custom warnings 1`] = `
-"<yellow><bold>My Custom Warning</>:</>
-<yellow></>
-<yellow>  Unknown option <bold>"unknown"</> with value <bold>"string"</> was found.</>
-<yellow>  This is probably a typing mistake. Fixing it will remove this message.</>
-<yellow></>
-<yellow>My custom comment</>"
+"<yellow><bold>My Custom Warning</intensity>:</color>
+<yellow></color>
+<yellow>  Unknown option <bold>"unknown"</intensity> with value <bold>"string"</intensity> was found.</color>
+<yellow>  This is probably a typing mistake. Fixing it will remove this message.</color>
+<yellow></color>
+<yellow>My custom comment</color>"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.js.snap
@@ -1,42 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`does not show suggestion when unrecognized cli param length <= 1 1`] = `
-"<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
-<red></>
-<red>  Unrecognized option <bold>"l"</>.</>
-<red></>
-<red>  <bold>CLI Options Documentation</>:</>
-<red>  https://jestjs.io/docs/cli</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Unrecognized CLI Parameter</intensity>:</color>
+<red></color>
+<red>  Unrecognized option <bold>"l"</intensity>.</color>
+<red></color>
+<red>  <bold>CLI Options Documentation</intensity>:</color>
+<red>  https://jestjs.io/docs/cli</color>
+<red></color>"
 `;
 
 exports[`fails for multiple unknown options 1`] = `
-"<red><bold><bold>●</><bold> Unrecognized CLI Parameters</>:</>
-<red></>
-<red>  Following options were not recognized:</>
-<red>  <bold>["jest", "test"]</></>
-<red></>
-<red>  <bold>CLI Options Documentation</>:</>
-<red>  https://jestjs.io/docs/cli</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Unrecognized CLI Parameters</intensity>:</color>
+<red></color>
+<red>  Following options were not recognized:</color>
+<red>  <bold>["jest", "test"]</intensity></color>
+<red></color>
+<red>  <bold>CLI Options Documentation</intensity>:</color>
+<red>  https://jestjs.io/docs/cli</color>
+<red></color>"
 `;
 
 exports[`fails for unknown option 1`] = `
-"<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
-<red></>
-<red>  Unrecognized option <bold>"unknown"</>.</>
-<red></>
-<red>  <bold>CLI Options Documentation</>:</>
-<red>  https://jestjs.io/docs/cli</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Unrecognized CLI Parameter</intensity>:</color>
+<red></color>
+<red>  Unrecognized option <bold>"unknown"</intensity>.</color>
+<red></color>
+<red>  <bold>CLI Options Documentation</intensity>:</color>
+<red>  https://jestjs.io/docs/cli</color>
+<red></color>"
 `;
 
 exports[`shows suggestion when unrecognized cli param length > 1 1`] = `
-"<red><bold><bold>●</><bold> Unrecognized CLI Parameter</>:</>
-<red></>
-<red>  Unrecognized option <bold>"hell"</>. Did you mean <bold>"help"</>?</>
-<red></>
-<red>  <bold>CLI Options Documentation</>:</>
-<red>  https://jestjs.io/docs/cli</>
-<red></>"
+"<red><bold><bold>●</intensity><bold> Unrecognized CLI Parameter</intensity>:</color>
+<red></color>
+<red>  Unrecognized option <bold>"hell"</intensity>. Did you mean <bold>"help"</intensity>?</color>
+<red></color>
+<red>  <bold>CLI Options Documentation</intensity>:</color>
+<red>  https://jestjs.io/docs/cli</color>
+<red></color>"
 `;

--- a/packages/jest-watcher/src/lib/__tests__/__snapshots__/formatTestNameByPattern.test.ts.snap
+++ b/packages/jest-watcher/src/lib/__tests__/__snapshots__/formatTestNameByPattern.test.ts.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 1`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 1`] = `"<dim>should⏎ </intensity></>name</><dim> the ⏎function you at...</intensity>"`;
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 2`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 2`] = `"<dim>should⏎ </intensity></>name</><dim> the ⏎function you at...</intensity>"`;
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 3`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 3`] = `"<dim>should⏎ </intensity></>name</><dim> the ⏎function you at...</intensity>"`;
 
-exports[`for one line test name pattern in the middle test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should </></>nam...</>"`;
+exports[`for one line test name pattern in the middle test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should </intensity></>nam...</>"`;
 
-exports[`for one line test name pattern in the middle test name with cutted tail and highlighted pattern 1`] = `"<dim>should </></>name</><dim> the functi...</>"`;
+exports[`for one line test name pattern in the middle test name with cutted tail and highlighted pattern 1`] = `"<dim>should </intensity></>name</><dim> the functi...</intensity>"`;
 
-exports[`for one line test name pattern in the middle test name with highlighted cutted 1`] = `"<dim>sho</></>...</>"`;
+exports[`for one line test name pattern in the middle test name with highlighted cutted 1`] = `"<dim>sho</intensity></>...</>"`;
 
-exports[`for one line test name pattern in the middle test name with highlighted pattern returns 1`] = `"<dim>should </></>name</><dim> the function you attach</>"`;
+exports[`for one line test name pattern in the middle test name with highlighted pattern returns 1`] = `"<dim>should </intensity></>name</><dim> the function you attach</intensity>"`;
 
-exports[`for one line test name pattern in the tail returns test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should name the function you </></>a...</>"`;
+exports[`for one line test name pattern in the tail returns test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should name the function you </intensity></>a...</>"`;
 
-exports[`for one line test name pattern in the tail returns test name with highlighted cutted 1`] = `"<dim>sho</></>...</>"`;
+exports[`for one line test name pattern in the tail returns test name with highlighted cutted 1`] = `"<dim>sho</intensity></>...</>"`;
 
-exports[`for one line test name pattern in the tail returns test name with highlighted pattern 1`] = `"<dim>should name the function you </></>attach</>"`;
+exports[`for one line test name pattern in the tail returns test name with highlighted pattern 1`] = `"<dim>should name the function you </intensity></>attach</>"`;
 
 exports[`for one line test name with pattern in the head returns test name with cutted tail and cutted highlighted pattern 1`] = `"</>shoul...</>"`;
 
-exports[`for one line test name with pattern in the head returns test name with cutted tail and highlighted pattern 1`] = `"</>should</><dim> name the function yo...</>"`;
+exports[`for one line test name with pattern in the head returns test name with cutted tail and highlighted pattern 1`] = `"</>should</><dim> name the function yo...</intensity>"`;
 
-exports[`for one line test name with pattern in the head returns test name with highlighted pattern 1`] = `"</>should</><dim> name the function you attach</>"`;
+exports[`for one line test name with pattern in the head returns test name with highlighted pattern 1`] = `"</>should</><dim> name the function you attach</intensity>"`;

--- a/packages/pretty-format/src/__tests__/__snapshots__/react.test.tsx.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/react.test.tsx.snap
@@ -1,49 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReactElement plugin highlights syntax 1`] = `
-"<cyan><Mouse</>
-  <yellow>prop</>=<green>{
-    <cyan><div></>
+"<cyan><Mouse</color>
+  <yellow>prop</color>=<green>{
+    <cyan><div></color>
       </>mouse</>
-      <cyan><span></>
+      <cyan><span></color>
         </>rat</>
-      <cyan></span></>
-    <cyan></div></>
-  }</>
-<cyan>/></>"
+      <cyan></span></color>
+    <cyan></div></color>
+  }</color>
+<cyan>/></color>"
 `;
 
 exports[`ReactElement plugin highlights syntax with color from theme option 1`] = `
-"<cyan><Mouse</>
-  <yellow>style</>=<red>"color:red"</>
-<cyan>></>
+"<cyan><Mouse</color>
+  <yellow>style</color>=<red>"color:red"</color>
+<cyan>></color>
   </>Hello, Mouse!</>
-<cyan></Mouse></>"
+<cyan></Mouse></color>"
 `;
 
 exports[`ReactTestComponent plugin highlights syntax 1`] = `
-"<cyan><Mouse</>
-  <yellow>prop</>=<green>{
-    <cyan><div></>
+"<cyan><Mouse</color>
+  <yellow>prop</color>=<green>{
+    <cyan><div></color>
       </>mouse</>
-      <cyan><span></>
+      <cyan><span></color>
         </>rat</>
-      <cyan></span></>
-    <cyan></div></>
-  }</>
-<cyan>/></>"
+      <cyan></span></color>
+    <cyan></div></color>
+  }</color>
+<cyan>/></color>"
 `;
 
 exports[`ReactTestComponent plugin highlights syntax with color from theme option 1`] = `
-"<cyan><Mouse</>
-  <yellow>style</>=<red>"color:red"</>
-<cyan>></>
+"<cyan><Mouse</color>
+  <yellow>style</color>=<red>"color:red"</color>
+<cyan>></color>
   </>Hello, Mouse!</>
-<cyan></Mouse></>"
+<cyan></Mouse></color>"
 `;
 
 exports[`ReactTestComponent removes undefined props 1`] = `
-"<cyan><Mouse</>
-  <yellow>xyz</>=<red>{true}</>
-<cyan>/></>"
+"<cyan><Mouse</color>
+  <yellow>xyz</color>=<red>{true}</color>
+<cyan>/></color>"
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,7 +2712,7 @@ __metadata:
     jest-junit: ^13.0.0
     jest-mock: "workspace:*"
     jest-runner-tsd: ^3.1.0
-    jest-serializer-ansi-escapes: ^1.0.0
+    jest-serializer-ansi-escapes: ^2.0.1
     jest-silent-reporter: ^0.5.0
     jest-snapshot: "workspace:*"
     jest-watch-typeahead: ^1.1.0
@@ -13647,10 +13647,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"jest-serializer-ansi-escapes@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "jest-serializer-ansi-escapes@npm:1.0.1"
-  checksum: 9cf71b090d27b45a7237247feebb556c474cafc52d12c0e5c49b08a5b871dec6046a83343e148eb607f2e6eb901513946347c08708ff35b0daf514085d599c65
+"jest-serializer-ansi-escapes@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jest-serializer-ansi-escapes@npm:2.0.1"
+  checksum: 90af1e8811656326375073472593370e6279ce9e4b965b1861d6c12a6cf0167b8b213261e837e1b2072aba5483cb87afcc1fea66af79b87bcf96f672f041e4af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Following up #12935

## Summary

This PR is upgrading `jest-serializer-ansi-escapes` to v2.

Version 2 of the plugin introduced better serialization for reset sequences. For instance, a snapshot like `<red>first<bold>second</>third</>` becomes `<red>first<bold>second</intensity>third</color>`.

197 snapshots got updated. I was avoiding this change in the first PR. The diff is huge, but the change is focused and simple.

## Test plan

Green CI.