### PR TITLE
fix: missing spaces in string concats

### DIFF
--- a/e2e/coverage-report/notRequiredInTestSuite.js
+++ b/e2e/coverage-report/notRequiredInTestSuite.js
@@ -6,7 +6,7 @@
  */
 
 throw new Error(
-  'this error should not be a problem because' +
+  'this error should not be a problem because ' +
     'this file is never required or executed',
 );
 

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -196,7 +196,7 @@ export const options: {[key: string]: Options} = {
     description:
       'The path to a jest config file specifying how to find ' +
       'and execute tests. If no rootDir is set in the config, the directory ' +
-      'containing the config file is assumed to be the rootDir for the project.' +
+      'containing the config file is assumed to be the rootDir for the project. ' +
       'This can also be a JSON encoded value which Jest will use as configuration.',
     type: 'string',
   },
@@ -213,7 +213,7 @@ export const options: {[key: string]: Options} = {
   coveragePathIgnorePatterns: {
     description:
       'An array of regexp pattern strings that are matched ' +
-      'against all file paths before executing the test. If the file path' +
+      'against all file paths before executing the test. If the file path ' +
       'matches any of the patterns, coverage information will be skipped.',
     string: true,
     type: 'array',
@@ -311,7 +311,7 @@ export const options: {[key: string]: Options} = {
   },
   ignoreProjects: {
     description:
-      'Ignore the tests of the specified projects.' +
+      'Ignore the tests of the specified projects. ' +
       'Jest uses the attribute `displayName` in the configuration to identify each project.',
     string: true,
     type: 'array',
@@ -352,7 +352,7 @@ export const options: {[key: string]: Options} = {
   },
   maxConcurrency: {
     description:
-      'Specifies the maximum number of tests that are allowed to run' +
+      'Specifies the maximum number of tests that are allowed to run ' +
       'concurrently. This only affects tests using `test.concurrent`.',
     type: 'number',
   },
@@ -517,7 +517,7 @@ export const options: {[key: string]: Options} = {
   },
   selectProjects: {
     description:
-      'Run the tests of the specified projects.' +
+      'Run the tests of the specified projects. ' +
       'Jest uses the attribute `displayName` in the configuration to identify each project.',
     string: true,
     type: 'array',

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -50,7 +50,7 @@ export default class LeakDetector {
 
         throw new Error(
           'The leaking detection mechanism requires newer version of node that supports ' +
-            'FinalizationRegistry, update your node or install the "weak-napi" package' +
+            'FinalizationRegistry, update your node or install the "weak-napi" package ' +
             'which support current node version as a dependency on your main project.',
         );
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The missing spaces at the end of each line affects the readability of the output to the CLI.

As an example:

```bash
jest --help

...
      --coveragePathIgnorePatterns  An array of regexp pattern strings that are
                                    matched against all file paths before
                                    executing the test. If the file pathmatches
                                    any of the patterns, coverage information
                                    will be skipped.                     [array]
...

```

Note how "path" and "matches" are squashed together in the output.

This PR simply adds the missing spaces

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

N/A

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
