### PR TITLE
docs(website): fix code block line highlight CSS

### DIFF
--- a/website/src/css/docusaurusTheme.css
+++ b/website/src/css/docusaurusTheme.css
@@ -21,6 +21,8 @@
   --grey: #aaaaaa;
   --grey2: #ededed;
   --grey3: #545454;
+
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 :root[data-theme='dark'] {
@@ -39,6 +41,8 @@
   --grey: #aaaaaa;
   --grey2: #545454;
   --grey3: #ededed;
+
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
 .header-github-link:hover {
@@ -69,15 +73,4 @@ html[data-theme='dark'] .footer--dark {
 
 .footer--dark .text--center {
   color: var(--grey);
-}
-
-.docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
-  display: block;
-  margin: 0 calc(-1 * var(--ifm-pre-padding));
-  padding: 0 var(--ifm-pre-padding);
-}
-
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is a minor breaking change. See https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments and https://github.com/facebook/docusaurus/pull/7176. Currently the highlighting color is falling back to the default, as in https://jestjs.io/docs/getting-started#using-typescript

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
