### PR TITLE
chore: make prettierPath optional in `SnapshotState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[jest-config]` Fix testing multiple projects with TypeScript config files ([#13099](https://github.com/facebook/jest/pull/13099))
 - `[@jest/expect-utils]` Fix deep equality of ImmutableJS Record ([#13055](https://github.com/facebook/jest/pull/13055))
 - `[jest-haste-map]` Increase the maximum possible file size that jest-haste-map can handle ([#13094](https://github.com/facebook/jest/pull/13094))
+- `[jest-snapshot]` Make `prettierPath` optional in `SnapshotState` ([#13149](https://github.com/facebook/jest/pull/13149))
 - `[jest-worker]` When a process runs out of memory worker exits correctly and doesn't spin indefinitely ([#13054](https://github.com/facebook/jest/pull/13054))
 
 ### Chore & Maintenance

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -46,7 +46,7 @@ export type InlineSnapshot = {
 
 export function saveInlineSnapshots(
   snapshots: Array<InlineSnapshot>,
-  prettierPath: string,
+  prettierPath: string | null,
 ): void {
   let prettier: Prettier | null = null;
   if (prettierPath) {

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -72,7 +72,7 @@ export function saveInlineSnapshots(
 const saveSnapshotsForFile = (
   snapshots: Array<InlineSnapshot>,
   sourceFilePath: string,
-  prettier?: Prettier,
+  prettier: Prettier | undefined,
 ) => {
   const sourceFile = fs.readFileSync(sourceFilePath, 'utf8');
 

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -24,7 +24,7 @@ import {
 
 export type SnapshotStateOptions = {
   updateSnapshot: Config.SnapshotUpdateState;
-  prettierPath: string;
+  prettierPath: string | null;
   expand?: boolean;
   snapshotFormat: PrettyFormatOptions;
 };
@@ -62,7 +62,7 @@ export default class SnapshotState {
   private _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
   private _uncheckedKeys: Set<string>;
-  private _prettierPath: string;
+  private _prettierPath: string | null;
   private _snapshotFormat: PrettyFormatOptions;
 
   added: number;

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -24,7 +24,7 @@ import {
 
 export type SnapshotStateOptions = {
   updateSnapshot: Config.SnapshotUpdateState;
-  prettierPath: string | null;
+  prettierPath?: string | null;
   expand?: boolean;
   snapshotFormat: PrettyFormatOptions;
 };
@@ -80,7 +80,7 @@ export default class SnapshotState {
     this._initialData = data;
     this._snapshotData = data;
     this._dirty = dirty;
-    this._prettierPath = options.prettierPath;
+    this._prettierPath = options.prettierPath ?? null;
     this._inlineSnapshots = [];
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
     this._counters = new Map();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

It's optional in usage, just not in the types: https://github.com/facebook/jest/blob/7d8d01c4854aa83e82cc11cefdd084a7d9b8bdfc/packages/jest-snapshot/src/InlineSnapshots.ts#L52

This is creating type errors in the test

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
