### PR TITLE
feat: upgrade to jsdom@20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-config]` [**BREAKING**] Make `snapshotFormat` default to `escapeString: false` and `printBasicPrototype: false` ([#13036](https://github.com/facebook/jest/pull/13036))
+- `[jest-environment-jsdom]` [**BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037))
 
 ### Fixes
 

--- a/docs/UpgradingToJest29.md
+++ b/docs/UpgradingToJest29.md
@@ -27,3 +27,7 @@ If you want to keep the old behavior, you can set the `snapshotFormat` property 
 +   printBasicPrototype: true
 + }
 ```
+
+## JSDOM upgrade
+
+`jest-environment-jsdom` has upgraded `jsdom` from v19 to v20. Due to issues with `@types/jsdom`, if you extend this environment, you might run into type errors. See https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/60999#discussioncomment-3158685.

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -24,7 +24,7 @@
     "@types/node": "*",
     "jest-mock": "^28.1.3",
     "jest-util": "^28.1.3",
-    "jsdom": "^19.0.0"
+    "jsdom": "^20.0.0"
   },
   "devDependencies": {
     "@jest/test-utils": "^28.1.3"

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -20,7 +20,6 @@
     "@jest/environment": "^28.1.3",
     "@jest/fake-timers": "^28.1.3",
     "@jest/types": "^28.1.3",
-    "@types/jsdom": "^16.2.4",
     "@types/node": "*",
     "jest-mock": "^28.1.3",
     "jest-util": "^28.1.3",

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -30,7 +30,8 @@ type Win =
   };
 
 export default class JSDOMEnvironment implements JestEnvironment<number> {
-  dom: JSDOM | null;
+  // TODO: make non-privat when we have `@types/jsdom` again
+  private dom: JSDOM | null;
   fakeTimers: LegacyFakeTimers<number> | null;
   fakeTimersModern: ModernFakeTimers | null;
   global: Win;

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -20,7 +20,9 @@ import {installCommonGlobals} from 'jest-util';
 
 // The `Window` interface does not have an `Error.stackTraceLimit` property, but
 // `JSDOMEnvironment` assumes it is there.
-type Win = Window &
+type Win =
+  // TODO: this adds a dependency on the @types/trusted-types module, probably fixed by `@types/jsdom`
+  /* Window & */
   Global.Global & {
     Error: {
       stackTraceLimit: number;

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/// <reference lib="dom" />
+
 import type {Context} from 'vm';
 // @ts-expect-error: TODO: we're missing v20 types
 import {JSDOM, ResourceLoader, VirtualConsole} from 'jsdom';
@@ -20,9 +22,7 @@ import {installCommonGlobals} from 'jest-util';
 
 // The `Window` interface does not have an `Error.stackTraceLimit` property, but
 // `JSDOMEnvironment` assumes it is there.
-type Win =
-  // TODO: this adds a dependency on the @types/trusted-types module, probably fixed by `@types/jsdom`
-  /* Window & */
+type Win = Window &
   Global.Global & {
     Error: {
       stackTraceLimit: number;
@@ -91,7 +91,6 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
         process.emit('uncaughtException', event.error);
       }
     };
-    // @ts-expect-error: TODO: we're missing v20 types
     global.addEventListener('error', this.errorEventListener);
 
     // However, don't report them as uncaught if the user listens to 'error' event.
@@ -100,23 +99,19 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
     const originalRemoveListener = global.removeEventListener;
     let userErrorListenerCount = 0;
     global.addEventListener = function (
-      // @ts-expect-error: TODO: we're missing v20 types
       ...args: Parameters<typeof originalAddListener>
     ) {
       if (args[0] === 'error') {
         userErrorListenerCount++;
       }
-      // @ts-expect-error: TODO: we're missing v20 types
       return originalAddListener.apply(this, args);
     };
     global.removeEventListener = function (
-      // @ts-expect-error: TODO: we're missing v20 types
       ...args: Parameters<typeof originalRemoveListener>
     ) {
       if (args[0] === 'error') {
         userErrorListenerCount--;
       }
-      // @ts-expect-error: TODO: we're missing v20 types
       return originalRemoveListener.apply(this, args);
     };
 
@@ -164,10 +159,8 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
     }
     if (this.global) {
       if (this.errorEventListener) {
-        // @ts-expect-error: TODO: we're missing v20 types
         this.global.removeEventListener('error', this.errorEventListener);
       }
-      // @ts-expect-error: TODO: we're missing v20 types
       this.global.close();
 
       // Dispose "document" to prevent "load" event from triggering.

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type {Context} from 'vm';
+// @ts-expect-error: TODO: we're missing v20 types
 import {JSDOM, ResourceLoader, VirtualConsole} from 'jsdom';
 import type {
   EnvironmentContext,
@@ -40,6 +41,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
 
     const virtualConsole = new VirtualConsole();
     virtualConsole.sendTo(context.console, {omitJSDOMErrors: true});
+    // @ts-expect-error: TODO: we're missing v20 types
     virtualConsole.on('jsdomError', error => {
       context.console.error(error);
     });
@@ -86,6 +88,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
         process.emit('uncaughtException', event.error);
       }
     };
+    // @ts-expect-error: TODO: we're missing v20 types
     global.addEventListener('error', this.errorEventListener);
 
     // However, don't report them as uncaught if the user listens to 'error' event.
@@ -94,19 +97,23 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
     const originalRemoveListener = global.removeEventListener;
     let userErrorListenerCount = 0;
     global.addEventListener = function (
+      // @ts-expect-error: TODO: we're missing v20 types
       ...args: Parameters<typeof originalAddListener>
     ) {
       if (args[0] === 'error') {
         userErrorListenerCount++;
       }
+      // @ts-expect-error: TODO: we're missing v20 types
       return originalAddListener.apply(this, args);
     };
     global.removeEventListener = function (
+      // @ts-expect-error: TODO: we're missing v20 types
       ...args: Parameters<typeof originalRemoveListener>
     ) {
       if (args[0] === 'error') {
         userErrorListenerCount--;
       }
+      // @ts-expect-error: TODO: we're missing v20 types
       return originalRemoveListener.apply(this, args);
     };
 
@@ -154,8 +161,10 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
     }
     if (this.global) {
       if (this.errorEventListener) {
+        // @ts-expect-error: TODO: we're missing v20 types
         this.global.removeEventListener('error', this.errorEventListener);
       }
+      // @ts-expect-error: TODO: we're missing v20 types
       this.global.close();
 
       // Dispose "document" to prevent "load" event from triggering.

--- a/packages/jest-fake-timers/tsconfig.json
+++ b/packages/jest-fake-timers/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/packages/jest-matcher-utils/tsconfig.json
+++ b/packages/jest-matcher-utils/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -24,6 +24,7 @@
     "@jest/test-result": "^28.1.3",
     "@jest/transform": "^28.1.3",
     "@jest/types": "^28.1.3",
+    "@types/node": "*",
     "chalk": "^4.0.0",
     "cjs-module-lexer": "^1.0.0",
     "collect-v8-coverage": "^1.0.0",
@@ -43,7 +44,6 @@
     "@jest/test-utils": "^28.1.3",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",
-    "@types/node": "*",
     "jest-environment-node": "^28.1.3"
   },
   "engines": {

--- a/packages/pretty-format/src/__tests__/DOMCollection.test.ts
+++ b/packages/pretty-format/src/__tests__/DOMCollection.test.ts
@@ -126,7 +126,7 @@ describe('DOMCollection plugin for list items', () => {
   });
 
   const expectedHTMLFormControlsCollection = [
-    'HTMLCollection [',
+    'HTMLFormControlsCollection [',
     '  <select>',
     '    <option',
     '      value="1"',

--- a/packages/pretty-format/tsconfig.json
+++ b/packages/pretty-format/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["es2020", "dom"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,17 +5174,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jsdom@npm:^16.2.4":
-  version: 16.2.14
-  resolution: "@types/jsdom@npm:16.2.14"
-  dependencies:
-    "@types/node": "*"
-    "@types/parse5": "*"
-    "@types/tough-cookie": "*"
-  checksum: 12bb926fa74ea07c0ba0bfd5bf185ac0fd771b28666a5e8784b9af4bb96bb0c51fc5f494eff7da1d3cd804e4757f640a23c344c1cd5d188f95ab0ab51770d88b
-  languageName: node
-  linkType: hard
-
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.4, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -5304,13 +5293,6 @@ __metadata:
   version: 4.0.0
   resolution: "@types/parse-json@npm:4.0.0"
   checksum: fd6bce2b674b6efc3db4c7c3d336bd70c90838e8439de639b909ce22f3720d21344f52427f1d9e57b265fcb7f6c018699b99e5e0c208a1a4823014269a6bf35b
-  languageName: node
-  linkType: hard
-
-"@types/parse5@npm:*":
-  version: 6.0.3
-  resolution: "@types/parse5@npm:6.0.3"
-  checksum: ddb59ee4144af5dfcc508a8dcf32f37879d11e12559561e65788756b95b33e6f03ea027d88e1f5408f9b7bfb656bf630ace31a2169edf44151daaf8dd58df1b7
   languageName: node
   linkType: hard
 
@@ -5567,13 +5549,6 @@ __metadata:
   version: 0.2.3
   resolution: "@types/tmp@npm:0.2.3"
   checksum: 0ca45e99b3b3c6959d5c4f4555f73c8007db540cfb0fbbb9373217f9ab85e67eef75193f51a1d6564b0ee6c6f5ffa259d1034d7f7530a5b7ce80acb94cfc4daa
-  languageName: node
-  linkType: hard
-
-"@types/tough-cookie@npm:*":
-  version: 4.0.2
-  resolution: "@types/tough-cookie@npm:4.0.2"
-  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
   languageName: node
   linkType: hard
 
@@ -13225,7 +13200,6 @@ __metadata:
     "@jest/fake-timers": ^28.1.3
     "@jest/test-utils": ^28.1.3
     "@jest/types": ^28.1.3
-    "@types/jsdom": ^16.2.4
     "@types/node": "*"
     jest-mock: ^28.1.3
     jest-util: ^28.1.3

--- a/yarn.lock
+++ b/yarn.lock
@@ -5571,9 +5571,9 @@ __metadata:
   linkType: hard
 
 "@types/tough-cookie@npm:*":
-  version: 4.0.1
-  resolution: "@types/tough-cookie@npm:4.0.1"
-  checksum: 7570c1c2d74201f4ead3512cf8e4c99e97d92ab8a02ae2fb987fd720ced0ca1a2baf250c98a861a170b86762606c9bf6d32207675f13dffc5ab75c08c96578d2
+  version: 4.0.2
+  resolution: "@types/tough-cookie@npm:4.0.2"
+  checksum: e055556ffdaa39ad85ede0af192c93f93f986f4bd9e9426efdc2948e3e2632db3a4a584d4937dbf6d7620527419bc99e6182d3daf2b08685e710f2eda5291905
   languageName: node
   linkType: hard
 
@@ -5961,10 +5961,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abab@npm:^2.0.3, abab@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "abab@npm:2.0.5"
-  checksum: 0ec951b46d5418c2c2f923021ec193eaebdb4e802ffd5506286781b454be722a13a8430f98085cd3e204918401d9130ec6cc8f5ae19be315b3a0e857d83196e1
+"abab@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "abab@npm:2.0.6"
+  checksum: 6ffc1af4ff315066c62600123990d87551ceb0aafa01e6539da77b0f5987ac7019466780bf480f1787576d4385e3690c81ccc37cfda12819bf510b8ab47e5a3e
   languageName: node
   linkType: hard
 
@@ -8661,14 +8661,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"data-urls@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "data-urls@npm:3.0.1"
+"data-urls@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "data-urls@npm:3.0.2"
   dependencies:
-    abab: ^2.0.3
+    abab: ^2.0.6
     whatwg-mimetype: ^3.0.0
-    whatwg-url: ^10.0.0
-  checksum: 00c71280d5d8146a2f19f3fce3ce59c3b860c66cd584f4e7db8764477a9c97966fa06543c9d9d28b762784f50e21c2e2ccb2d0be24b392ec82eb21daf7804b3e
+    whatwg-url: ^11.0.0
+  checksum: 033fc3dd0fba6d24bc9a024ddcf9923691dd24f90a3d26f6545d6a2f71ec6956f93462f2cdf2183cc46f10dc01ed3bcb36731a8208456eb1a08147e571fe2a76
   languageName: node
   linkType: hard
 
@@ -13229,7 +13229,7 @@ __metadata:
     "@types/node": "*"
     jest-mock: ^28.1.3
     jest-util: ^28.1.3
-    jsdom: ^19.0.0
+    jsdom: ^20.0.0
   languageName: unknown
   linkType: soft
 
@@ -13970,27 +13970,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^19.0.0":
-  version: 19.0.0
-  resolution: "jsdom@npm:19.0.0"
+"jsdom@npm:^20.0.0":
+  version: 20.0.0
+  resolution: "jsdom@npm:20.0.0"
   dependencies:
-    abab: ^2.0.5
-    acorn: ^8.5.0
+    abab: ^2.0.6
+    acorn: ^8.7.1
     acorn-globals: ^6.0.0
     cssom: ^0.5.0
     cssstyle: ^2.3.0
-    data-urls: ^3.0.1
+    data-urls: ^3.0.2
     decimal.js: ^10.3.1
     domexception: ^4.0.0
     escodegen: ^2.0.0
     form-data: ^4.0.0
     html-encoding-sniffer: ^3.0.0
     http-proxy-agent: ^5.0.0
-    https-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.1
     is-potential-custom-element-name: ^1.0.1
     nwsapi: ^2.2.0
-    parse5: 6.0.1
-    saxes: ^5.0.1
+    parse5: ^7.0.0
+    saxes: ^6.0.0
     symbol-tree: ^3.2.4
     tough-cookie: ^4.0.0
     w3c-hr-time: ^1.0.2
@@ -13998,15 +13998,15 @@ __metadata:
     webidl-conversions: ^7.0.0
     whatwg-encoding: ^2.0.0
     whatwg-mimetype: ^3.0.0
-    whatwg-url: ^10.0.0
-    ws: ^8.2.3
+    whatwg-url: ^11.0.0
+    ws: ^8.8.0
     xml-name-validator: ^4.0.0
   peerDependencies:
     canvas: ^2.5.0
   peerDependenciesMeta:
     canvas:
       optional: true
-  checksum: 94b693bf4a394097dd96705550bb7b6cd3c8db3c5414e6e9c92a0995ed8b61067597da2f37fca6bed4b5a2f1ef33960ee759522156dccd0b306311988ea87cfb
+  checksum: f69b40679d8cfaee2353615445aaff08b823c53dc7778ede6592d02ed12b3e9fb4e8db2b6d033551b67e08424a3adb2b79d231caa7dcda2d16019c20c705c11f
   languageName: node
   linkType: hard
 
@@ -16508,9 +16508,9 @@ __metadata:
   linkType: hard
 
 "nwsapi@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "nwsapi@npm:2.2.0"
-  checksum: 5ef4a9bc0c1a5b7f2e014aa6a4b359a257503b796618ed1ef0eb852098f77e772305bb0e92856e4bbfa3e6c75da48c0113505c76f144555ff38867229c2400a7
+  version: 2.2.1
+  resolution: "nwsapi@npm:2.2.1"
+  checksum: 6c21fcb6950538012516b39137ed9b53ed56843e521362e977282c781169f229e7bca8ec6e207165b19912550f360806b222f77b6c9202bb8d66818456875c3d
   languageName: node
   linkType: hard
 
@@ -17088,19 +17088,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:6.0.1, parse5@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "parse5@npm:6.0.1"
-  checksum: 7d569a176c5460897f7c8f3377eff640d54132b9be51ae8a8fa4979af940830b2b0c296ce75e5bd8f4041520aadde13170dbdec44889975f906098ea0002f4bd
-  languageName: node
-  linkType: hard
-
 "parse5@npm:^3.0.1":
   version: 3.0.3
   resolution: "parse5@npm:3.0.3"
   dependencies:
     "@types/node": "*"
   checksum: 6a82d59d60496f4a8bba99daee37eda728adb403197b9c9a163dcc02e369758992bcc67f1618d4f1445f4b12e7651e001c2847e446b8376d4d706e1d571f570d
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "parse5@npm:6.0.1"
+  checksum: 7d569a176c5460897f7c8f3377eff640d54132b9be51ae8a8fa4979af940830b2b0c296ce75e5bd8f4041520aadde13170dbdec44889975f906098ea0002f4bd
   languageName: node
   linkType: hard
 
@@ -18053,9 +18053,9 @@ __metadata:
   linkType: hard
 
 "psl@npm:^1.1.28, psl@npm:^1.1.33":
-  version: 1.8.0
-  resolution: "psl@npm:1.8.0"
-  checksum: 6150048ed2da3f919478bee8a82f3828303bc0fc730fb015a48f83c9977682c7b28c60ab01425a72d82a2891a1681627aa530a991d50c086b48a3be27744bde7
+  version: 1.9.0
+  resolution: "psl@npm:1.9.0"
+  checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
   languageName: node
   linkType: hard
 
@@ -19592,12 +19592,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"saxes@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "saxes@npm:5.0.1"
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
   dependencies:
     xmlchars: ^2.2.0
-  checksum: 5636b55cf15f7cf0baa73f2797bf992bdcf75d1b39d82c0aa4608555c774368f6ac321cb641fd5f3d3ceb87805122cd47540da6a7b5960fe0dbdb8f8c263f000
+  checksum: d3fa3e2aaf6c65ed52ee993aff1891fc47d5e47d515164b5449cbf5da2cbdc396137e55590472e64c5c436c14ae64a8a03c29b9e7389fc6f14035cf4e982ef3b
   languageName: node
   linkType: hard
 
@@ -22537,16 +22537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"whatwg-url@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "whatwg-url@npm:10.0.0"
-  dependencies:
-    tr46: ^3.0.0
-    webidl-conversions: ^7.0.0
-  checksum: a21ec309c5cc743fe9414509408bedf65eaf0fb5c17ac66baa08ef12fce16da4dd30ce90abefbd5a716408301c58a73666dabfd5042cf4242992eb98b954f861
-  languageName: node
-  linkType: hard
-
 "whatwg-url@npm:^11.0.0":
   version: 11.0.0
   resolution: "whatwg-url@npm:11.0.0"
@@ -23014,9 +23004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.2.3, ws@npm:^8.4.2":
-  version: 8.8.0
-  resolution: "ws@npm:8.8.0"
+"ws@npm:^8.4.2, ws@npm:^8.8.0":
+  version: 8.8.1
+  resolution: "ws@npm:8.8.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -23025,7 +23015,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 6ceed1ca1cb800ef60c7fc8346c7d5d73d73be754228eb958765abf5d714519338efa20ffe674167039486eb3a813aae5a497f8d319e16b4d96216a31df5bd95
+  checksum: 2152cf862cae0693f3775bc688a6afb2e989d19d626d215e70f5fcd8eb55b1c3b0d3a6a4052905ec320e2d7734e20aeedbf9744496d62f15a26ad79cf4cf7dae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://github.com/jsdom/jsdom/releases/tag/20.0.0

Had to remove `@types/jsdom` as its dependency on `@types/parse5` clashes with the builtin types of `parse5`. I've opened https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61299 as a start on migrating, but ugh

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
