### PR TITLE
refactor(jest-mock)!: change the default `jest.mocked` helper’s behaviour to deep mocked

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -180,7 +180,7 @@ module.exports = {
       },
     },
     {
-      files: ['website/**/*'],
+      files: ['docs/**/*', 'website/**/*'],
       rules: {
         'import/order': 'off',
         'import/sort-keys': 'off',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[jest-config]` [**BREAKING**] Make `snapshotFormat` default to `escapeString: false` and `printBasicPrototype: false` ([#13036](https://github.com/facebook/jest/pull/13036))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037), [#13058](https://github.com/facebook/jest/pull/13058))
 - `[jest-mock]` [**BREAKING**] Refactor `Mocked*` utility types. `MaybeMockedDeep` and `MaybeMocked` became `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exported ([#13123](https://github.com/facebook/jest/pull/13123), [#13124](https://github.com/facebook/jest/pull/13124))
+- `[jest-mock]` [**BREAKING**] Change the default `jest.mocked` helper’s behavior to deep mocked ([#13125](https://github.com/facebook/jest/pull/13125))
 - `[jest-worker]` Adds `workerIdleMemoryLimit` option which is used as a check for worker memory leaks >= Node 16.11.0 and recycles child workers as required. ([#13056](https://github.com/facebook/jest/pull/13056), [#13105](https://github.com/facebook/jest/pull/13105), [#13106](https://github.com/facebook/jest/pull/13106), [#13107](https://github.com/facebook/jest/pull/13107))
 - `[pretty-format]` [**BREAKING**] Remove `ConvertAnsi` plugin in favour of `jest-serializer-ansi-escapes` ([#13040](https://github.com/facebook/jest/pull/13040))
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -284,9 +284,17 @@ Returns the `jest` object for chaining.
 
 :::tip
 
-Writing tests in TypeScript? Use [`jest.Mocked`](MockFunctionAPI.md/#jestmockedsource) utility type or [`jest.mocked()`](MockFunctionAPI.md/#jestmockedsource-shallow-boolean) helper method to have your mocked modules typed.
+Writing tests in TypeScript? Use [`jest.Mocked`](MockFunctionAPI.md/#jestmockedsource) utility type or [`jest.mocked()`](MockFunctionAPI.md/#jestmockedsource-options) helper method to have your mocked modules typed.
 
 :::
+
+### `jest.Mocked<Source>`
+
+See [TypeScript Usage](MockFunctionAPI.md/#jestmockedsource) chapter of Mock Functions page for documentation.
+
+### `jest.mocked(source, options?)`
+
+See [TypeScript Usage](MockFunctionAPI.md/#jestmockedsource-options) chapter of Mock Functions page for documentation.
 
 ### `jest.unmock(moduleName)`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -598,50 +598,6 @@ Returns the `jest` object for chaining.
 
 Restores all mocks back to their original value. Equivalent to calling [`.mockRestore()`](MockFunctionAPI.md#mockfnmockrestore) on every mocked function. Beware that `jest.restoreAllMocks()` only works when the mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
-### `jest.mocked<T>(item: T, deep = false)`
-
-The `mocked` test helper provides typings on your mocked modules and even their deep methods, based on the typing of its source. It makes use of the latest TypeScript feature, so you even have argument types completion in the IDE (as opposed to `jest.MockInstance`).
-
-_Note: while it needs to be a function so that input type is changed, the helper itself does nothing else than returning the given input value._
-
-Example:
-
-```ts
-// foo.ts
-export const foo = {
-  a: {
-    b: {
-      c: {
-        hello: (name: string) => `Hello, ${name}`,
-      },
-    },
-  },
-  name: () => 'foo',
-};
-```
-
-```ts
-// foo.spec.ts
-import {foo} from './foo';
-jest.mock('./foo');
-
-// here the whole foo var is mocked deeply
-const mockedFoo = jest.mocked(foo, true);
-
-test('deep', () => {
-  // there will be no TS error here, and you'll have completion in modern IDEs
-  mockedFoo.a.b.c.hello('me');
-  // same here
-  expect(mockedFoo.a.b.c.hello.mock.calls).toHaveLength(1);
-});
-
-test('direct', () => {
-  foo.name();
-  // here only foo.name is mocked (or its methods if it's an object)
-  expect(jest.mocked(foo.name).mock.calls).toHaveLength(1);
-});
-```
-
 ## Fake Timers
 
 ### `jest.useFakeTimers(fakeTimersConfig?)`

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -282,6 +282,12 @@ Modules that are mocked with `jest.mock` are mocked only for the file that calls
 
 Returns the `jest` object for chaining.
 
+:::tip
+
+Writing tests in TypeScript? Use [`jest.Mocked`](MockFunctionAPI.md/#jestmockedsource) utility type or [`jest.mocked()`](MockFunctionAPI.md/#jestmockedsource-shallow-boolean) helper method to have your mocked modules typed.
+
+:::
+
 ### `jest.unmock(moduleName)`
 
 Indicates that the module system should never return a mocked version of the specified module from `require()` (e.g. that it should always return the real module).
@@ -467,7 +473,7 @@ const returnsTrue = jest.fn(() => true);
 console.log(returnsTrue()); // true;
 ```
 
-:::note
+:::tip
 
 See [Mock Functions](MockFunctionAPI.md#jestfnimplementation) page for details on TypeScript usage.
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -550,9 +550,9 @@ test('returns correct data', () => {
 
 Types of classes, functions or objects can be passed as type argument to `jest.Mocked<Source>`. If you prefer to constrain the input type, use: `jest.MockedClass<Source>`, `jest.MockedFunction<Source>` or `jest.MockedObject<Source>`.
 
-### `jest.mocked(source, {shallow?: boolean})`
+### `jest.mocked(source, options?)`
 
-The `mocked()` helper method wraps types of the `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
+The `mocked()` helper method wraps types of the `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` as the `options` argument to disable the deeply mocked behavior.
 
 Returns the `source` object.
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -526,8 +526,8 @@ test('calculate calls add', () => {
 The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with type definitions of Jest mock function.
 
 ```ts
+import type {fetch} from 'node-fetch';
 import {expect, jest, test} from '@jest/globals';
-import type {fetch} from './fetch';
 
 jest.mock('node-fetch');
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -534,7 +534,7 @@ jest.mock('node-fetch');
 let mockedFetch: jest.Mocked<typeof fetch>;
 
 afterEach(() => {
-  mockedFetch = resetMockedFetch();
+  mockedFetch.mockClear();
 });
 
 test('makes correct call', () => {

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -554,7 +554,7 @@ Types of classes, functions or objects can be passed as type argument to `jest.M
 
 The `mocked()` helper method wraps types of the `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
 
-Returns the input value.
+Returns the `source` object.
 
 ```ts title="song.ts"
 export const song = {

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -520,3 +520,50 @@ test('calculate calls add', () => {
   expect(mockAdd).toBeCalledWith(1, 2);
 });
 ```
+
+### `jest.mocked<T>(source: T, {shallow?: boolean})`
+
+The `mocked()` type helper method wraps `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
+
+Returns the input value.
+
+Example:
+
+```ts title="song.ts"
+export const song = {
+  one: {
+    more: {
+      time: (t: number) => {
+        return t;
+      },
+    },
+  },
+};
+```
+
+```ts title="song.test.ts"
+import {expect, jest, test} from '@jest/globals';
+import {song} from './song';
+
+jest.mock('./song');
+jest.spyOn(console, 'log');
+
+const mockedSong = jest.mocked(song);
+
+test('deep method is typed correctly', () => {
+  mockedSong.one.more.time.mockReturnValue(12);
+
+  expect(mockedSong.one.more.time(10)).toBe(12);
+  expect(mockedSong.one.more.time.mock.calls).toHaveLength(1);
+});
+
+test('direct usage', () => {
+  jest.mocked(console.log).mockImplementation(() => {
+    return;
+  });
+
+  console.log('one more time');
+
+  expect(jest.mocked(console.log).mock.calls).toHaveLength(1);
+});
+```

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -550,7 +550,7 @@ test('returns correct data', () => {
 
 Types of classes, functions or objects can be passed as type argument to `jest.Mocked<Source>`. If you prefer to constrain the input type, use: `jest.MockedClass<Source>`, `jest.MockedFunction<Source>` or `jest.MockedObject<Source>`.
 
-### `jest.mocked<T>(source: T, {shallow?: boolean})`
+### `jest.mocked(source, {shallow?: boolean})`
 
 The `mocked()` helper method wraps types of the `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -526,12 +526,16 @@ test('calculate calls add', () => {
 The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with type definitions of Jest mock function.
 
 ```ts
-import fetch from 'node-fetch';
 import {expect, jest, test} from '@jest/globals';
+import type {fetch} from './fetch';
 
 jest.mock('node-fetch');
 
 let mockedFetch: jest.Mocked<typeof fetch>;
+
+afterEach(() => {
+  mockedFetch = resetMockedFetch();
+});
 
 test('makes correct call', () => {
   mockedFetch = getMockedFetch();
@@ -548,11 +552,9 @@ Types of classes, functions or objects can be passed as type argument to `jest.M
 
 ### `jest.mocked<T>(source: T, {shallow?: boolean})`
 
-The `mocked()` type helper method wraps `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
+The `mocked()` helper method wraps types of the `source` object and its deep nested members with type definitions of Jest mock function. You can pass `{shallow: true}` option to disable the deeply mocked behavior.
 
 Returns the input value.
-
-Example:
 
 ```ts title="song.ts"
 export const song = {
@@ -574,6 +576,8 @@ jest.mock('./song');
 jest.spyOn(console, 'log');
 
 const mockedSong = jest.mocked(song);
+// or through `jest.Mocked<Source>`
+// const mockedSong = song as jest.Mocked<typeof song>;
 
 test('deep method is typed correctly', () => {
   mockedSong.one.more.time.mockReturnValue(12);

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -526,8 +526,8 @@ test('calculate calls add', () => {
 The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with type definitions of Jest mock function.
 
 ```ts
-import type {fetch} from 'node-fetch';
 import {expect, jest, test} from '@jest/globals';
+import type {fetch} from 'node-fetch';
 
 jest.mock('node-fetch');
 

--- a/docs/UpgradingToJest29.md
+++ b/docs/UpgradingToJest29.md
@@ -62,14 +62,14 @@ import {jest} from '@jest/globals';
 
 ### `jest.mocked()`
 
-The `mocked()` helper method now wraps types of deep members of passed object by default. If you have used the method with `true` argument before, remove it to avoid type errors:
+The [`jest.mocked()`](MockFunctionAPI.md/#jestmockedsource-options) helper method now wraps types of deep members of passed object by default. If you have used the method with `true` as the second argument, remove it to avoid type errors:
 
 ```diff
 - const mockedObject = jest.mocked(someObject, true);
 + const mockedObject = jest.mocked(someObject);
 ```
 
-To have the old shallow mocked behavior, pass `{shallow: true}` option:
+To have the old shallow mocked behavior, pass `{shallow: true}` as the second argument:
 
 ```diff
 - const mockedObject = jest.mocked(someObject);

--- a/docs/UpgradingToJest29.md
+++ b/docs/UpgradingToJest29.md
@@ -62,7 +62,7 @@ import {jest} from '@jest/globals';
 
 ### `jest.mocked()`
 
-The `mocked()` method now wraps deep members of passed object by default. If you used the method with `true` argument before, remove it to avoid type errors:
+The `mocked()` helper method now wraps types of deep members of passed object by default. If you have used the method with `true` argument before, remove it to avoid type errors:
 
 ```diff
 - const mockedObject = jest.mocked(someObject, true);

--- a/docs/UpgradingToJest29.md
+++ b/docs/UpgradingToJest29.md
@@ -40,10 +40,38 @@ If you want to keep the old behavior, you can set the `snapshotFormat` property 
 
 Notably, `jsdom@20` includes support for `crypto.getRandomValues()`, which means packages like `jsdom` and `nanoid`, which doesn't work properly in Jest@28, can work without extra polyfills.
 
-## `jest-mock`
-
-Exports of `Mocked*` utility types changed. `MaybeMockedDeep` and `MaybeMocked` now are exported as `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exposed.
-
 ## `pretty-format`
 
-`ConvertAnsi` plugin is removed in favour of [`jest-serializer-ansi-escapes`](https://github.com/mrazauskas/jest-serializer-ansi-escapes).
+`ConvertAnsi` plugin is removed from `pretty-format` in favour of [`jest-serializer-ansi-escapes`](https://github.com/mrazauskas/jest-serializer-ansi-escapes).
+
+### `jest-mock`
+
+Exports of `Mocked*` utility types from `jest-mock` module have changed. `MaybeMockedDeep` and `MaybeMocked` now are exported as `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exposed.
+
+## TypeScript
+
+:::info
+
+The TypeScript examples from this page will only work as documented if you import `jest` from `'@jest/globals'`:
+
+```ts
+import {jest} from '@jest/globals';
+```
+
+:::
+
+### `jest.mocked()`
+
+The `mocked()` method now wraps deep members of passed object by default. If you used the method with `true` argument before, remove it to avoid type errors:
+
+```diff
+- const mockedObject = jest.mocked(someObject, true);
++ const mockedObject = jest.mocked(someObject);
+```
+
+To have the old shallow mocked behavior, pass `{shallow: true}` option:
+
+```diff
+- const mockedObject = jest.mocked(someObject);
++ const mockedObject = jest.mocked(someObject, {shallow: true});
+```

--- a/docs/UpgradingToJest29.md
+++ b/docs/UpgradingToJest29.md
@@ -42,11 +42,11 @@ Notably, `jsdom@20` includes support for `crypto.getRandomValues()`, which means
 
 ## `pretty-format`
 
-`ConvertAnsi` plugin is removed from `pretty-format` in favour of [`jest-serializer-ansi-escapes`](https://github.com/mrazauskas/jest-serializer-ansi-escapes).
+`ConvertAnsi` plugin is removed from `pretty-format` package in favour of [`jest-serializer-ansi-escapes`](https://github.com/mrazauskas/jest-serializer-ansi-escapes).
 
 ### `jest-mock`
 
-Exports of `Mocked*` utility types from `jest-mock` module have changed. `MaybeMockedDeep` and `MaybeMocked` now are exported as `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exposed.
+Exports of `Mocked*` utility types from `jest-mock` package have changed. `MaybeMockedDeep` and `MaybeMocked` now are exported as `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exposed.
 
 ## TypeScript
 

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -202,6 +202,11 @@ export interface Jest {
     */
   requireActual: (moduleName: string) => unknown;
   /**
+   * Wraps `source` object and its deep members with type definitions of Jest mock function.
+   * Pass `{shallow: true}` option to disable the deeply mocked behavior.
+   */
+  mocked: ModuleMocker['mocked'];
+  /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.
    */
@@ -224,10 +229,6 @@ export interface Jest {
    * with `jest.spyOn()`; other mocks will require you to manually restore them.
    */
   restoreAllMocks(): Jest;
-  /**
-   * Wraps an object or a module with mock type definitions.
-   */
-  mocked: ModuleMocker['mocked'];
   /**
    * Runs failed tests n-times until they pass or until the max number of
    * retries is exhausted.

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -202,8 +202,9 @@ export interface Jest {
     */
   requireActual: (moduleName: string) => unknown;
   /**
-   * Wraps `source` object and its deep members with type definitions of Jest mock function.
-   * Pass `{shallow: true}` option to disable the deeply mocked behavior.
+   * Wraps types of the `source` object and its deep members with type definitions
+   * of Jest mock function. Pass `{shallow: true}` option to disable the deeply
+   * mocked behavior.
    */
   mocked: ModuleMocker['mocked'];
   /**

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -83,7 +83,7 @@ export type Mocked<T extends object> = T extends ClassLike
   ? MockedObject<T>
   : T;
 
-type MockedShallow<T extends object> = T extends ClassLike
+export type MockedShallow<T extends object> = T extends ClassLike
   ? MockedClass<T>
   : T extends FunctionLike
   ? MockedFunctionShallow<T>
@@ -1216,13 +1216,16 @@ export class ModuleMocker {
     return value == null ? `${value}` : typeof value;
   }
 
-  mocked<T extends object>(item: T, deep?: false): MockedShallow<T>;
-  mocked<T extends object>(item: T, deep: true): Mocked<T>;
+  mocked<T extends object>(source: T, options?: {shallow: false}): Mocked<T>;
   mocked<T extends object>(
-    item: T,
-    _deep = false,
+    source: T,
+    options: {shallow: true},
+  ): MockedShallow<T>;
+  mocked<T extends object>(
+    source: T,
+    _options?: {shallow: boolean},
   ): Mocked<T> | MockedShallow<T> {
-    return item as Mocked<T> | MockedShallow<T>;
+    return source as Mocked<T> | MockedShallow<T>;
   }
 }
 

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -7,7 +7,13 @@
 
 import {expectAssignable, expectError, expectType} from 'tsd-lite';
 import {jest} from '@jest/globals';
-import type {Mock, ModuleMocker, SpyInstance} from 'jest-mock';
+import type {
+  Mock,
+  Mocked,
+  MockedShallow,
+  ModuleMocker,
+  SpyInstance,
+} from 'jest-mock';
 
 expectType<typeof jest>(
   jest
@@ -210,7 +216,7 @@ expectType<ModuleMocker['fn']>(jest.fn);
 
 expectType<ModuleMocker['spyOn']>(jest.spyOn);
 
-// deep mocked()
+// mocked()
 
 class SomeClass {
   constructor(one: string, two?: boolean) {}
@@ -248,9 +254,17 @@ const someObject = {
   someClassInstance: new SomeClass('value'),
 };
 
-const mockObjectA = jest.mocked(someObject, true);
+expectType<Mocked<typeof someObject>>(jest.mocked(someObject));
+expectType<Mocked<typeof someObject>>(
+  jest.mocked(someObject, {shallow: false}),
+);
+expectType<MockedShallow<typeof someObject>>(
+  jest.mocked(someObject, {shallow: true}),
+);
 
-expectError(jest.mocked('abc', true));
+expectError(jest.mocked('abc'));
+
+const mockObjectA = jest.mocked(someObject);
 
 expectType<[]>(mockObjectA.methodA.mock.calls[0]);
 expectType<[b: string]>(mockObjectA.methodB.mock.calls[0]);
@@ -303,11 +317,9 @@ expectError(
 
 expectAssignable<typeof someObject>(mockObjectA);
 
-// mocked()
+// shallow mocked()
 
-const mockObjectB = jest.mocked(someObject);
-
-expectError(jest.mocked('abc'));
+const mockObjectB = jest.mocked(someObject, {shallow: true});
 
 expectType<[]>(mockObjectB.methodA.mock.calls[0]);
 expectType<[b: string]>(mockObjectB.methodB.mock.calls[0]);


### PR DESCRIPTION
Split from #12727

## Summary

It seems to me that by default `jest.mocked()` should wrap the deep methods of passed object. Currently it requires and argument: `jest.mocked(someObject, true)`. Also note that without reading the docs it isn’t clear what `true` does.

---

Consider this example:

```ts
import { expect, jest, test } from "@jest/globals";
import { someObject } from "./someObject";

jest.mock("./someObject");

test("is mock function?", () => {
  expect(jest.isMockFunction(mockObject.one.more.time)).toBe(true);
});
```

The test will pass. Seems like `jest.mock()` is mocking deeply nested methods. So I think `jest.mocked()` should do the same by default (and `jest.Mocked<T>` as well).

Possibly shallow mocked definitions were implemented to improve performance of TS compiler. Or to work around some limitation, i.e. handling of recursive types. If I got it right, `ts-jest` implemented `jest.mock()` in the early days of TypeScript v3. Performance and handling of recursive types improved a lot in TS v4.

Perhaps it’s time to swap the defaults? I mean, to make the behaviour of `jest.mocked()` deep by default and to allow opting out with an option: `jest.mocked(someObject, {shallow: true})`.

## Test plan

Type tests added.