### PR TITLE
chore: tweak regex used in e2e tests

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -279,8 +279,8 @@ export const normalizeIcons = (str: string) => {
 
   // Make sure to keep in sync with `jest-cli/src/constants`
   return str
-    .replace(new RegExp('\u00D7', 'g'), '\u2715')
-    .replace(new RegExp('\u221A', 'g'), '\u2713');
+    .replace(new RegExp('\u00D7', 'gu'), '\u2715')
+    .replace(new RegExp('\u221A', 'gu'), '\u2713');
 };
 
 // Certain environments (like CITGM and GH Actions) do not come with mercurial installed

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -277,7 +277,7 @@ export const normalizeIcons = (str: string) => {
     return str;
   }
 
-  // Make sure to keep in sync with `jest-cli/src/constants`
+  // Make sure to keep in sync with `jest-util/src/specialChars`
   return str
     .replace(new RegExp('\u00D7', 'gu'), '\u2715')
     .replace(new RegExp('\u221A', 'gu'), '\u2713');


### PR DESCRIPTION
Just added the `u` flag in the regex as it helps in correct working of regex character ranges