### PR TITLE
docs: fix CRA vscode debugging configuration example

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/website/versioned_docs/version-25.x/Troubleshooting.md
+++ b/website/versioned_docs/version-25.x/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/website/versioned_docs/version-26.x/Troubleshooting.md
+++ b/website/versioned_docs/version-26.x/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/website/versioned_docs/version-27.x/Troubleshooting.md
+++ b/website/versioned_docs/version-27.x/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/website/versioned_docs/version-28.0/Troubleshooting.md
+++ b/website/versioned_docs/version-28.0/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/website/versioned_docs/version-28.1/Troubleshooting.md
+++ b/website/versioned_docs/version-28.1/Troubleshooting.md
@@ -110,9 +110,14 @@ If you are using Facebook's [`create-react-app`](https://github.com/facebookincu
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
-      "args": ["test", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom",
+        "--watchAll=false"
+      ],
       "cwd": "${workspaceRoot}",
-      "protocol": "inspector",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The example vscode launch configuration for CRA projects has an invalid key in it, which could confuse users.

Also the configuration launched jest in watch mode, which required user input in the terminal before debugging. The example launch configurations for normal tests do not launch in watch mode.

This PR changes the configuration to fix these issues

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I verified that the `inspector` key gets highlighted by the latest version of vscode as invalid. Also I tested if removing it changed the behaviour of the tests and found that it did not. I tested this with the default test of a new CRA project.

I verified that the example launch configuration for CRA tests no longer starts jest in watch mode. I verified that the example launch configuration for normal tests does not start jest in watch mode.
