### PR TITLE
fix(expect-utils): Fix equality of ImmutableJS Record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
+- `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
 
 ### Chore & Maintenance
 

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {List, OrderedMap, OrderedSet} from 'immutable';
+import {List, OrderedMap, OrderedSet, Record} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {
   arrayBufferEquality,
@@ -535,6 +535,13 @@ describe('iterableEquality', () => {
   test('returns true when given Immutable OrderedSets without an OwnerID', () => {
     const a = OrderedSet().add('newValue');
     const b = List(['newValue']).toOrderedSet();
+    expect(iterableEquality(a, b)).toBe(true);
+  });
+
+  test('returns true when given Immutable Record without an OwnerID', () => {
+    class TestRecord extends Record({dummy: ''}) {}
+    const a = new TestRecord().merge({dummy: 'data'});
+    const b = new TestRecord().set('dummy', 'data');
     expect(iterableEquality(a, b)).toBe(true);
   });
 });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -243,6 +243,7 @@ const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
 const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
 const IS_LIST_SENTINEL = '@@__IMMUTABLE_LIST__@@';
 const IS_ORDERED_SENTINEL = '@@__IMMUTABLE_ORDERED__@@';
+const IS_RECORD_SYMBOL = '@@__IMMUTABLE_RECORD__@@';
 
 export function isImmutableUnorderedKeyed(maybeKeyed: any) {
   return !!(
@@ -281,5 +282,12 @@ export function isImmutableOrderedSet(maybeSet: any) {
     maybeSet &&
     maybeSet[IS_SET_SENTINEL] &&
     maybeSet[IS_ORDERED_SENTINEL]
+  );
+}
+
+export function isImmutableRecord(maybeSet: any) {
+  return !!(
+    maybeSet &&
+    maybeSet[IS_RECORD_SYMBOL]
   );
 }

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -13,6 +13,7 @@ import {
   isImmutableList,
   isImmutableOrderedKeyed,
   isImmutableOrderedSet,
+  isImmutableRecord,
   isImmutableUnorderedKeyed,
   isImmutableUnorderedSet,
 } from './jasmineUtils';
@@ -260,7 +261,8 @@ export const iterableEquality = (
   if (
     !isImmutableList(a) &&
     !isImmutableOrderedKeyed(a) &&
-    !isImmutableOrderedSet(a)
+    !isImmutableOrderedSet(a) &&
+    !isImmutableRecord(a)
   ) {
     const aEntries = Object.entries(a);
     const bEntries = Object.entries(b);


### PR DESCRIPTION
## Summary

Fixes #13051 

## Test plan

I added an `iterableEquality` test for two `Record` that have the same contents, but were not considered equal before this change. This PR follows the changes made in #12977 for a similar issue.