### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -98,6 +98,16 @@ Arguments can also be mixed:
 jest --update-snapshot --detectOpenHandles
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Options
 
 :::note

--- a/website/versioned_docs/version-25.x/CLI.md
+++ b/website/versioned_docs/version-25.x/CLI.md
@@ -96,6 +96,16 @@ Arguments can also be mixed:
 jest --update-snapshot --detectOpenHandles
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Options
 
 :::note

--- a/website/versioned_docs/version-26.x/CLI.md
+++ b/website/versioned_docs/version-26.x/CLI.md
@@ -81,6 +81,16 @@ you can use:
 npm test -- -u -t="ColorPicker"
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Camelcase & dashed args support
 
 Jest supports both camelcase and dashed arg formats. The following examples will have an equal result:

--- a/website/versioned_docs/version-27.x/CLI.md
+++ b/website/versioned_docs/version-27.x/CLI.md
@@ -96,6 +96,16 @@ Arguments can also be mixed:
 jest --update-snapshot --detectOpenHandles
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Options
 
 _Note: CLI options take precedence over values from the [Configuration](Configuration.md)._

--- a/website/versioned_docs/version-28.0/CLI.md
+++ b/website/versioned_docs/version-28.0/CLI.md
@@ -98,6 +98,16 @@ Arguments can also be mixed:
 jest --update-snapshot --detectOpenHandles
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
 ## Options
 
 :::note

--- a/website/versioned_docs/version-28.1/CLI.md
+++ b/website/versioned_docs/version-28.1/CLI.md
@@ -83,17 +83,6 @@ you can use:
 npm test -- -u -t="ColorPicker"
 ```
 
-## Autocomplete
-
-You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
-
-To install, run:
-
-```shell
-brew install fig
-```
-
-
 ## Camelcase & dashed args support
 
 Jest supports both camelcase and dashed arg formats. The following examples will have an equal result:
@@ -107,6 +96,16 @@ Arguments can also be mixed:
 
 ```bash
 jest --update-snapshot --detectOpenHandles
+```
+
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
 ```
 
 ## Options

--- a/website/versioned_docs/version-28.1/CLI.md
+++ b/website/versioned_docs/version-28.1/CLI.md
@@ -83,6 +83,17 @@ you can use:
 npm test -- -u -t="ColorPicker"
 ```
 
+## Autocomplete
+
+You can get IDE-style autocompletions for Jest with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```
+
+
 ## Camelcase & dashed args support
 
 Jest supports both camelcase and dashed arg formats. The following examples will have an equal result:


### PR DESCRIPTION
## Summary

[Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Jest. It looks like this:

<img width="379" alt="image" src="https://user-images.githubusercontent.com/4949076/181378396-c6f79699-5bc8-4ab5-87de-cf4077d541d2.png">

We think this will help users become more efficient with Jest CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

## Test plan

Edited just the docs, shouldn't affect tests. 