### PR TITLE
fix: when an out of memory event occurs process should exit correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
+
 ### Chore & Maintenance
 
 - `[*]` [**BREAKING**] Drop support for Node v12 and v17 ([#13033](https://github.com/facebook/jest/pull/13033))


### PR DESCRIPTION
## Summary

Fix for #13052

## Test plan

Testing simulated a `SIGTERM` event and verifies process exits as expected.
