### PR TITLE
refactor(jest-mock): simplify `PropertyLikeKeys` utility type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - `[jest-changed-files]` Fix a lock-up after repeated invocations ([#12757](https://github.com/facebook/jest/issues/12757))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS OrderedSets ([#12977](https://github.com/facebook/jest/pull/12977))
-- `[jest-mock]` Add index signature support for `spyOn` types ([#13013](https://github.com/facebook/jest/pull/13013))
+- `[jest-mock]` Add index signature support for `spyOn` types ([#13013](https://github.com/facebook/jest/pull/13013), [#13020](https://github.com/facebook/jest/pull/13020))
 - `[jest-snapshot]` Fix indentation of awaited inline snapshots ([#12986](https://github.com/facebook/jest/pull/12986))
 
 ### Chore & Maintenance

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -374,8 +374,6 @@ expectType<SpyInstance<typeof indexSpiedObject.methodE>>(
   spyOn(indexSpiedObject, 'methodE'),
 );
 
-expectError(spyOn(indexSpiedObject, 'propertyA'));
-
 expectType<SpyInstance<() => {a: string}>>(
   spyOn(indexSpiedObject, 'propertyA', 'get'),
 );

--- a/packages/jest-mock/__typetests__/utility-types.test.ts
+++ b/packages/jest-mock/__typetests__/utility-types.test.ts
@@ -86,10 +86,10 @@ type IndexObject = {
 
   methodA(): void;
   methodB(b: string): boolean;
-  methodC: (c: number) => true;
+  methodC: (c: number) => boolean;
 
-  propertyA: {a: 123};
-  propertyB: {b: 'value'};
+  propertyA: {a: number};
+  propertyB: {b: string};
 };
 
 // ClassLike
@@ -142,6 +142,6 @@ declare const objectProperties: PropertyLikeKeys<SomeObject>;
 declare const indexObjectProperties: PropertyLikeKeys<IndexObject>;
 
 expectType<'propertyA' | 'propertyB' | 'propertyC'>(classProperties);
-expectType<string>(indexClassProperties);
+expectType<string | number>(indexClassProperties);
 expectType<'propertyA' | 'propertyB' | 'someClassInstance'>(objectProperties);
-expectType<string>(indexObjectProperties);
+expectType<string | number>(indexObjectProperties);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -42,13 +42,10 @@ export type MethodLikeKeys<T> = keyof {
   [K in keyof T as T[K] extends FunctionLike ? K : never]: T[K];
 };
 
-export type PropertyLikeKeys<T> = {
-  [K in keyof T]: T[K] extends FunctionLike
-    ? never
-    : T[K] extends ClassLike
-    ? never
-    : K;
-}[keyof T];
+export type PropertyLikeKeys<T> = Exclude<
+  keyof T,
+  ConstructorLikeKeys<T> | MethodLikeKeys<T>
+>;
 
 // TODO Figure out how to replace this with TS ConstructorParameters utility type
 // https://www.typescriptlang.org/docs/handbook/utility-types.html#constructorparameterstype


### PR DESCRIPTION
## Summary

The shape of `PropertyLikeKeys` utility type looks somewhat redundant after #13013. I was not happy with it, hence decided to go for a refactor.

## Test plan

`PropertyLikeKeys` is covered by type test. These and all other type tests should pass.