### PR TITLE
fix: repair caching of typescript compiler instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- `[jest-config]` Fix testing multiple projects with TypeScript config files ([#13099](https://github.com/facebook/jest/pull/13099))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
 - `[jest-haste-map]` Increase the maximum possible file size that jest-haste-map can handle ([#13094](https://github.com/facebook/jest/pull/13094))
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))

--- a/e2e/__tests__/typescriptConfigFile.test.ts
+++ b/e2e/__tests__/typescriptConfigFile.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {tmpdir} from 'os';
+import * as path from 'path';
+import {cleanup, writeFiles} from '../Utils';
+import runJest from '../runJest';
+
+const DIR = path.resolve(tmpdir(), 'typescript-config-file');
+
+beforeEach(() => cleanup(DIR));
+afterEach(() => cleanup(DIR));
+
+test('works with single typescript config that imports something', () => {
+  writeFiles(DIR, {
+    '__tests__/mytest.alpha.js': "test('alpha', () => expect(1).toBe(1));",
+    '__tests__/mytest.common.js': "test('common', () => expect(1).toBe(1));",
+    'alpha.config.ts': `
+    import commonRegex from './common';
+    export default {
+      testRegex: [ commonRegex, '__tests__/mytest.alpha.js' ]
+    };`,
+    'common.ts': "export default '__tests__/mytest.common.js$';",
+  });
+
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--projects', 'alpha.config.ts'],
+    {
+      skipPkgJsonCheck: true,
+    },
+  );
+
+  expect(stderr).toContain('PASS __tests__/mytest.alpha.js');
+  expect(stderr).toContain('PASS __tests__/mytest.common.js');
+  expect(stderr).toContain('Test Suites: 2 passed, 2 total');
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe('');
+});
+
+test('works with multiple typescript configs', () => {
+  writeFiles(DIR, {
+    '__tests__/mytest.alpha.js': "test('alpha', () => expect(1).toBe(1));",
+    '__tests__/mytest.beta.js': "test('beta', () => expect(1).toBe(1));",
+    'alpha.config.ts': `
+    export default {
+      testRegex: '__tests__/mytest.alpha.js'
+    };`,
+    'beta.config.ts': `
+    export default {
+      testRegex: '__tests__/mytest.beta.js'
+    };`,
+  });
+
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--projects', 'alpha.config.ts', 'beta.config.ts'],
+    {
+      skipPkgJsonCheck: true,
+    },
+  );
+
+  expect(stderr).toContain('PASS __tests__/mytest.alpha.js');
+  expect(stderr).toContain('PASS __tests__/mytest.beta.js');
+  expect(stderr).toContain('Test Suites: 2 passed, 2 total');
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe('');
+});
+
+test('works with multiple typescript configs that import something', () => {
+  writeFiles(DIR, {
+    '__tests__/mytest.alpha.js': "test('alpha', () => expect(1).toBe(1));",
+    '__tests__/mytest.beta.js': "test('beta', () => expect(1).toBe(1));",
+    '__tests__/mytest.common.js': "test('common', () => expect(1).toBe(1));",
+    'alpha.config.ts': `
+    import commonRegex from './common';
+    export default {
+      testRegex: [ commonRegex, '__tests__/mytest.alpha.js' ]
+    };`,
+    'beta.config.ts': `
+    import commonRegex from './common';
+    export default {
+      testRegex: [ commonRegex, '__tests__/mytest.beta.js' ]
+    };`,
+    'common.ts': "export default '__tests__/mytest.common.js$';",
+  });
+
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--projects', 'alpha.config.ts', 'beta.config.ts'],
+    {
+      skipPkgJsonCheck: true,
+    },
+  );
+
+  expect(stderr).toContain('PASS __tests__/mytest.alpha.js');
+  expect(stderr).toContain('PASS __tests__/mytest.beta.js');
+  expect(stderr).toContain('PASS __tests__/mytest.common.js');
+  expect(stderr.replace('PASS __tests__/mytest.common.js', '')).toContain(
+    'PASS __tests__/mytest.common.js',
+  );
+  expect(stderr).toContain('Test Suites: 4 passed, 4 total');
+  expect(exitCode).toBe(0);
+  expect(stdout).toBe('');
+});

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -100,13 +100,13 @@ const loadTSConfigFile = async (
 
 let registeredCompilerPromise: Promise<Service>;
 
-const getRegisteredCompiler = async () => {
+function getRegisteredCompiler() {
   // Cache the promise to avoid multiple registrations
   registeredCompilerPromise = registeredCompilerPromise ?? registerTsNode();
   return registeredCompilerPromise;
-};
+}
 
-const registerTsNode = async () => {
+async function registerTsNode(): Promise<Service> {
   try {
     // Register TypeScript compiler instance
     const tsNode = await import('ts-node');
@@ -127,4 +127,4 @@ const registerTsNode = async () => {
 
     throw e;
   }
-};
+}

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -77,16 +77,14 @@ export default async function readConfigFileAndSetRootDir(
   return configObject;
 }
 
-let registerer: Service;
-
 // Load the TypeScript configuration
 const loadTSConfigFile = async (
   configPath: string,
 ): Promise<Config.InitialOptions> => {
-  // Register TypeScript compiler instance
-  await registerTsNode();
+  // Get registered TypeScript compiler instance
+  const registeredCompiler = await getRegisteredCompiler();
 
-  registerer.enabled(true);
+  registeredCompiler.enabled(true);
 
   let configObject = interopRequireDefault(require(configPath)).default;
 
@@ -95,19 +93,24 @@ const loadTSConfigFile = async (
     configObject = await configObject();
   }
 
-  registerer.enabled(false);
+  registeredCompiler.enabled(false);
 
   return configObject;
 };
 
-async function registerTsNode(): Promise<Service> {
-  if (registerer) {
-    return registerer;
-  }
+let registeredCompilerPromise: Promise<Service>;
 
+const getRegisteredCompiler = async () => {
+  // Cache the promise to avoid multiple registrations
+  registeredCompilerPromise = registeredCompilerPromise ?? registerTsNode();
+  return registeredCompilerPromise;
+};
+
+const registerTsNode = async () => {
   try {
+    // Register TypeScript compiler instance
     const tsNode = await import('ts-node');
-    registerer = tsNode.register({
+    return tsNode.register({
       compilerOptions: {
         module: 'CommonJS',
       },
@@ -115,7 +118,6 @@ async function registerTsNode(): Promise<Service> {
         '**': 'cjs',
       },
     });
-    return registerer;
   } catch (e: any) {
     if (e.code === 'ERR_MODULE_NOT_FOUND') {
       throw new Error(
@@ -125,4 +127,4 @@ async function registerTsNode(): Promise<Service> {
 
     throw e;
   }
-}
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

After updating to jest 28, testing crashes when loading multiple TypeScript jest config files (e.g. `jest --projects jest-node.config.ts jest-jsdom.config.ts`). This only appears to happen, if the files import something. The issue has been documented previously in kulshekhar/ts-jest#3691.

The cause was a race condition when creating the typescript compiler service, leading to ts-node being registered multiple times. This causes a crash similar to TypeStrong/ts-node#883.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I added integration tests based on the multiProjectRunner test. They verify that:
- a single TypeScript jest config with imports works as expected
- multiple TypeScript jest configs without imports work as expected
- multiple TypeScript jest configs with imports work as expected

The first and the second test would have already passed previously, the third failed previously.
