### PR TITLE
docs: remove invalid properties from vscode launch configuration examples

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }

--- a/website/versioned_docs/version-25.x/Troubleshooting.md
+++ b/website/versioned_docs/version-25.x/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/website/versioned_docs/version-25.x/Troubleshooting.md
+++ b/website/versioned_docs/version-25.x/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }

--- a/website/versioned_docs/version-26.x/Troubleshooting.md
+++ b/website/versioned_docs/version-26.x/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/website/versioned_docs/version-26.x/Troubleshooting.md
+++ b/website/versioned_docs/version-26.x/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }

--- a/website/versioned_docs/version-27.x/Troubleshooting.md
+++ b/website/versioned_docs/version-27.x/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/website/versioned_docs/version-27.x/Troubleshooting.md
+++ b/website/versioned_docs/version-27.x/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }

--- a/website/versioned_docs/version-28.0/Troubleshooting.md
+++ b/website/versioned_docs/version-28.0/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/website/versioned_docs/version-28.0/Troubleshooting.md
+++ b/website/versioned_docs/version-28.0/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }

--- a/website/versioned_docs/version-28.1/Troubleshooting.md
+++ b/website/versioned_docs/version-28.1/Troubleshooting.md
@@ -69,7 +69,7 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }
@@ -91,7 +91,7 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/website/versioned_docs/version-28.1/Troubleshooting.md
+++ b/website/versioned_docs/version-28.1/Troubleshooting.md
@@ -70,7 +70,6 @@ To automatically launch and attach to a process running your tests, use the foll
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }
@@ -93,7 +92,6 @@ or the following for Windows:
       ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "port": 9229
     }
   ]
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The example vscode debug launch configurations contain an invalid/unused property. Fixes #13098

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I tested it in vscode and the error deos not get highlighted. I also verified that the launched process actually opened a different port then the one specified.