### PR TITLE
Jest-HasteMap: Passed over inaccessible and unregistered file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
+- `[@jest/jest-haste-map]` EPERM crash in High accesible files in Windows ([#13088](https://github.com/facebook/jest/pull/13088))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/watchers/NodeWatcher.js
+++ b/packages/jest-haste-map/src/watchers/NodeWatcher.js
@@ -279,7 +279,7 @@ module.exports = class NodeWatcher extends EventEmitter {
     const relativePath = path.join(path.relative(this.root, dir), file);
 
     fs.lstat(fullPath, (error, stat) => {
-      if (error && error.code !== 'ENOENT') {
+      if (error && error.code !== 'ENOENT' && error.code !== 'EPERM') {
         this.emit('error', error);
       } else if (!error && stat.isDirectory()) {
         // win32 emits usless change events on dirs.

--- a/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
+++ b/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
@@ -241,6 +241,12 @@ WatchmanWatcher.prototype.handleFileChange = function (changeDescriptor) {
         return;
       }
 
+      // Files can be inaccessible
+      // the most reliable thing to do here is to ignore the event.
+      if (error && error.code === 'EPERM') {
+        return;
+      }
+
       if (handleError(self, error)) {
         return;
       }

--- a/packages/jest-util/src/tryRealpath.ts
+++ b/packages/jest-util/src/tryRealpath.ts
@@ -11,7 +11,7 @@ export default function tryRealpath(path: string): string {
   try {
     path = realpathSync.native(path);
   } catch (error: any) {
-    if (error.code !== 'ENOENT') {
+    if (error.code !== 'ENOENT' && error.code !== 'EPERM') {
       throw error;
     }
   }


### PR DESCRIPTION
`nodewatcher` specifically in Windows makes an exception when it tries to access a file in High level , this will help in preventing the `EPERM` crash when it tries to access file that is high level