### PR TITLE
Imported jest in mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[]` Expose `TransformFactory` type ([#13188](https://github.com/facebook/jest/pull/13188
+
 ### Chore & Maintenance
 
 ### Performance
@@ -21,10 +23,10 @@
 ### Features
 
 - `[expect]` [**BREAKING**] Differentiate between `MatcherContext` `MatcherUtils` and `MatcherState` types ([#13141](https://github.com/facebook/jest/pull/13141))
-- `[jest-circus]` Add support for `test.failing.each` ([#13142](https://github.com/facebook/jest/pull/13142))
+- `[jest-circus]` Add supprt for `test.failing.each` ([#13142](https://github.com/facebook/jest/pull/13142))
 - `[jest-config]` [**BREAKING**] Make `snapshotFormat` default to `escapeString: false` and `printBasicPrototype: false` ([#13036](https://github.com/facebook/jest/pull/13036))
 - `[jest-config]` [**BREAKING**] Remove undocumented `collectCoverageOnlyFrom` option ([#13156](https://github.com/facebook/jest/pull/13156))
-- `[jest-environment-jsdom]` [**BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037), [#13058](https://github.com/facebook/jest/pull/13058))
+- `[jest-environment-jsdom]` **BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037), [#13058](https://github.com/facebook/jest/pull/13058))
 - `[@jest/globals]` Add `jest.Mocked`, `jest.MockedClass`, `jest.MockedFunction` and `jest.MockedObject` utility types ([#12727](https://github.com/facebook/jest/pull/12727))
 - `[jest-mock]` [**BREAKING**] Refactor `Mocked*` utility types. `MaybeMockedDeep` and `MaybeMocked` became `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exported ([#13123](https://github.com/facebook/jest/pull/13123), [#13124](https://github.com/facebook/jest/pull/13124))
 - `[jest-mock]` [**BREAKING**] Change the default `jest.mocked` helper’s behavior to deep mocked ([#13125](https://github.com/facebook/jest/pull/13125))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- `[babel-plugin-jest-hoist]` Support imported `jest` in mock factory ([#13188](https://github.com/facebook/jest/pull/13188
+- `[babel-plugin-jest-hoist]` Support imported `jest` in mock factory ([#13188](https://github.com/facebook/jest/pull/13188))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- `[]` Expose `TransformFactory` type ([#13188](https://github.com/facebook/jest/pull/13188
+- `[babel-plugin-jest-hoist]` Support imported `jest` in mock factory ([#13188](https://github.com/facebook/jest/pull/13188
 
 ### Chore & Maintenance
 
@@ -23,10 +23,10 @@
 ### Features
 
 - `[expect]` [**BREAKING**] Differentiate between `MatcherContext` `MatcherUtils` and `MatcherState` types ([#13141](https://github.com/facebook/jest/pull/13141))
-- `[jest-circus]` Add supprt for `test.failing.each` ([#13142](https://github.com/facebook/jest/pull/13142))
+- `[jest-circus]` Add support for `test.failing.each` ([#13142](https://github.com/facebook/jest/pull/13142))
 - `[jest-config]` [**BREAKING**] Make `snapshotFormat` default to `escapeString: false` and `printBasicPrototype: false` ([#13036](https://github.com/facebook/jest/pull/13036))
 - `[jest-config]` [**BREAKING**] Remove undocumented `collectCoverageOnlyFrom` option ([#13156](https://github.com/facebook/jest/pull/13156))
-- `[jest-environment-jsdom]` **BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037), [#13058](https://github.com/facebook/jest/pull/13058))
+- `[jest-environment-jsdom]` [**BREAKING**] Upgrade to `jsdom@20` ([#13037](https://github.com/facebook/jest/pull/13037), [#13058](https://github.com/facebook/jest/pull/13058))
 - `[@jest/globals]` Add `jest.Mocked`, `jest.MockedClass`, `jest.MockedFunction` and `jest.MockedObject` utility types ([#12727](https://github.com/facebook/jest/pull/12727))
 - `[jest-mock]` [**BREAKING**] Refactor `Mocked*` utility types. `MaybeMockedDeep` and `MaybeMocked` became `Mocked` and `MockedShallow` respectively; only deep mocked variants of `MockedClass`, `MockedFunction` and `MockedObject` are exported ([#13123](https://github.com/facebook/jest/pull/13123), [#13124](https://github.com/facebook/jest/pull/13124))
 - `[jest-mock]` [**BREAKING**] Change the default `jest.mocked` helper’s behavior to deep mocked ([#13125](https://github.com/facebook/jest/pull/13125))

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -40,7 +40,7 @@ function _getJestObj() {
 
 `;
 
-exports[`babel-plugin-jest-hoist global jest.mock within jest: global jest.mock within jest 1`] = `
+exports[`babel-plugin-jest-hoist global jest.mock within jest.mock: global jest.mock within jest.mock 1`] = `
 
 jest.mock('some-module', () => {
   jest.mock('some-module');
@@ -63,7 +63,34 @@ function _getJestObj() {
 
 `;
 
-exports[`babel-plugin-jest-hoist imported jest.mock within jest: imported jest.mock within jest 1`] = `
+exports[`babel-plugin-jest-hoist global jest.requireActual in jest.mock: global jest.requireActual in jest.mock 1`] = `
+
+jest.mock('some-module', () => {
+  jest.requireActual('some-module');
+});
+
+jest.requireActual('some-module');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  _getJestObj().requireActual('some-module');
+});
+
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+
+  _getJestObj = () => jest;
+
+  return jest;
+}
+
+jest.requireActual('some-module');
+
+
+`;
+
+exports[`babel-plugin-jest-hoist imported jest.mock within jest.mock: imported jest.mock within jest.mock 1`] = `
 
 import {jest} from '@jest/globals';
 
@@ -86,6 +113,36 @@ function _getJestObj() {
 }
 
 import {jest} from '@jest/globals';
+
+
+`;
+
+exports[`babel-plugin-jest-hoist imported jest.requireActual in jest.mock: imported jest.requireActual in jest.mock 1`] = `
+
+import {jest} from '@jest/globals';
+
+jest.mock('some-module', () => {
+  jest.requireActual('some-module');
+});
+
+jest.requireActual('some-module');
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  _getJestObj().requireActual('some-module');
+});
+
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+
+  _getJestObj = () => jest;
+
+  return jest;
+}
+
+import {jest} from '@jest/globals';
+jest.requireActual('some-module');
 
 
 `;

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -40,6 +40,56 @@ function _getJestObj() {
 
 `;
 
+exports[`babel-plugin-jest-hoist global jest.mock within jest: global jest.mock within jest 1`] = `
+
+jest.mock('some-module', () => {
+  jest.mock('some-module');
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  _getJestObj().mock('some-module');
+});
+
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+
+  _getJestObj = () => jest;
+
+  return jest;
+}
+
+
+`;
+
+exports[`babel-plugin-jest-hoist imported jest.mock within jest: imported jest.mock within jest 1`] = `
+
+import {jest} from '@jest/globals';
+
+jest.mock('some-module', () => {
+  jest.mock('some-module');
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  _getJestObj().mock('some-module');
+});
+
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+
+  _getJestObj = () => jest;
+
+  return jest;
+}
+
+import {jest} from '@jest/globals';
+
+
+`;
+
 exports[`babel-plugin-jest-hoist required \`jest\` within \`jest\`: required \`jest\` within \`jest\` 1`] = `
 
 const {jest} = require('@jest/globals');

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -90,7 +90,7 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
-    'imported jest.mock within jest': {
+    'imported jest.mock within jest.mock': {
       code: formatResult(`
         import {jest} from '@jest/globals';
 
@@ -101,11 +101,35 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
-    'global jest.mock within jest': {
+    'global jest.mock within jest.mock': {
       code: formatResult(`
         jest.mock('some-module', () => {
           jest.mock('some-module');
         });
+      `),
+      formatResult,
+      snapshot: true,
+    },
+    'imported jest.requireActual in jest.mock': {
+      code: formatResult(`
+        import {jest} from '@jest/globals';
+
+        jest.mock('some-module', () => {
+          jest.requireActual('some-module');
+        });
+
+        jest.requireActual('some-module');
+      `),
+      formatResult,
+      snapshot: true,
+    },
+    'global jest.requireActual in jest.mock': {
+      code: formatResult(`
+        jest.mock('some-module', () => {
+          jest.requireActual('some-module');
+        });
+
+        jest.requireActual('some-module');
       `),
       formatResult,
       snapshot: true,

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -90,10 +90,19 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
-    'imported jest within jest': {
+    'imported jest.mock within jest': {
       code: formatResult(`
         import {jest} from '@jest/globals';
 
+        jest.mock('some-module', () => {
+          jest.mock('some-module');
+        });
+      `),
+      formatResult,
+      snapshot: true,
+    },
+    'global jest.mock within jest': {
+      code: formatResult(`
         jest.mock('some-module', () => {
           jest.mock('some-module');
         });

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -90,6 +90,17 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
+    'imported jest within jest': {
+      code: formatResult(`
+        import {jest} from '@jest/globals';
+
+        jest.mock('some-module', () => {
+          jest.mock('some-module');
+        });
+      `),
+      formatResult,
+      snapshot: true,
+    },
   },
   /* eslint-enable */
 });

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -161,6 +161,19 @@ FUNCTIONS.mock = args => {
               hoistedVariables.add(node);
               isAllowedIdentifier = true;
             }
+          } else if (binding?.path.isImportSpecifier()) {
+            const importDecl = binding.path
+              .parentPath as NodePath<ImportDeclaration>;
+            const imported = binding.path.node.imported;
+            if (
+              importDecl.node.source.value === JEST_GLOBALS_MODULE_NAME &&
+              (isIdentifier(imported) ? imported.name : imported.value) ===
+                JEST_GLOBALS_MODULE_JEST_EXPORT_NAME
+            ) {
+              isAllowedIdentifier = true;
+              // Imports are already hoisted, so we don't need to add it
+              // to hoistedVariables.
+            }
           }
         }
 

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -14,6 +14,7 @@ import {
   CallExpression,
   Expression,
   Identifier,
+  ImportDeclaration,
   MemberExpression,
   Node,
   Program,
@@ -31,6 +32,7 @@ const JEST_GLOBALS_MODULE_NAME = '@jest/globals';
 const JEST_GLOBALS_MODULE_JEST_EXPORT_NAME = 'jest';
 
 const hoistedVariables = new WeakSet<VariableDeclarator>();
+const hoistedJestExpressions = new WeakSet<Expression>();
 
 // We allow `jest`, `expect`, `require`, all default Node.js globals and all
 // ES2015 built-ins to be used inside of a `jest.mock` factory.
@@ -277,9 +279,26 @@ const extractJestObjExprIfHoistable = (
   // Important: Call the function check last
   // It might throw an error to display to the user,
   // which should only happen if we're already sure it's a call on the Jest object.
-  const functionLooksHoistable = FUNCTIONS[propertyName]?.(args);
+  let functionLooksHoistableOrInHoistable = FUNCTIONS[propertyName]?.(args);
 
-  return functionLooksHoistable ? jestObjExpr : null;
+  for (
+    let path: NodePath<Node> | null = expr;
+    path && !functionLooksHoistableOrInHoistable;
+    path = path.parentPath
+  ) {
+    functionLooksHoistableOrInHoistable = hoistedJestExpressions.has(
+      // @ts-expect-error: it's ok if path.node is not an Expression, .has will
+      // just return false.
+      path.node,
+    );
+  }
+
+  if (functionLooksHoistableOrInHoistable) {
+    hoistedJestExpressions.add(expr.node);
+    return jestObjExpr;
+  }
+
+  return null;
 };
 
 /* eslint-disable sort-keys */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR:
- Fixes the detection of `jest.*` refs to imported `jest` in non-top-level contexts
- Transforms all the `jest.*` refs inside hoisted code to the "lazy" version

Fixes https://github.com/facebook/jest/issues/12422

## Test plan

Tests added

---

I have two questions:
1. This test doesn't make sense to me, since `import`s are hoisted and thus the `jest` import is _already hoisted, even without any transform_:
   ```js
   import {jest} from '@jest/globals';
   jest.mock('some-module', () => {
     jest.mock('some-module');
   });
         ↓ ↓ ↓ ↓ ↓ ↓
   _getJestObj().mock('some-module', () => {
     _getJestObj().mock('some-module');
   });
   function _getJestObj() {
     const {jest} = require('@jest/globals');
     _getJestObj = () => jest;
     return jest;
   }
   import {jest} from '@jest/globals';
   ```
   
   What's the reason to transform it?

2. Can we always transform `jest` to `_getJestObj`, so that we don't have to check if it's hoisted or not and we can simplify the plugin?
3. Since `require` is cached by default, can we use `require('@jest/globals').jest` directly instead of `_getJestObj()`?