### PR TITLE
Fix[Jest-circus]-:reversed order of aftereach and afterall hook

### DIFF
--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`afterEach & afterAll run in reverse order 1`] = `
+"add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+start_describe_definition: Scoped / Nested block
+add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+finish_describe_definition: Scoped / Nested block
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+hook_start: beforeAll
+1 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+1 - test
+test_fn_success: 
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+run_describe_start: Scoped / Nested block
+hook_start: beforeAll
+2 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+hook_start: beforeEach
+2 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+2 - test
+test_fn_success: 
+hook_start: afterEach
+2 - afterEach
+hook_success: afterEach
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+hook_start: afterAll
+2 - afterAll
+hook_success: afterAll
+run_describe_finish: Scoped / Nested block
+hook_start: afterAll
+1 - afterAll
+hook_success: afterAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+unhandledErrors: 0"
+`;
+
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1
 add_hook: beforeAll

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -59,8 +59,9 @@ hook_start: afterAll
 hook_success: afterAll
 run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish
+
 unhandledErrors: 0"
-`;
+;
 
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -61,7 +61,7 @@ run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish
 
 unhandledErrors: 0"
-;
+`;
 
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -71,3 +71,22 @@ test('beforeAll is exectued correctly', () => {
 
   expect(stdout).toMatchSnapshot();
 });
+
+test('afterEach & afterAll run in reverse order', () => {
+  const {stdout} = runTest(`
+      beforeAll(() => console.log('1 - beforeAll'));
+      afterAll(() => console.log('1 - afterAll'));
+      beforeEach(() => console.log('1 - beforeEach'));
+      afterEach(() => console.log('1 - afterEach'));
+      test('', () => console.log('1 - test'));
+      describe('Scoped / Nested block', () => {
+        beforeAll(() => console.log('2 - beforeAll'));
+        afterAll(() => console.log('2 - afterAll'));
+        beforeEach(() => console.log('2 - beforeEach'));
+        afterEach(() => console.log('2 - afterEach'));
+        test('', () => console.log('2 - test'));
+      });
+    `);
+
+  expect(stdout).toMatchSnapshot();
+});


### PR DESCRIPTION
Citing to the current docs, jest-circus executes the `afterEach` and `afterall` Hook in the declaration order.
But the current Jest [docs](https://jestjs.io/docs/setup-teardown#scoping) , the latter makes sense to use `beforeEach` to setup the method  and `afterEach` to dispose the method


```
let methodA: Method
let methodB: Method
beforeEach(() => { methodA = new BaseMethod() })
afterEach(() => { methodA.dispose() })

beforeEach(() => { methodB = newMethodConsumer(methodA) })
afterEach(() => { methodB.dispose() })  // This could use the methodA After the disposal of methodA

``` 

This would led to the reversing of the order of `afterAll`  and `afterEach` before they are executed.