### PR TITLE
fix(jest-mock): add index signature support for `spyOn` types

### DIFF
--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -279,6 +279,34 @@ const spiedObject = {
   },
 };
 
+type IndexSpiedObject = {
+  [key: string]: Record<string, any>;
+
+  methodA(): boolean;
+  methodB(a: string, b: number): void;
+  methodC: (c: number) => boolean;
+  methodE: (e: any) => never;
+
+  propertyA: {a: string};
+};
+
+const indexSpiedObject: IndexSpiedObject = {
+  methodA() {
+    return true;
+  },
+  methodB(a: string, b: number) {
+    return;
+  },
+  methodC(c: number) {
+    return true;
+  },
+  methodE(e: any) {
+    throw new Error();
+  },
+
+  propertyA: {a: 'abc'},
+};
+
 const spy = spyOn(spiedObject, 'methodA');
 
 expectNotAssignable<Function>(spy); // eslint-disable-line @typescript-eslint/ban-types
@@ -330,3 +358,30 @@ expectType<SpyInstance<(value: string | number | Date) => Date>>(
   spyOn(globalThis, 'Date'),
 );
 expectType<SpyInstance<() => number>>(spyOn(Date, 'now'));
+
+// object with index signatures
+
+expectType<SpyInstance<typeof indexSpiedObject.methodA>>(
+  spyOn(indexSpiedObject, 'methodA'),
+);
+expectType<SpyInstance<typeof indexSpiedObject.methodB>>(
+  spyOn(indexSpiedObject, 'methodB'),
+);
+expectType<SpyInstance<typeof indexSpiedObject.methodC>>(
+  spyOn(indexSpiedObject, 'methodC'),
+);
+expectType<SpyInstance<typeof indexSpiedObject.methodE>>(
+  spyOn(indexSpiedObject, 'methodE'),
+);
+
+expectError(spyOn(indexSpiedObject, 'propertyA'));
+
+expectType<SpyInstance<() => {a: string}>>(
+  spyOn(indexSpiedObject, 'propertyA', 'get'),
+);
+expectType<SpyInstance<(value: {a: string}) => void>>(
+  spyOn(indexSpiedObject, 'propertyA', 'set'),
+);
+expectError(spyOn(indexSpiedObject, 'propertyA'));
+
+expectError(spyOn(indexSpiedObject, 'notThere'));

--- a/packages/jest-mock/__typetests__/utility-types.test.ts
+++ b/packages/jest-mock/__typetests__/utility-types.test.ts
@@ -37,6 +37,31 @@ class SomeClass {
   }
 }
 
+class IndexClass {
+  [key: string]: Record<string, any>;
+
+  propertyB = {b: 123};
+  private _propertyC = {c: undefined};
+  #propertyD = 'abc';
+
+  constructor(public propertyA: {a: string}) {}
+
+  methodA(): void {
+    return;
+  }
+
+  methodB(b: string): string {
+    return b;
+  }
+
+  get propertyC() {
+    return this._propertyC;
+  }
+  set propertyC(value) {
+    this._propertyC = value;
+  }
+}
+
 const someObject = {
   SomeClass,
 
@@ -55,6 +80,17 @@ const someObject = {
 };
 
 type SomeObject = typeof someObject;
+
+type IndexObject = {
+  [key: string]: Record<string, any>;
+
+  methodA(): void;
+  methodB(b: string): boolean;
+  methodC: (c: number) => true;
+
+  propertyA: {a: 123};
+  propertyB: {b: 'value'};
+};
 
 // ClassLike
 
@@ -89,15 +125,23 @@ expectType<'SomeClass'>(constructorKeys);
 // MethodKeys
 
 declare const classMethods: MethodLikeKeys<SomeClass>;
+declare const indexClassMethods: MethodLikeKeys<IndexClass>;
 declare const objectMethods: MethodLikeKeys<SomeObject>;
+declare const indexObjectMethods: MethodLikeKeys<IndexObject>;
 
 expectType<'methodA' | 'methodB'>(classMethods);
+expectType<'methodA' | 'methodB'>(indexClassMethods);
 expectType<'methodA' | 'methodB' | 'methodC'>(objectMethods);
+expectType<'methodA' | 'methodB' | 'methodC'>(indexObjectMethods);
 
 // PropertyKeys
 
 declare const classProperties: PropertyLikeKeys<SomeClass>;
+declare const indexClassProperties: PropertyLikeKeys<IndexClass>;
 declare const objectProperties: PropertyLikeKeys<SomeObject>;
+declare const indexObjectProperties: PropertyLikeKeys<IndexObject>;
 
 expectType<'propertyA' | 'propertyB' | 'propertyC'>(classProperties);
+expectType<string>(indexClassProperties);
 expectType<'propertyA' | 'propertyB' | 'someClassInstance'>(objectProperties);
+expectType<string>(indexObjectProperties);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -34,13 +34,13 @@ export type MockFunctionMetadata<
 export type ClassLike = {new (...args: any): any};
 export type FunctionLike = (...args: any) => any;
 
-export type ConstructorLikeKeys<T> = {
-  [K in keyof T]: T[K] extends ClassLike ? K : never;
-}[keyof T];
+export type ConstructorLikeKeys<T> = keyof {
+  [K in keyof T as T[K] extends ClassLike ? K : never]: T[K];
+};
 
-export type MethodLikeKeys<T> = {
-  [K in keyof T]: T[K] extends FunctionLike ? K : never;
-}[keyof T];
+export type MethodLikeKeys<T> = keyof {
+  [K in keyof T as T[K] extends FunctionLike ? K : never]: T[K];
+};
 
 export type PropertyLikeKeys<T> = {
   [K in keyof T]: T[K] extends FunctionLike


### PR DESCRIPTION
Fixes #13012
Adapted from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60971/files

## Summary

As it is explained in the linked issue (and also #12966), currently `spyOn` types do not handle [index signatures](https://www.typescriptlang.org/docs/handbook/2/objects.html#index-signatures). Thanks @Maxim-Mazurok, a fix landed in `@types/jest`. Here I adapted it for Jest types to make it work through `import {jest} from '@jest/globals'`. 

@Maxim-Mazurok could you take a look, please? (;

## Test plan

Type tests are added. They are failing on `main`, but should pass on this branch.