### PR TITLE
fix: Typing warning: Unknown option 'fakeTimers'

### DIFF
--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -129,6 +129,7 @@ const groupOptions = (
     detectOpenHandles: options.detectOpenHandles,
     errorOnDeprecated: options.errorOnDeprecated,
     expand: options.expand,
+    fakeTimers: options.fakeTimers,
     filter: options.filter,
     findRelatedTests: options.findRelatedTests,
     forceExit: options.forceExit,

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -375,6 +375,7 @@ export type GlobalConfig = {
   detectLeaks: boolean;
   detectOpenHandles: boolean;
   expand: boolean;
+  fakeTimers: FakeTimers;
   filter?: string;
   findRelatedTests: boolean;
   forceExit: boolean;
@@ -509,6 +510,7 @@ export type Argv = Arguments<
     debug: boolean;
     env: string;
     expand: boolean;
+    fakeTimers: FakeTimers;
     findRelatedTests: boolean;
     forceExit: boolean;
     globals: string;

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -23,6 +23,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   detectOpenHandles: false,
   errorOnDeprecated: false,
   expand: false,
+  fakeTimers: {enableGlobally: false},
   filter: undefined,
   findRelatedTests: false,
   forceExit: false,


### PR DESCRIPTION
## Summary

The [documentation](https://jestjs.io/docs/configuration#faketimers-object) says that we can add an option to `jest.config.js`:
```json
{
  "fakeTimers": {
    "enableGlobally": true
  }
}
```

But when adding this parameter, a warning appears in the console:
```text
● Validation Warning:

  Unknown option "fakeTimers" with value {"enableGlobally": true} was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

I haven't been able to test these changes locally, but I hope my changes fix the warning.
I would be grateful for the review and help with the acceptance of this pull request.

## Test plan
It seems to me that additional tests for my changes will not be required.
I ran (`yarn test`) tests locally - all tests passed successfully.

<hr/>

P.S. 
1. [Here](https://github.com/facebook/jest/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) says: `If you are submitting a pull request for the first time, just let us know that you have completed the CLA` - therefore, I inform you that I have it signed.
2. I'm not sure if I need to make changes to `CHANGELOG.md`. I described changelog below. Please help me with this =)

### Changelog

- packages/jest-config/src/index.ts
  - added `fakeTimers: options.fakeTimers` to `globalConfig` section of `groupOptions` function return
- packages/jest-types/src/Config.ts
  - added `fakeTimers: FakeTimers;` to both `InitialOptions` and `GlobalConfig` types
- packages/test-utils/src/config.ts
  - added `fakeTimers: {enableGlobally: false},` to `DEFAULT_GLOBAL_CONFIG` variable
