### PR TITLE
fix: an unstable test

### DIFF
--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -30,14 +30,18 @@ jest.mock('prettier', () => {
   return mockPrettier;
 });
 
-let dir: string;
 beforeEach(() => {
   jest.mocked(prettier.resolveConfig.sync).mockReset();
 });
 
+let dir: string;
 beforeEach(() => {
   dir = path.join(tmpdir(), `jest-inline-snapshot-test-${Date.now()}`);
   fs.mkdirSync(dir);
+});
+
+afterEach(() => {
+  fs.rmSync(dir, {recursive: true});
 });
 
 test('saveInlineSnapshots() replaces empty function call with a template literal', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://github.com/facebook/jest/runs/7796198469?check_suite_focus=true
The temp folder used by the tests was not deleted and sometimes failed due to conflicts.
Add `afterEach` to remove it.

## Test plan

Test passed normally
