### PR TITLE
Refine babel-plugin-jest-hoist typings

### DIFF
--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -14,8 +14,10 @@ import {
   CallExpression,
   Expression,
   Identifier,
+  MemberExpression,
   Node,
   Program,
+  Super,
   VariableDeclaration,
   VariableDeclarator,
   callExpression,
@@ -197,7 +199,9 @@ function GETTER_NAME() {
 }
 `;
 
-const isJestObject = (expression: NodePath<Expression>): boolean => {
+const isJestObject = (
+  expression: NodePath<Expression | Super>,
+): expression is NodePath<Identifier | MemberExpression> => {
   // global
   if (
     expression.isIdentifier() &&
@@ -231,8 +235,8 @@ const isJestObject = (expression: NodePath<Expression>): boolean => {
   return false;
 };
 
-const extractJestObjExprIfHoistable = <T extends Node>(
-  expr: NodePath<T>,
+const extractJestObjExprIfHoistable = (
+  expr: NodePath,
 ): NodePath<Expression> | null => {
   if (!expr.isCallExpression()) {
     return null;


### PR DESCRIPTION
Super will not be included in Expression in Babel 8

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix potential Babel 8 typing errors: https://github.com/babel/babel/runs/7308856226?check_suite_focus=true#step:10:507

In Babel 8 we will remove `Super` from `Expression`: So a MemberExpression's object will be `Expression | Super` and `isJestObject` should handle `Super` as well. It already supports `Super` but will need typing updates. I updated typings so that it should work with both Babel 7 and Babel 8.

This PR should unblock https://github.com/babel/babel/pull/14750

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Run `yarn lint`