### PR TITLE
fix: add workerIdleMemoryLimit to ValidConfig

### DIFF
--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -187,6 +187,7 @@ const initialOptions: Config.InitialOptions = {
     ],
   ],
   watchman: true,
+  workerIdleMemoryLimit: 0.2,
 };
 
 export default initialOptions;

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -187,7 +187,7 @@ const initialOptions: Config.InitialOptions = {
     ],
   ],
   watchman: true,
-  workerIdleMemoryLimit: 0.2,
+  workerIdleMemoryLimit: multipleValidOptions(0.2, '50%'),
 };
 
 export default initialOptions;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -327,7 +327,7 @@ export type InitialOptions = Partial<{
   watchAll: boolean;
   watchman: boolean;
   watchPlugins: Array<string | [string, Record<string, unknown>]>;
-  workerIdleMemoryLimit: number;
+  workerIdleMemoryLimit: number | string;
 }>;
 
 export type SnapshotUpdateState = 'all' | 'new' | 'none';
@@ -574,6 +574,6 @@ export type Argv = Arguments<
     watchAll: boolean;
     watchman: boolean;
     watchPathIgnorePatterns: Array<string>;
-    workerIdleMemoryLimit: number;
+    workerIdleMemoryLimit: number | string;
   }>
 >;


### PR DESCRIPTION
## Summary

@phawxby added `workerIdleMemoryLimit` but it shows a config warning when using the alpha release, this adds the option to the ValidConfig. As mentioned here: https://github.com/facebook/jest/pull/13056#issuecomment-1207935049

## Test plan

This is just a config fix for an already tested change, so doesn't seem like it needs specific tests.
