### PR TITLE
docs: rework Type Definitions section in Getting Started guide

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -156,10 +156,31 @@ npm install --save-dev ts-jest
 
 #### Type definitions
 
-You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
+There are two ways have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-> For `@types/*` modules it's recommended to try to match the version of the associated module. For example, if you are using `26.4.0` of `jest` then using `26.4.x` of `@types/jest` is ideal. In general, try to match the major (`26`) and minor (`4`) version as closely as possible.
+You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+
+```ts title="sum.test.ts"
+import {describe, expect, test} from '@jest/globals';
+import {sum} from './sum';
+
+describe('sum module', () => {
+  test('adds 1 + 2 to equal 3', () => {
+    expect(sum(1, 2)).toBe(3);
+  });
+});
+```
+
+:::tip
+
+See the additional usage documentation of [`describe.each`/`test.each`](GlobalAPI.md#typescript-usage) and [`mock functions`](MockFunctionAPI.md#typescript-usage).
+
+:::
+
+Or you may choose to install the [`@types/jest`](https://npmjs.com/package/@types/jest) package. It provides types for Jest globals without a need to import them.
 
 ```bash npm2yarn
 npm install --save-dev @types/jest
 ```
+
+Note that `@types/jest` is a third party library maintained at [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest), hence the latest Jest features or versions may not be covered yet. Try to match versions of Jest and `@types/jest` as closely as possible. For example, if you are using Jest `27.4.0` then installing `27.4.x` of `@types/jest` is ideal.


### PR DESCRIPTION
## Summary

Built-in types improved a lot recently. Users should judge, of course. In my opinion, the built-in types of `jest.fn()`, `.each` and also `jest.Mocked` / `jest.mocked()` are better than the ones shipped in `@types/jest`. Also both implementations are more or less equal in features.

Perhaps it’s a good idea to promote the built-in types in the Getting Started guide alongside with `@types/jest`? More usage might bring more feedback and a chance to make the types even better ;D

## Test plan

Deploy preview.