### PR TITLE
fix: ignore `EISDIR` when resolving symlinks

### DIFF
--- a/packages/jest-util/src/tryRealpath.ts
+++ b/packages/jest-util/src/tryRealpath.ts
@@ -11,7 +11,7 @@ export default function tryRealpath(path: string): string {
   try {
     path = realpathSync.native(path);
   } catch (error: any) {
-    if (error.code !== 'ENOENT') {
+    if (error.code !== 'ENOENT' && error.code !== 'EISDIR') {
       throw error;
     }
   }


### PR DESCRIPTION
Fix for issue https://github.com/facebook/jest/issues/11135

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes the EISDIR error when using RAM Disk for temp folder. Refer: https://github.com/facebook/jest/issues/11135

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Only one specific error code `EISDIR` is being ignored on the windows. No other major code changes.
