### PR TITLE
fix: increase the maximum possible file size that jest-haste-map can handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
+- `[jest-haste-map]` Increase the maximum possible file size that jest-haste-map can handle ([#13094](https://github.com/facebook/jest/pull/13094))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/worker.ts
+++ b/packages/jest-haste-map/src/worker.ts
@@ -100,7 +100,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
 
   // If a SHA-1 is requested on update, compute it.
   if (computeSha1) {
-    sha1 = sha1hex(getContent() || fs.readFileSync(filePath));
+    sha1 = sha1hex(content || fs.readFileSync(filePath));
   }
 
   return {dependencies, id, module, sha1};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, the read file is decoded using UTF8 regardless of whether the worker needs to or not. This bottlenecks the maximum file size that the worker can hash to ~536MB (maximum length of a string) which causes a hard crash if exceeded. For files that don't need to be decoded and are only hashed, this change allows the worker to hash the file without decoding it, leaving it as a buffer. Since buffers have a maximum size of ~2GB on 64-bit systems, this increases the maximum possible file size significantly.

For files that were already successfully decoded in previous steps (eg. JSON files), the worker will continue to hash the already decoded `content` string instead of rereading the file.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tests for the hashing are already handled in `jest-haste-map/src/__tests__/worker.test.js`
