### PR TITLE
docs: Fixed React Native tests link

### DIFF
--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests) projects.
 
 ## Join the community
 

--- a/website/versioned_docs/version-25.x/MoreResources.md
+++ b/website/versioned_docs/version-25.x/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests__) projects.
 
 ## Join the community
 

--- a/website/versioned_docs/version-26.x/MoreResources.md
+++ b/website/versioned_docs/version-26.x/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests__) projects.
 
 ## Join the community
 

--- a/website/versioned_docs/version-27.x/MoreResources.md
+++ b/website/versioned_docs/version-27.x/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests) projects.
 
 ## Join the community
 

--- a/website/versioned_docs/version-28.0/MoreResources.md
+++ b/website/versioned_docs/version-28.0/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests__) projects.
 
 ## Join the community
 

--- a/website/versioned_docs/version-28.1/MoreResources.md
+++ b/website/versioned_docs/version-28.1/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests__) projects.
 
 ## Join the community
 


### PR DESCRIPTION
## Summary
The link to the React Native tests folder changed, therefore was wrong.

## Test plan
It is broken in production.
