### PR TITLE
chore: bump `typescript` and related dependencies

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,7 +15,7 @@
     "core-js": "^3.2.1",
     "rxjs": "^7.5.5",
     "tslib": "^2.0.0",
-    "typescript": "^4.7.3",
+    "typescript": "^4.7.4",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "^17.0.1",
-    "typescript": "^4.7.3"
+    "typescript": "^4.7.4"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "@crowdin/cli": "^3.5.2",
     "@jest/globals": "workspace:*",
     "@jest/test-utils": "workspace:*",
-    "@microsoft/api-extractor": "^7.24.0",
+    "@microsoft/api-extractor": "^7.28.4",
     "@tsconfig/node12": "^1.0.9",
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.0.0",
     "@types/babel__template": "^7.0.2",
@@ -82,7 +82,7 @@
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
     "type-fest": "^2.11.2",
-    "typescript": "^4.7.3",
+    "typescript": "^4.7.4",
     "which": "^2.0.1"
   },
   "scripts": {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.1",
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "chalk": "^4.0.0",
     "fast-check": "^3.0.0",
     "immutable": "^4.0.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -58,7 +58,7 @@
     "@types/micromatch": "^4.0.1",
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
-    "typescript": "^4.7.3"
+    "typescript": "^4.7.4"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -21,7 +21,7 @@
     "jest-snapshot": "^28.1.2"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "tsd-lite": "^0.5.6"
   },
   "engines": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -21,7 +21,7 @@
     "@types/node": "*"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "tsd-lite": "^0.5.6"
   },
   "engines": {

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.1",
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/exit": "^0.1.30",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -28,7 +28,7 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/graceful-fs": "^4.1.3",
     "@types/pnpapi": "^0.0.2",
     "@types/resolve": "^1.20.2",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -40,7 +40,7 @@
     "source-map-support": "0.5.13"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.3",
     "@types/source-map-support": "^0.5.0",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -45,7 +45,7 @@
     "@babel/preset-flow": "^7.7.2",
     "@babel/preset-react": "^7.12.1",
     "@jest/test-utils": "^28.1.1",
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
     "@types/semver": "^7.1.0",

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "tsd-lite": "^0.5.6"
   },
   "publishConfig": {

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -22,7 +22,7 @@
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",
     "get-stream": "^6.0.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -19,7 +19,7 @@
     "jest-cli": "^28.1.2"
   },
   "devDependencies": {
-    "@tsd/typescript": "~4.7.3",
+    "@tsd/typescript": "~4.7.4",
     "tsd-lite": "^0.5.6"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,7 +2616,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect@workspace:packages/jest-expect"
   dependencies:
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     expect: ^28.1.1
     jest-snapshot: ^28.1.2
     tsd-lite: ^0.5.6
@@ -2661,9 +2661,9 @@ __metadata:
     "@crowdin/cli": ^3.5.2
     "@jest/globals": "workspace:*"
     "@jest/test-utils": "workspace:*"
-    "@microsoft/api-extractor": ^7.24.0
+    "@microsoft/api-extractor": ^7.28.4
     "@tsconfig/node12": ^1.0.9
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/babel__core": ^7.1.14
     "@types/babel__generator": ^7.0.0
     "@types/babel__template": ^7.0.2
@@ -2731,7 +2731,7 @@ __metadata:
     tempy: ^1.0.0
     ts-node: ^10.5.0
     type-fest: ^2.11.2
-    typescript: ^4.7.3
+    typescript: ^4.7.4
     which: ^2.0.1
   languageName: unknown
   linkType: soft
@@ -2747,7 +2747,7 @@ __metadata:
     "@jest/transform": ^28.1.2
     "@jest/types": ^28.1.1
     "@jridgewell/trace-mapping": ^0.3.13
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/exit": ^0.1.30
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.3
@@ -2879,7 +2879,7 @@ __metadata:
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
     "@jest/schemas": ^28.0.2
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
@@ -3816,27 +3816,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor-model@npm:7.17.3":
-  version: 7.17.3
-  resolution: "@microsoft/api-extractor-model@npm:7.17.3"
+"@microsoft/api-extractor-model@npm:7.21.0":
+  version: 7.21.0
+  resolution: "@microsoft/api-extractor-model@npm:7.21.0"
   dependencies:
     "@microsoft/tsdoc": 0.14.1
     "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.45.5
-  checksum: 5b68f59c7ea0c4cb9678e40fd9a0aab1c46e1e3cc6f754bcee58dd3fbfc290b0865b56823cdd0a6ec58b569501cbe4a84a708f87a5cc409c7fdab10c0853b112
+    "@rushstack/node-core-library": 3.49.0
+  checksum: 9e0cb0cd2d344ee23f32294103856e413fd998ceefc5ea26427b603ef7a6dc155ff6710bf3a30d0c426b9928118e8f56e080f0c0aa9685f3e825e7e154340f62
   languageName: node
   linkType: hard
 
-"@microsoft/api-extractor@npm:^7.24.0":
-  version: 7.24.2
-  resolution: "@microsoft/api-extractor@npm:7.24.2"
+"@microsoft/api-extractor@npm:^7.28.4":
+  version: 7.28.4
+  resolution: "@microsoft/api-extractor@npm:7.28.4"
   dependencies:
-    "@microsoft/api-extractor-model": 7.17.3
+    "@microsoft/api-extractor-model": 7.21.0
     "@microsoft/tsdoc": 0.14.1
     "@microsoft/tsdoc-config": ~0.16.1
-    "@rushstack/node-core-library": 3.45.5
-    "@rushstack/rig-package": 0.3.11
-    "@rushstack/ts-command-line": 4.11.0
+    "@rushstack/node-core-library": 3.49.0
+    "@rushstack/rig-package": 0.3.13
+    "@rushstack/ts-command-line": 4.12.1
     colors: ~1.2.1
     lodash: ~4.17.15
     resolve: ~1.17.0
@@ -3845,7 +3845,7 @@ __metadata:
     typescript: ~4.6.3
   bin:
     api-extractor: bin/api-extractor
-  checksum: e4345ac9e15018155ece8424046137ed3b157a0484512d4d52279f80acd352eca81566652c600ef81893febc69e7d3d4cebc6a155a1a218724d28e8009fe886d
+  checksum: 889e286986c29de3c6c9101e547575b14d5764c58868980a4b8d68921c65721a6e50b97a55f14a9c0d2dc190cdd90148e87cf97f27515e5cede1b7bbf7513912
   languageName: node
   linkType: hard
 
@@ -4413,9 +4413,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rushstack/node-core-library@npm:3.45.5":
-  version: 3.45.5
-  resolution: "@rushstack/node-core-library@npm:3.45.5"
+"@rushstack/node-core-library@npm:3.49.0":
+  version: 3.49.0
+  resolution: "@rushstack/node-core-library@npm:3.49.0"
   dependencies:
     "@types/node": 12.20.24
     colors: ~1.2.1
@@ -4426,29 +4426,29 @@ __metadata:
     semver: ~7.3.0
     timsort: ~0.3.0
     z-schema: ~5.0.2
-  checksum: 4533c809401827eca3f98863ef2adb1975a5c57bca3fef706a710dd90828d0468bcc3fce15bda483784d690573be1dfcf890abb99f368e9a3bff75aa88913997
+  checksum: 6ac8247a466faebc242cf8ca6a9960d78dee305482358cca15e9a9ba22f775c18d4f857a9dfcad4c03853d4a6fde768d142a794b6af2baa6aecd5f8faee989a2
   languageName: node
   linkType: hard
 
-"@rushstack/rig-package@npm:0.3.11":
-  version: 0.3.11
-  resolution: "@rushstack/rig-package@npm:0.3.11"
+"@rushstack/rig-package@npm:0.3.13":
+  version: 0.3.13
+  resolution: "@rushstack/rig-package@npm:0.3.13"
   dependencies:
     resolve: ~1.17.0
     strip-json-comments: ~3.1.1
-  checksum: a6354152a9ac7503a217e7903d2739d35f305b2331f880fca94e6f309ba78e86b58fa8eda888238429bc4203a5cef4df4218f80e636fa75290e68875b971697a
+  checksum: 98c0b7dbefe6ae169745d065d696fbef5d07e71bae5146e070a2e37de82c5625752865c54f12bba6b002868fcb27a1d2d098a19b0a5d20a1dfacaa002c81c13d
   languageName: node
   linkType: hard
 
-"@rushstack/ts-command-line@npm:4.11.0":
-  version: 4.11.0
-  resolution: "@rushstack/ts-command-line@npm:4.11.0"
+"@rushstack/ts-command-line@npm:4.12.1":
+  version: 4.12.1
+  resolution: "@rushstack/ts-command-line@npm:4.12.1"
   dependencies:
     "@types/argparse": 1.0.38
     argparse: ~1.0.9
     colors: ~1.2.1
     string-argv: ~0.3.1
-  checksum: 966692b5738d198130d6a8f01f819dfa95dccaf7a8e4c2f9d76d36205790584e827afb18f837703f07bfe93faa3b705c81e682888a4aef0da350758c7c6582d1
+  checksum: e9479bd001f4f206d207c867ec7b91444727cf8a1c685dac7589c6a33b54f47200deabc450d6831a1cc38501f0322eb7003c1f78f1fa43230541c4b7ddc4718d
   languageName: node
   linkType: hard
 
@@ -4772,13 +4772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsd/typescript@npm:~4.7.3":
-  version: 4.7.3
-  resolution: "@tsd/typescript@npm:4.7.3"
+"@tsd/typescript@npm:~4.7.4":
+  version: 4.7.4
+  resolution: "@tsd/typescript@npm:4.7.4"
   bin:
     tsc: typescript/bin/tsc
     tsserver: typescript/bin/tsserver
-  checksum: 18f7537b883ee9ccf697938ff7cbc042cc6137c1b473d4d36dabf68eca1c6190fbfb6dad0f2b0f7f71bff66a1518295cb1e01731f8fbaf678cf5c3d6e363fdb9
+  checksum: 1a84773cb4bb01898fb0b6011ec5c2fb3e3c91585ea009bbf9d525b46d40f1827417dfc5f7b1efdf534b111a5947b063ae04490d147bda37b038e1a7d264672d
   languageName: node
   linkType: hard
 
@@ -6195,7 +6195,7 @@ __metadata:
     jest-zone-patch: "*"
     rxjs: ^7.5.5
     tslib: ^2.0.0
-    typescript: ^4.7.3
+    typescript: ^4.7.4
     zone.js: ~0.11.3
   languageName: unknown
   linkType: soft
@@ -10208,7 +10208,7 @@ __metadata:
     jest: "workspace:*"
     react: 17.0.2
     react-dom: ^17.0.1
-    typescript: ^4.7.3
+    typescript: ^4.7.4
   languageName: unknown
   linkType: soft
 
@@ -10272,7 +10272,7 @@ __metadata:
   dependencies:
     "@jest/expect-utils": ^28.1.1
     "@jest/test-utils": ^28.1.1
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     chalk: ^4.0.0
     fast-check: ^3.0.0
     immutable: ^4.0.0
@@ -13160,7 +13160,7 @@ __metadata:
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
-    typescript: ^4.7.3
+    typescript: ^4.7.4
   peerDependencies:
     "@types/node": "*"
     ts-node: ">=9.0.0"
@@ -13415,7 +13415,7 @@ __metadata:
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
     "@jest/types": ^28.1.1
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/node": "*"
     tsd-lite: ^0.5.6
   languageName: unknown
@@ -13497,7 +13497,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-resolve@workspace:packages/jest-resolve"
   dependencies:
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/graceful-fs": ^4.1.3
     "@types/pnpapi": ^0.0.2
     "@types/resolve": ^1.20.2
@@ -13537,7 +13537,7 @@ __metadata:
     "@jest/test-result": ^28.1.1
     "@jest/transform": ^28.1.2
     "@jest/types": ^28.1.1
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/exit": ^0.1.30
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
@@ -13638,7 +13638,7 @@ __metadata:
     "@jest/test-utils": ^28.1.1
     "@jest/transform": ^28.1.2
     "@jest/types": ^28.1.1
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/babel__traverse": ^7.0.6
     "@types/graceful-fs": ^4.1.3
     "@types/natural-compare": ^1.4.0
@@ -13797,7 +13797,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-worker@workspace:packages/jest-worker"
   dependencies:
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"
     "@types/supports-color": ^8.1.0
@@ -13847,7 +13847,7 @@ __metadata:
   dependencies:
     "@jest/core": ^28.1.2
     "@jest/types": ^28.1.1
-    "@tsd/typescript": ~4.7.3
+    "@tsd/typescript": ~4.7.4
     import-local: ^3.0.2
     jest-cli: ^28.1.2
     tsd-lite: ^0.5.6
@@ -21561,13 +21561,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.7.3":
-  version: 4.7.3
-  resolution: "typescript@npm:4.7.3"
+"typescript@npm:^4.7.4":
+  version: 4.7.4
+  resolution: "typescript@npm:4.7.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: fd13a1ce53790a36bb8350e1f5e5e384b5f6cb9b0635114a6d01d49cb99916abdcfbc13c7521cdae2f2d3f6d8bc4a8ae7625edf645a04ee940588cd5e7597b2f
+  checksum: 5750181b1cd7e6482c4195825547e70f944114fb47e58e4aa7553e62f11b3f3173766aef9c281783edfd881f7b8299cf35e3ca8caebe73d8464528c907a164df
   languageName: node
   linkType: hard
 
@@ -21581,13 +21581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.7.3#~builtin<compat/typescript>":
-  version: 4.7.3
-  resolution: "typescript@patch:typescript@npm%3A4.7.3#~builtin<compat/typescript>::version=4.7.3&hash=7ad353"
+"typescript@patch:typescript@^4.7.4#~builtin<compat/typescript>":
+  version: 4.7.4
+  resolution: "typescript@patch:typescript@npm%3A4.7.4#~builtin<compat/typescript>::version=4.7.4&hash=7ad353"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 137d18a77f52254a284960b16ab53d0619f57b69b5d585804b8413f798a1175ce3e774fb95e6a101868577aafe357d8fcfc9171f0dc9fc0c210e9ae59d107cc0
+  checksum: 9096d8f6c16cb80ef3bf96fcbbd055bf1c4a43bd14f3b7be45a9fbe7ada46ec977f604d5feed3263b4f2aa7d4c7477ce5f9cd87de0d6feedec69a983f3a4f93e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

I was hoping to silence warning messages by bumping `@microsoft/api-extractor`, but it still complains. Seems like they are stuck with TS 4.6.3. That’s fine. Let‘s upgrade everything anyways (;

## Test plan

Green CI.