### PR TITLE
docs: ESM update

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -182,6 +182,7 @@ module.exports = {
     {
       files: ['docs/**/*', 'website/**/*'],
       rules: {
+        'no-redeclare': 'off',
         'import/order': 'off',
         'import/sort-keys': 'off',
         'no-restricted-globals': ['off'],

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -71,3 +71,18 @@ const exported = require('main.cjs');
 ```
 
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const { execSync } = await import('node:child_process');
+
+// etc.
+```

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -65,7 +65,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';
@@ -88,5 +87,6 @@ const exported = require('./main.cjs');
 // alternatively
 const {BrowserWindow} = (await import('electron')).default;
 const exported = await import('./main.cjs');
+
 // etc.
 ```

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -40,8 +40,7 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -49,8 +48,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -40,9 +40,9 @@ import.meta.jest.useFakeTimers();
 
 ## Module mocking in ESM
 
-Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work for ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
-ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+ESM mocking is supported through `jest.unstable_mockModule`. As the name suggests, this API is still work in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 
 The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -49,7 +49,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -61,8 +64,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -38,4 +38,35 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+```js
+// - main.cjs
+const { BrowserWindow, app } = require('electron');
+
+// etc.
+
+module.exports = { example };
+```
+
+```js
+// - main.test.js
+import { jest } from '@jest/globals';
+
+jest.mock('electron', () => ({
+  app: {
+    on: jest.fn(),
+    whenReady: jest.fn(() => Promise.resolve()),
+  },
+  BrowserWindow: jest.fn().mockImplementation(() => ({
+    // partial mocks.
+  }))
+}));
+
+const { BrowserWindow } = (await import('electron')).default;
+const exported = await import('main.cjs');
+
+// etc.
+```
+
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -40,7 +40,9 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 
 ```js
 import {jest} from '@jest/globals';

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -38,7 +38,9 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+## Module mocking in ESM
+
+Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -38,19 +38,37 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import {jest} from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const {execSync} = await import('node:child_process');
+
+// etc.
+```
+
+For mocking CJS modules, you should continue to use `jest.mock`. See the example below:
 
 ```js title="main.cjs"
-const { BrowserWindow, app } = require('electron');
+const {BrowserWindow, app} = require('electron');
 
 // etc.
 
-module.exports = { example };
+module.exports = {example};
 ```
 
+<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import {jest} from '@jest/globals';
 
 const require = createRequire(import.meta.url);
 
@@ -61,28 +79,14 @@ jest.mock('electron', () => ({
   },
   BrowserWindow: jest.fn().mockImplementation(() => ({
     // partial mocks.
-  }))
+  })),
 }));
 
-const { BrowserWindow } = require('electron');
-const exported = require('main.cjs');
+const {BrowserWindow} = require('electron');
+const exported = require('./main.cjs');
 
-// etc.
-```
-
-Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
-
-In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
-
-```js
-import { jest } from '@jest/globals';
-
-jest.unstable_mockModule('node:child_process', () => ({
-  execSync: jest.fn(),
-  // etc.
-}));
-
-const { execSync } = await import('node:child_process');
-
+// alternatively
+const {BrowserWindow} = (await import('electron')).default;
+const exported = await import('./main.cjs');
 // etc.
 ```

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -42,7 +42,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -32,19 +32,20 @@ jest.useFakeTimers();
 // etc.
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ```js title="main.cjs"
-const { BrowserWindow, app } = require('electron');
+const {BrowserWindow, app} = require('electron');
 
 // etc.
 
-module.exports = { example };
+module.exports = {example};
 ```
 
+<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import {jest} from '@jest/globals';
 
 const require = createRequire(import.meta.url);
 
@@ -55,11 +56,15 @@ jest.mock('electron', () => ({
   },
   BrowserWindow: jest.fn().mockImplementation(() => ({
     // partial mocks.
-  }))
+  })),
 }));
 
-const { BrowserWindow } = require('electron');
-const exported = require('main.cjs');
+const {BrowserWindow} = require('electron');
+const exported = require('./main.cjs');
+
+// alternatively
+const {BrowserWindow} = (await import('electron')).default;
+const exported = await import('./main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -32,7 +32,7 @@ jest.useFakeTimers();
 // etc.
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work in ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
 ```js title="main.cjs"
 const {BrowserWindow, app} = require('electron');

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -34,8 +34,7 @@ jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -43,8 +42,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -43,7 +43,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -55,8 +58,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-25.x/ManualMocks.md
+++ b/website/versioned_docs/version-25.x/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/website/versioned_docs/version-25.x/ManualMocks.md
+++ b/website/versioned_docs/version-25.x/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/website/versioned_docs/version-25.x/ManualMocks.md
+++ b/website/versioned_docs/version-25.x/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-25.x/ManualMocks.md
+++ b/website/versioned_docs/version-25.x/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-25.x/ManualMocks.md
+++ b/website/versioned_docs/version-25.x/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -42,7 +42,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -32,19 +32,20 @@ jest.useFakeTimers();
 // etc.
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ```js title="main.cjs"
-const { BrowserWindow, app } = require('electron');
+const {BrowserWindow, app} = require('electron');
 
 // etc.
 
-module.exports = { example };
+module.exports = {example};
 ```
 
+<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import {jest} from '@jest/globals';
 
 const require = createRequire(import.meta.url);
 
@@ -55,11 +56,15 @@ jest.mock('electron', () => ({
   },
   BrowserWindow: jest.fn().mockImplementation(() => ({
     // partial mocks.
-  }))
+  })),
 }));
 
-const { BrowserWindow } = require('electron');
-const exported = require('main.cjs');
+const {BrowserWindow} = require('electron');
+const exported = require('./main.cjs');
+
+// alternatively
+const {BrowserWindow} = (await import('electron')).default;
+const exported = await import('./main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -32,7 +32,7 @@ jest.useFakeTimers();
 // etc.
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work in ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
 ```js title="main.cjs"
 const {BrowserWindow, app} = require('electron');

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -34,8 +34,7 @@ jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -43,8 +42,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -43,7 +43,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -55,8 +58,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-26.x/ManualMocks.md
+++ b/website/versioned_docs/version-26.x/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/website/versioned_docs/version-26.x/ManualMocks.md
+++ b/website/versioned_docs/version-26.x/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/website/versioned_docs/version-26.x/ManualMocks.md
+++ b/website/versioned_docs/version-26.x/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-26.x/ManualMocks.md
+++ b/website/versioned_docs/version-26.x/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-26.x/ManualMocks.md
+++ b/website/versioned_docs/version-26.x/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -60,7 +60,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';
@@ -83,5 +82,6 @@ const exported = require('./main.cjs');
 // alternatively
 const {BrowserWindow} = (await import('electron')).default;
 const exported = await import('./main.cjs');
+
 // etc.
 ```

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -35,7 +35,9 @@ jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 
 ```js
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -44,7 +44,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -56,8 +59,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -33,7 +33,9 @@ jest.useFakeTimers();
 // etc.
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+## Module mocking in ESM
+
+Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -33,4 +33,35 @@ jest.useFakeTimers();
 // etc.
 ```
 
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+```js
+// - main.cjs
+const { BrowserWindow, app } = require('electron');
+
+// etc.
+
+module.exports = { example };
+```
+
+```js
+// - main.test.js
+import { jest } from '@jest/globals';
+
+jest.mock('electron', () => ({
+  app: {
+    on: jest.fn(),
+    whenReady: jest.fn(() => Promise.resolve()),
+  },
+  BrowserWindow: jest.fn().mockImplementation(() => ({
+    // partial mocks.
+  }))
+}));
+
+const { BrowserWindow } = (await import('electron')).default;
+const exported = await import('main.cjs');
+
+// etc.
+```
+
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -35,9 +35,9 @@ jest.useFakeTimers();
 
 ## Module mocking in ESM
 
-Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work for ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
-ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+ESM mocking is supported through `jest.unstable_mockModule`. As the name suggests, this API is still work in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 
 The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -35,8 +35,7 @@ jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -44,8 +43,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -66,3 +66,18 @@ const exported = require('main.cjs');
 ```
 
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const { execSync } = await import('node:child_process');
+
+// etc.
+```

--- a/website/versioned_docs/version-27.x/ManualMocks.md
+++ b/website/versioned_docs/version-27.x/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/website/versioned_docs/version-27.x/ManualMocks.md
+++ b/website/versioned_docs/version-27.x/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/website/versioned_docs/version-27.x/ManualMocks.md
+++ b/website/versioned_docs/version-27.x/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-27.x/ManualMocks.md
+++ b/website/versioned_docs/version-27.x/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-27.x/ManualMocks.md
+++ b/website/versioned_docs/version-27.x/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -71,3 +71,18 @@ const exported = require('main.cjs');
 ```
 
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const { execSync } = await import('node:child_process');
+
+// etc.
+```

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -65,7 +65,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';
@@ -88,5 +87,6 @@ const exported = require('./main.cjs');
 // alternatively
 const {BrowserWindow} = (await import('electron')).default;
 const exported = await import('./main.cjs');
+
 // etc.
 ```

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -40,8 +40,7 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -49,8 +48,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -40,9 +40,9 @@ import.meta.jest.useFakeTimers();
 
 ## Module mocking in ESM
 
-Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work for ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
-ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+ESM mocking is supported through `jest.unstable_mockModule`. As the name suggests, this API is still work in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 
 The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -49,7 +49,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -61,8 +64,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -38,4 +38,35 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+```js
+// - main.cjs
+const { BrowserWindow, app } = require('electron');
+
+// etc.
+
+module.exports = { example };
+```
+
+```js
+// - main.test.js
+import { jest } from '@jest/globals';
+
+jest.mock('electron', () => ({
+  app: {
+    on: jest.fn(),
+    whenReady: jest.fn(() => Promise.resolve()),
+  },
+  BrowserWindow: jest.fn().mockImplementation(() => ({
+    // partial mocks.
+  }))
+}));
+
+const { BrowserWindow } = (await import('electron')).default;
+const exported = await import('main.cjs');
+
+// etc.
+```
+
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -40,7 +40,9 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 
 ```js
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -38,7 +38,9 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+## Module mocking in ESM
+
+Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -38,19 +38,37 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import {jest} from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const {execSync} = await import('node:child_process');
+
+// etc.
+```
+
+For mocking CJS modules, you should continue to use `jest.mock`. See the example below:
 
 ```js title="main.cjs"
-const { BrowserWindow, app } = require('electron');
+const {BrowserWindow, app} = require('electron');
 
 // etc.
 
-module.exports = { example };
+module.exports = {example};
 ```
 
+<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import {jest} from '@jest/globals';
 
 const require = createRequire(import.meta.url);
 
@@ -61,28 +79,14 @@ jest.mock('electron', () => ({
   },
   BrowserWindow: jest.fn().mockImplementation(() => ({
     // partial mocks.
-  }))
+  })),
 }));
 
-const { BrowserWindow } = require('electron');
-const exported = require('main.cjs');
+const {BrowserWindow} = require('electron');
+const exported = require('./main.cjs');
 
-// etc.
-```
-
-Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
-
-In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
-
-```js
-import { jest } from '@jest/globals';
-
-jest.unstable_mockModule('node:child_process', () => ({
-  execSync: jest.fn(),
-  // etc.
-}));
-
-const { execSync } = await import('node:child_process');
-
+// alternatively
+const {BrowserWindow} = (await import('electron')).default;
+const exported = await import('./main.cjs');
 // etc.
 ```

--- a/website/versioned_docs/version-28.x/ManualMocks.md
+++ b/website/versioned_docs/version-28.x/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/website/versioned_docs/version-28.x/ManualMocks.md
+++ b/website/versioned_docs/version-28.x/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/website/versioned_docs/version-28.x/ManualMocks.md
+++ b/website/versioned_docs/version-28.x/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-28.x/ManualMocks.md
+++ b/website/versioned_docs/version-28.x/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-28.x/ManualMocks.md
+++ b/website/versioned_docs/version-28.x/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -71,3 +71,18 @@ const exported = require('main.cjs');
 ```
 
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const { execSync } = await import('node:child_process');
+
+// etc.
+```

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -65,7 +65,6 @@ const {BrowserWindow, app} = require('electron');
 module.exports = {example};
 ```
 
-<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
 import {createRequire} from 'node:module';
 import {jest} from '@jest/globals';
@@ -88,5 +87,6 @@ const exported = require('./main.cjs');
 // alternatively
 const {BrowserWindow} = (await import('electron')).default;
 const exported = await import('./main.cjs');
+
 // etc.
 ```

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -40,8 +40,7 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-```js
-// - main.cjs
+```js title="main.cjs"
 const { BrowserWindow, app } = require('electron');
 
 // etc.
@@ -49,8 +48,7 @@ const { BrowserWindow, app } = require('electron');
 module.exports = { example };
 ```
 
-```js
-// - main.test.js
+```js title="main.test.cjs"
 import { jest } from '@jest/globals';
 
 jest.mock('electron', () => ({

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -7,7 +7,7 @@ Jest ships with _experimental_ support for ECMAScript Modules (ESM).
 
 > Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `14.13.1`).
+> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -40,9 +40,9 @@ import.meta.jest.useFakeTimers();
 
 ## Module mocking in ESM
 
-Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Since ESM evaluates static `import` statements before looking at the code, the hoisting of `jest.mock` calls that happens in CJS won't work for ESM. To mock modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules - the same applies to modules which load the mocked modules.
 
-ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+ESM mocking is supported through `jest.unstable_mockModule`. As the name suggests, this API is still work in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 
 The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -49,7 +49,10 @@ module.exports = { example };
 ```
 
 ```js title="main.test.cjs"
+import { createRequire } from 'node:module';
 import { jest } from '@jest/globals';
+
+const require = createRequire(import.meta.url);
 
 jest.mock('electron', () => ({
   app: {
@@ -61,8 +64,8 @@ jest.mock('electron', () => ({
   }))
 }));
 
-const { BrowserWindow } = (await import('electron')).default;
-const exported = await import('main.cjs');
+const { BrowserWindow } = require('electron');
+const exported = require('main.cjs');
 
 // etc.
 ```

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -38,4 +38,35 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+```js
+// - main.cjs
+const { BrowserWindow, app } = require('electron');
+
+// etc.
+
+module.exports = { example };
+```
+
+```js
+// - main.test.js
+import { jest } from '@jest/globals';
+
+jest.mock('electron', () => ({
+  app: {
+    on: jest.fn(),
+    whenReady: jest.fn(() => Promise.resolve()),
+  },
+  BrowserWindow: jest.fn().mockImplementation(() => ({
+    // partial mocks.
+  }))
+}));
+
+const { BrowserWindow } = (await import('electron')).default;
+const exported = await import('main.cjs');
+
+// etc.
+```
+
 Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -40,7 +40,9 @@ import.meta.jest.useFakeTimers();
 
 Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
-Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
+
+The usage of `jest.unstable_mockModule` is essentially the same as `jest.mock` with two differences: the factory function is required and it can be sync or async:
 
 ```js
 import {jest} from '@jest/globals';

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -38,7 +38,9 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+## Module mocking in ESM
+
+Since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
 
 ESM module mocking is supported through `jest.unstable_mockModule`. As the name suggest works are in progress, please follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -38,19 +38,37 @@ import.meta.jest.useFakeTimers();
 // jest === import.meta.jest => true
 ```
 
-Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+Additionally, since ESM evaluates static `import` statements before looking at the code, hoisting on `jest.mock` calls that happens in CJS modules won't work in ESM. To `mock` modules in ESM, you need to use `require` or dynamic `import()` after `jest.mock` calls to load the mocked modules, same applies to modules which have to load the mocked modules.
+
+Please also note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates. `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
+
+```js
+import {jest} from '@jest/globals';
+
+jest.unstable_mockModule('node:child_process', () => ({
+  execSync: jest.fn(),
+  // etc.
+}));
+
+const {execSync} = await import('node:child_process');
+
+// etc.
+```
+
+For mocking CJS modules, you should continue to use `jest.mock`. See the example below:
 
 ```js title="main.cjs"
-const { BrowserWindow, app } = require('electron');
+const {BrowserWindow, app} = require('electron');
 
 // etc.
 
-module.exports = { example };
+module.exports = {example};
 ```
 
+<!-- eslint-disable no-redeclare -->
 ```js title="main.test.cjs"
-import { createRequire } from 'node:module';
-import { jest } from '@jest/globals';
+import {createRequire} from 'node:module';
+import {jest} from '@jest/globals';
 
 const require = createRequire(import.meta.url);
 
@@ -61,28 +79,14 @@ jest.mock('electron', () => ({
   },
   BrowserWindow: jest.fn().mockImplementation(() => ({
     // partial mocks.
-  }))
+  })),
 }));
 
-const { BrowserWindow } = require('electron');
-const exported = require('main.cjs');
+const {BrowserWindow} = require('electron');
+const exported = require('./main.cjs');
 
-// etc.
-```
-
-Please note that we currently don't support `jest.mock` in a clean way in ESM, but that is something we intend to add proper support for in the future. Follow [this issue](https://github.com/facebook/jest/issues/10025) for updates.
-
-In short, `jest.unstable_mockModule` is needed to mock ESM for now. Its usage is essentially the same as `jest.mock`. See the example below:
-
-```js
-import { jest } from '@jest/globals';
-
-jest.unstable_mockModule('node:child_process', () => ({
-  execSync: jest.fn(),
-  // etc.
-}));
-
-const { execSync } = await import('node:child_process');
-
+// alternatively
+const {BrowserWindow} = (await import('electron')).default;
+const exported = await import('./main.cjs');
 // etc.
 ```

--- a/website/versioned_docs/version-29.0/ManualMocks.md
+++ b/website/versioned_docs/version-29.0/ManualMocks.md
@@ -130,6 +130,8 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+
 ## Mocking methods which are not implemented in JSDOM
 
 If some code uses a method which JSDOM (the DOM implementation used by Jest) hasn't implemented yet, testing it is not easily possible. This is e.g. the case with `window.matchMedia()`. Jest returns `TypeError: window.matchMedia is not a function` and doesn't properly execute the test.

--- a/website/versioned_docs/version-29.0/ManualMocks.md
+++ b/website/versioned_docs/version-29.0/ManualMocks.md
@@ -132,7 +132,7 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the static imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 :::
 

--- a/website/versioned_docs/version-29.0/ManualMocks.md
+++ b/website/versioned_docs/version-29.0/ManualMocks.md
@@ -130,7 +130,9 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
+:::caution
+
+Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-29.0/ManualMocks.md
+++ b/website/versioned_docs/version-29.0/ManualMocks.md
@@ -132,7 +132,9 @@ If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web
 
 :::caution
 
-Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+`jest.mock` calls cannot be hoisted to the top of the module if you enabled ECMAScript modules support. The ESM module loader always evaluates the imports before executing code. See [ECMAScriptModules](ECMAScriptModules.md) for details.
+
+:::
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_docs/version-29.0/ManualMocks.md
+++ b/website/versioned_docs/version-29.0/ManualMocks.md
@@ -130,7 +130,7 @@ The code for this example is available at [examples/manual-mocks](https://github
 
 If you're using [ES module imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import) then you'll normally be inclined to put your `import` statements at the top of the test file. But often you need to instruct Jest to use a mock before modules use it. For this reason, Jest will automatically hoist `jest.mock` calls to the top of the module (before any imports). To learn more about this and see it in action, see [this repo](https://github.com/kentcdodds/how-jest-mocking-works).
 
-*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](https://jestjs.io/docs/ecmascript-modules) for details.*
+*__Caution__: Jest does NOT hoist `jest.mock` calls to the top of the module if you have ESM support activated. See [ECMAScriptModules](ECMAScriptModules.md) for details.*
 
 ## Mocking methods which are not implemented in JSDOM
 

--- a/website/versioned_sidebars/version-25.x-sidebars.json
+++ b/website/versioned_sidebars/version-25.x-sidebars.json
@@ -68,6 +68,10 @@
         },
         {
           "type": "doc",
+          "id": "version-25.x/ecmascript-modules"
+        },
+        {
+          "type": "doc",
           "id": "version-25.x/webpack"
         },
         {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

As discussed in #13135, this PR:

- documented that there's no hoisting on `jest.mock` with ESM support activated and added example of putting the `mock` calls before `import` statements to properly load the import modules.
- updated `Using with ES module imports` in `ManulMocks.md` to point out the hoisting mentioned there does not applied when ESM support is activated with link to `ECMAScriptModules.md`.

Additionally, I've updated the Node version number mentioned in `ECMAScriptModules.md` to reflect the fact that `vm.Module` is still considered experimental in `18.8.0`.

@mrazauskas I've found that already a link to #10025 in `ECMAScriptModules.md`, do you want to add some documentations for `jest.unstable_mock` there as well or you think it's fine just leave it like this for now?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

No test plan. Only docs are updated.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
