### PR TITLE
Fix:-Clearly defining the public interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
 - `[jest-haste-map]` Increase the maximum possible file size that jest-haste-map can handle ([#13094](https://github.com/facebook/jest/pull/13094))
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
-- `[jest-haste-map]` Clearly defined the public interfaces  ([#13127](https://github.com/facebook/jest/pull/13127))
-
+- `[jest-haste-map]` Clearly defined the public interfaces ([#13127](https://github.com/facebook/jest/pull/13127))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
 - `[jest-haste-map]` Increase the maximum possible file size that jest-haste-map can handle ([#13094](https://github.com/facebook/jest/pull/13094))
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
+- `[jest-haste-map]` Clearly defined the public interfaces  ([#13127](https://github.com/facebook/jest/pull/13127))
+
 
 ### Chore & Maintenance
 

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -13,7 +13,7 @@ import type {AggregatedResult, TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import type {ChangedFilesPromise} from 'jest-changed-files';
 import {readConfigs} from 'jest-config';
-import type HasteMap from 'jest-haste-map';
+import type {IHasteMap} from 'jest-haste-map';
 import Runtime from 'jest-runtime';
 import {createDirectory, preRunMessage} from 'jest-util';
 import {TestWatcher} from 'jest-watcher';
@@ -233,7 +233,7 @@ const runWatch = async (
   hasDeprecationWarnings: boolean,
   globalConfig: Config.GlobalConfig,
   outputStream: NodeJS.WriteStream,
-  hasteMapInstances: Array<HasteMap>,
+  hasteMapInstances: Array<IHasteMap>,
   filter?: Filter,
 ) => {
   if (hasDeprecationWarnings) {

--- a/packages/jest-core/src/lib/createContext.ts
+++ b/packages/jest-core/src/lib/createContext.ts
@@ -7,12 +7,12 @@
 
 import type {TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
-import type {HasteMapObject} from 'jest-haste-map';
+import type {IHasteFS, IModuleMap} from 'jest-haste-map';
 import Runtime from 'jest-runtime';
 
 export default function createContext(
   config: Config.ProjectConfig,
-  {hasteFS, moduleMap}: HasteMapObject,
+  {hasteFS, moduleMap}: {hasteFS: IHasteFS; moduleMap: IModuleMap},
 ): TestContext {
   return {
     config,

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -240,31 +240,28 @@ export default async function watch(
   emitFileChange();
 
   hasteMapInstances.forEach((hasteMapInstance, index) => {
-    hasteMapInstance.on(
-      'change',
-      ({eventsQueue, hasteFS, moduleMap}: HasteChangeEvent) => {
-        const validPaths = eventsQueue.filter(({filePath}) =>
-          isValidPath(globalConfig, filePath),
-        );
+    hasteMapInstance.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
+      const validPaths = eventsQueue.filter(({filePath}) =>
+        isValidPath(globalConfig, filePath),
+      );
 
-        if (validPaths.length) {
-          const context = (contexts[index] = createContext(
-            contexts[index].config,
-            {hasteFS, moduleMap},
-          ));
+      if (validPaths.length) {
+        const context = (contexts[index] = createContext(
+          contexts[index].config,
+          {hasteFS, moduleMap},
+        ));
 
-          activePlugin = null;
+        activePlugin = null;
 
-          searchSources = searchSources.slice();
-          searchSources[index] = {
-            context,
-            searchSource: new SearchSource(context),
-          };
-          emitFileChange();
-          startRun(globalConfig);
-        }
-      },
-    );
+        searchSources = searchSources.slice();
+        searchSources[index] = {
+          context,
+          searchSource: new SearchSource(context),
+        };
+        emitFileChange();
+        startRun(globalConfig);
+      }
+    });
   });
 
   if (!hasExitListener) {

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -12,10 +12,7 @@ import exit = require('exit');
 import slash = require('slash');
 import type {TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
-import type {
-  ChangeEvent as HasteChangeEvent,
-  default as HasteMap,
-} from 'jest-haste-map';
+import type {IHasteMap as HasteMap} from 'jest-haste-map';
 import {formatExecError} from 'jest-message-util';
 import {
   isInteractive,

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -8,9 +8,9 @@
 import {globsToMatcher, replacePathSepForGlob} from 'jest-util';
 import H from './constants';
 import * as fastPath from './lib/fast_path';
-import type {FileData} from './types';
+import type {FileData, IHasteFS} from './types';
 
-export default class HasteFS {
+export default class HasteFS implements IHasteFS {
   private readonly _rootDir: string;
   private readonly _files: FileData;
 

--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -19,7 +19,7 @@ import type {
 const EMPTY_OBJ: Record<string, ModuleMetaData> = {};
 const EMPTY_MAP = new Map();
 
-export default class ModuleMap implements IModuleMap<SerializableModuleMap> {
+export default class ModuleMap implements IModuleMap {
   static DuplicateHasteCandidatesError: typeof DuplicateHasteCandidatesError;
   private readonly _raw: RawModuleMap;
   private json: SerializableModuleMap | undefined;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -34,6 +34,8 @@ import type {
   FileMetaData,
   HasteMapStatic,
   HasteRegExp,
+  IHasteMap,
+  IModuleMap,
   InternalHasteMap,
   HasteMap as InternalHasteMapObject,
   MockData,
@@ -109,11 +111,12 @@ type Watcher = {
 
 type HasteWorker = typeof import('./worker');
 
-export type {default as FS} from './HasteFS';
-export {default as ModuleMap} from './ModuleMap';
+export const ModuleMap = HasteModuleMap as {
+  create: (rootPath: string) => IModuleMap;
+};
 export type {
-  ChangeEvent,
-  HasteMap as HasteMapObject,
+  IHasteFS,
+  IHasteMap,
   IModuleMap,
   SerializableModuleMap,
 } from './types';
@@ -210,7 +213,7 @@ function invariant(condition: unknown, message?: string): asserts condition {
  *     Worker processes can directly access the cache through `HasteMap.read()`.
  *
  */
-export default class HasteMap extends EventEmitter {
+class HasteMap extends EventEmitter implements IHasteMap {
   private _buildPromise: Promise<InternalHasteMapObject> | null = null;
   private _cachePath = '';
   private _changeInterval?: ReturnType<typeof setInterval>;
@@ -227,7 +230,7 @@ export default class HasteMap extends EventEmitter {
     return HasteMap;
   }
 
-  static async create(options: Options): Promise<HasteMap> {
+  static async create(options: Options): Promise<IHasteMap> {
     if (options.hasteMapModulePath) {
       const CustomHasteMap = require(options.hasteMapModulePath);
       return new CustomHasteMap(options);
@@ -1143,3 +1146,8 @@ function copy<T extends Record<string, unknown>>(object: T): T {
 function copyMap<K, V>(input: Map<K, V>): Map<K, V> {
   return new Map(input);
 }
+
+export default HasteMap as HasteMapStatic & {
+  create(options: Options): Promise<IHasteMap>;
+  getStatic(config: Config.ProjectConfig): HasteMapStatic;
+};

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -39,6 +39,24 @@ export interface IModuleMap<S = SerializableModuleMap> {
   toJSON(): S;
 }
 
+export interface IHasteFS {
+  exists(path: string): boolean;
+  getAbsoluteFileIterator(): Iterable<string>;
+  getAllFiles(): Array<string>;
+  getDependencies(file: string): Array<string> | null;
+  getSize(path: string): number | null;
+  matchFiles(pattern: RegExp | string): Array<string>;
+  matchFilesWithGlob(
+    globs: ReadonlyArray<string>,
+    root: string | null,
+  ): Set<string>;
+}
+
+export interface IHasteMap {
+  on(eventType: 'change', handler: (event: ChangeEvent) => void): void;
+  build(): Promise<{hasteFS: IHasteFS; moduleMap: IModuleMap}>;
+}
+
 export type HasteMapStatic<S = SerializableModuleMap> = {
   getCacheFilePath(
     tmpdir: string,

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from 'path';
-import type {FS as HasteFS} from 'jest-haste-map';
+import type {IHasteFS} from 'jest-haste-map';
 import type {ResolveModuleConfig, default as Resolver} from 'jest-resolve';
 import {SnapshotResolver, isSnapshotPath} from 'jest-snapshot';
 
@@ -20,13 +20,13 @@ export type ResolvedModule = {
  * to retrieve a list of all transitive inverse dependencies.
  */
 export class DependencyResolver {
-  private _hasteFS: HasteFS;
+  private _hasteFS: IHasteFS;
   private _resolver: Resolver;
   private _snapshotResolver: SnapshotResolver;
 
   constructor(
     resolver: Resolver,
-    hasteFS: HasteFS,
+    hasteFS: IHasteFS,
     snapshotResolver: SnapshotResolver,
   ) {
     this._resolver = resolver;

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import {sync as resolveSync} from 'resolve';
 import {ModuleMap} from 'jest-haste-map';
+import type {IModuleMap} from 'jest-haste-map';
 import userResolver from '../__mocks__/userResolver';
 import userResolverAsync from '../__mocks__/userResolverAsync';
 import defaultResolver from '../defaultResolver';

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -359,7 +359,7 @@ describe('findNodeModuleAsync', () => {
 });
 
 describe('resolveModule', () => {
-  let moduleMap: ModuleMap;
+  let moduleMap: IModuleMap;
   beforeEach(() => {
     moduleMap = ModuleMap.create('/');
   });
@@ -464,7 +464,7 @@ describe('resolveModule', () => {
 });
 
 describe('resolveModuleAsync', () => {
-  let moduleMap: ModuleMap;
+  let moduleMap: IModuleMap;
   beforeEach(() => {
     moduleMap = ModuleMap.create('/');
   });
@@ -627,7 +627,7 @@ describe('nodeModulesPaths', () => {
 
 describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
   const _path = path;
-  let moduleMap: ModuleMap;
+  let moduleMap: IModuleMap;
 
   beforeEach(() => {
     jest.resetModules();

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -48,7 +48,7 @@ import {
   shouldInstrument,
 } from '@jest/transform';
 import type {Config, Global} from '@jest/types';
-import type {IModuleMap} from 'jest-haste-map';
+import type {IHasteMap, IModuleMap} from 'jest-haste-map';
 import HasteMap from 'jest-haste-map';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
 import type {MockFunctionMetadata, ModuleMocker} from 'jest-mock';
@@ -331,7 +331,7 @@ export default class Runtime {
   static createHasteMap(
     config: Config.ProjectConfig,
     options?: HasteMapOptions,
-  ): Promise<HasteMap> {
+  ): Promise<IHasteMap> {
     const ignorePatternParts = [
       ...config.modulePathIgnorePatterns,
       ...(options && options.watch ? config.watchPathIgnorePatterns : []),

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -8,7 +8,7 @@
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import type {MatcherFunctionWithState} from 'expect';
-import type {FS as HasteFS} from 'jest-haste-map';
+import type {IHasteFS} from 'jest-haste-map';
 import {
   BOLD_WEIGHT,
   EXPECTED_COLOR,
@@ -110,11 +110,11 @@ function stripAddedIndentation(inlineSnapshot: string) {
   return inlineSnapshot;
 }
 
-const fileExists = (filePath: string, hasteFS: HasteFS): boolean =>
+const fileExists = (filePath: string, hasteFS: IHasteFS): boolean =>
   hasteFS.exists(filePath) || fs.existsSync(filePath);
 
 export const cleanup = (
-  hasteFS: HasteFS,
+  hasteFS: IHasteFS,
   update: Config.SnapshotUpdateState,
   snapshotResolver: SnapshotResolver,
   testPathIgnorePatterns?: Config.ProjectConfig['testPathIgnorePatterns'],

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -9,7 +9,7 @@ import type {V8Coverage} from 'collect-v8-coverage';
 import type {CoverageMap, CoverageMapData} from 'istanbul-lib-coverage';
 import type {ConsoleBuffer} from '@jest/console';
 import type {Config, TestResult, TransformTypes} from '@jest/types';
-import type {FS as HasteFS, ModuleMap} from 'jest-haste-map';
+import type {IHasteFS, IModuleMap} from 'jest-haste-map';
 import type Resolver from 'jest-resolve';
 
 export interface RuntimeTransformResult extends TransformTypes.TransformResult {
@@ -190,8 +190,8 @@ export type Test = {
 
 export type TestContext = {
   config: Config.ProjectConfig;
-  hasteFS: HasteFS;
-  moduleMap: ModuleMap;
+  hasteFS: IHasteFS;
+  moduleMap: IModuleMap;
   resolver: Resolver;
 };
 


### PR DESCRIPTION
Going through the `jest-haste-map` has a lot of API, which is not being used by Jest and none of them are in the docs too.
I tried to define the interfaces that are currently being used and also will probably be helpful to `hasteMapModulepath` 

This would clarify and reduce the API noise!
