### PR TITLE
feat(@jest/test-result, @jest/types)!: replace `Bytes` and `Milliseconds` types with `number`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-mock]` [**BREAKING**] Refactor `Mocked*` utility types. `MaybeMockedDeep` and `MaybeMocked` became `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exported ([#13123](https://github.com/facebook/jest/pull/13123), [#13124](https://github.com/facebook/jest/pull/13124))
 - `[jest-mock]` [**BREAKING**] Change the default `jest.mocked` helper’s behavior to deep mocked ([#13125](https://github.com/facebook/jest/pull/13125))
 - `[jest-snapshot]` [**BREAKING**] Let `babel` find config when updating inline snapshots ([#13150](https://github.com/facebook/jest/pull/13150))
+- `[@jest/test-result, @jest/types]` [**BREAKING**] Replace `Bytes` and `Milliseconds` types with `number` ([#13155](https://github.com/facebook/jest/pull/13155))
 - `[jest-worker]` Adds `workerIdleMemoryLimit` option which is used as a check for worker memory leaks >= Node 16.11.0 and recycles child workers as required ([#13056](https://github.com/facebook/jest/pull/13056), [#13105](https://github.com/facebook/jest/pull/13105), [#13106](https://github.com/facebook/jest/pull/13106), [#13107](https://github.com/facebook/jest/pull/13107))
 - `[pretty-format]` [**BREAKING**] Remove `ConvertAnsi` plugin in favour of `jest-serializer-ansi-escapes` ([#13040](https://github.com/facebook/jest/pull/13040))
 

--- a/packages/jest-jasmine2/src/jasmine/Spec.ts
+++ b/packages/jest-jasmine2/src/jasmine/Spec.ts
@@ -31,7 +31,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* eslint-disable sort-keys, local/prefer-spread-eventually, local/prefer-rest-params-eventually, @typescript-eslint/no-empty-function */
 
 import {AssertionError} from 'assert';
-import type {FailedAssertion, Milliseconds, Status} from '@jest/test-result';
+import type {FailedAssertion, Status} from '@jest/test-result';
 import type {Circus} from '@jest/types';
 import {convertDescriptorToString} from 'jest-util';
 import ExpectationFailed from '../ExpectationFailed';
@@ -63,7 +63,7 @@ export type SpecResult = {
   id: string;
   description: string;
   fullName: string;
-  duration?: Milliseconds;
+  duration?: number;
   failedExpectations: Array<FailedAssertion>;
   testPath: string;
   passedExpectations: Array<ReturnType<typeof expectationResultFactory>>;

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -18,7 +18,6 @@ export type {
   AssertionResult,
   FailedAssertion,
   FormattedTestResults,
-  Milliseconds,
   RuntimeTransformResult,
   SerializableError,
   SnapshotSummary,

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -44,8 +44,6 @@ export type Status = AssertionResult['status'];
 
 export type Bytes = number;
 
-export type Milliseconds = TestResult.Milliseconds;
-
 export type AssertionResult = TestResult.AssertionResult;
 
 export type FormattedAssertionResult = Pick<
@@ -103,10 +101,10 @@ export type TestResult = {
   numTodoTests: number;
   openHandles: Array<Error>;
   perfStats: {
-    end: Milliseconds;
-    runtime: Milliseconds;
+    end: number;
+    runtime: number;
     slow: boolean;
-    start: Milliseconds;
+    start: number;
   };
   skipped: boolean;
   snapshot: {

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -42,8 +42,6 @@ export type AssertionLocation = {
 
 export type Status = AssertionResult['status'];
 
-export type Bytes = number;
-
 export type AssertionResult = TestResult.AssertionResult;
 
 export type FormattedAssertionResult = Pick<
@@ -94,7 +92,7 @@ export type TestResult = {
   displayName?: Config.DisplayName;
   failureMessage?: string | null;
   leaks: boolean;
-  memoryUsage?: Bytes;
+  memoryUsage?: number;
   numFailingTests: number;
   numPassingTests: number;
   numPendingTests: number;

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type Milliseconds = number;
-
 type Status = 'passed' | 'failed' | 'skipped' | 'pending' | 'todo' | 'disabled';
 
 type Callsite = {
@@ -17,7 +15,7 @@ type Callsite = {
 // this is here to make it possible to avoid huge dependency trees just for types
 export type AssertionResult = {
   ancestorTitles: Array<string>;
-  duration?: Milliseconds | null;
+  duration?: number | null;
   failureDetails: Array<unknown>;
   failureMessages: Array<string>;
   fullName: string;


### PR DESCRIPTION
Related #12406

## Summary

Seems like `number` is enough instead of `Bytes` and `Milliseconds` types. Just like `Path` type was replaced with `string` some time ago.

## Test plan

Type definitions should build without an error.