### PR TITLE
Run GC after tests finish before process/worker terminated to prevent timeout on termination

### DIFF
--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -56,9 +56,7 @@ export default class LeakDetector {
     const isGarbageCollectorHidden = globalThis.gc == null;
 
     // GC is usually hidden, so we have to expose it before running.
-    if (isGarbageCollectorHidden) {
-      setFlagsFromString('--expose-gc');
-    }
+    setFlagsFromString('--expose-gc');
     runInNewContext('gc')();
 
     // The GC was not initially exposed, so let's hide it again.

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -56,7 +56,9 @@ export default class LeakDetector {
     const isGarbageCollectorHidden = globalThis.gc == null;
 
     // GC is usually hidden, so we have to expose it before running.
-    setFlagsFromString('--expose-gc');
+    if (isGarbageCollectorHidden) {
+      setFlagsFromString('--expose-gc');
+    }
     runInNewContext('gc')();
 
     // The GC was not initially exposed, so let's hide it again.


### PR DESCRIPTION
## Summary

I was getting the

>A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

error at the end of my tests, and increasing
https://github.com/facebook/jest/blob/7b52a2edd3c2dfffa547000d2d0a8942b4e8fc5a/packages/jest-worker/src/base/BaseWorkerPool.ts#L19
fixed it.

I also noticed that triggering a manual gc in an `afterAll` for all tests fixed the issue too.

https://github.com/tjenkinson/redos-detector/blob/74c9eb9cc31c8399289de7aab22ef509660c0d5a/src/jest-setup.js#L1-L9

My theory for what's happening is that before the process exits node is triggering GC automatically, and this is taking longer than the `FORCE_EXIT_DELAY`.

So this PR triggers GC when the tests have finished, and this seems to fix the issue.

I initially thought this logic should go in the `jest-worker` package and started by adding a new message that would be sent from the child process when GC had completed, which the main process would wait for, and this would be what then started the force exit timer. The solution in this PR felt simpler though so I went with that for now.

Might fix https://github.com/facebook/jest/issues/11354

Note `--detectOpenHandles` also "fixes" it, but I think that's because doing that also forces a `globalThis.gc` before the process is requested to end as part of https://github.com/facebook/jest/blob/7b52a2edd3c2dfffa547000d2d0a8942b4e8fc5a/packages/jest-runner/src/runTest.ts#L382

## Test plan

I started writing a unit test but that got complicated because currently the tests in `testRunner.test.ts` work, but internally an error is thrown because none of the test files actually exist and can be read from the file system. If you think a test for this is needed we'll need to figure out how to mock the files so that it actually runs to the logic that then triggers the GC.

I tested this with my project where the issue can be seen.

To do that yourself you can:
- clone https://github.com/tjenkinson/redos-detector
- `git checkout 74c9eb9cc31c8399289de7aab22ef509660c0d5a`
- comment out the contents of https://github.com/tjenkinson/redos-detector/blob/74c9eb9cc31c8399289de7aab22ef509660c0d5a/src/jest-setup.js
- `npm t` (node v16.13.1)

You should see the error quoted above.

Then if you replace `jest-runner` with the version in this PR the error will go away.
