### PR TITLE
feat(@jest/environment, jest-runtime): allow passing a generic type argument to `jest.createMockFromModule<T>()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[@jest/environment, jest-runtime]` Allow passing a generic type argument to `jest.createMockFromModule<T>()` method ([#13202](https://github.com/facebook/jest/pull/13202))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -129,6 +129,7 @@ export interface Jest {
    * Creates a mock function. Optionally takes a mock implementation.
    */
   fn: ModuleMocker['fn'];
+  // TODO remove `genMockFromModule()` in Jest 30
   /**
    * Given the name of a module, use the automatic mocking system to generate a
    * mocked version of the module for you.

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -8,7 +8,7 @@
 import type {Context} from 'vm';
 import type {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
 import type {Circus, Config, Global} from '@jest/types';
-import type {ModuleMocker} from 'jest-mock';
+import type {Mocked, ModuleMocker} from 'jest-mock';
 
 export type EnvironmentContext = {
   console: Console;
@@ -92,7 +92,7 @@ export interface Jest {
    * This is useful when you want to create a manual mock that extends the
    * automatic mock's behavior.
    */
-  createMockFromModule(moduleName: string): unknown;
+  createMockFromModule<T extends object>(moduleName: string): Mocked<T>;
   /**
    * Indicates that the module system should never return a mocked version of
    * the specified module and its dependencies.
@@ -138,7 +138,7 @@ export interface Jest {
    *
    * @deprecated Use `jest.createMockFromModule()` instead
    */
-  genMockFromModule(moduleName: string): unknown;
+  genMockFromModule<T extends object>(moduleName: string): Mocked<T>;
   /**
    * When mocking time, `Date.now()` will also be mocked. If you for some reason
    * need access to the real current time, you can invoke this function.

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -92,7 +92,7 @@ export interface Jest {
    * This is useful when you want to create a manual mock that extends the
    * automatic mock's behavior.
    */
-  createMockFromModule<T extends object>(moduleName: string): Mocked<T>;
+  createMockFromModule<T = unknown>(moduleName: string): Mocked<T>;
   /**
    * Indicates that the module system should never return a mocked version of
    * the specified module and its dependencies.
@@ -138,7 +138,7 @@ export interface Jest {
    *
    * @deprecated Use `jest.createMockFromModule()` instead
    */
-  genMockFromModule<T extends object>(moduleName: string): Mocked<T>;
+  genMockFromModule<T = unknown>(moduleName: string): Mocked<T>;
   /**
    * When mocking time, `Date.now()` will also be mocked. If you for some reason
    * need access to the real current time, you can invoke this function.

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -868,15 +868,15 @@ export class ModuleMocker {
   private _generateMock<T>(
     metadata: MockMetadata<T>,
     callbacks: Array<Function>,
-    refs: {
-      [key: string]:
-        | Record<string, any>
-        | Array<unknown>
-        | RegExp
-        | UnknownFunction
-        | undefined
-        | Mock<UnknownFunction>;
-    },
+    refs: Record<
+      number,
+      | Record<string, any>
+      | Array<unknown>
+      | RegExp
+      | UnknownFunction
+      | Mock
+      | undefined
+    >,
   ): Mocked<T> {
     // metadata not compatible but it's the same type, maybe problem with
     // overloading of _makeComponent and not _generateMock?

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -20,9 +20,7 @@ export type MockMetadataType =
 // TODO remove re-export in Jest 30
 export type MockFunctionMetadataType = MockMetadataType;
 
-export type MetaDataValue<T> = T extends UnknownFunction
-  ? ReturnType<T>
-  : undefined;
+type MetaDataValue<T> = T extends UnknownFunction ? ReturnType<T> : undefined;
 
 export type MockMetadata<T, MetadataType = MockMetadataType> = {
   ref?: number;
@@ -930,10 +928,10 @@ export class ModuleMocker {
    * @param component The component for which to retrieve metadata.
    */
   getMetadata<T>(
-    component: MetaDataValue<T>,
-    _refs?: Map<MetaDataValue<T>, number>,
+    component: unknown,
+    _refs?: Map<unknown, number>,
   ): MockMetadata<T> | null {
-    const refs = _refs || new Map<MetaDataValue<T>, number>();
+    const refs = _refs || new Map<unknown, number>();
     const ref = refs.get(component);
     if (ref != null) {
       return {ref};
@@ -944,7 +942,7 @@ export class ModuleMocker {
       return null;
     }
 
-    const metadata: MockMetadata<T> = {type};
+    const metadata: MockMetadata<any> = {type};
     if (
       type === 'constant' ||
       type === 'collection' ||

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -20,8 +20,6 @@ export type MockMetadataType =
 // TODO remove re-export in Jest 30
 export type MockFunctionMetadataType = MockMetadataType;
 
-type MetaDataValue<T> = T extends UnknownFunction ? ReturnType<T> : undefined;
-
 export type MockMetadata<T, MetadataType = MockMetadataType> = {
   ref?: number;
   members?: Record<string, MockMetadata<T>>;
@@ -29,7 +27,7 @@ export type MockMetadata<T, MetadataType = MockMetadataType> = {
   name?: string;
   refID?: number;
   type?: MetadataType;
-  value?: MetaDataValue<T>;
+  value?: T;
   length?: number;
 };
 
@@ -927,11 +925,11 @@ export class ModuleMocker {
    * @see README.md
    * @param component The component for which to retrieve metadata.
    */
-  getMetadata<T>(
-    component: unknown,
-    _refs?: Map<unknown, number>,
+  getMetadata<T = unknown>(
+    component: T,
+    _refs?: Map<T, number>,
   ): MockMetadata<T> | null {
-    const refs = _refs || new Map<unknown, number>();
+    const refs = _refs || new Map<T, number>();
     const ref = refs.get(component);
     if (ref != null) {
       return {ref};
@@ -942,7 +940,7 @@ export class ModuleMocker {
       return null;
     }
 
-    const metadata: MockMetadata<any> = {type};
+    const metadata: MockMetadata<T> = {type};
     if (
       type === 'constant' ||
       type === 'collection' ||

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -862,8 +862,8 @@ export class ModuleMocker {
     return createConstructor(mockConstructor);
   }
 
-  private _generateMock<T extends UnknownFunction>(
-    metadata: MockFunctionMetadata<T>,
+  private _generateMock<T extends object>(
+    metadata: MockFunctionMetadata<UnknownFunction>,
     callbacks: Array<Function>,
     refs: {
       [key: string]:
@@ -872,9 +872,9 @@ export class ModuleMocker {
         | RegExp
         | UnknownFunction
         | undefined
-        | Mock<T>;
+        | Mock<UnknownFunction>;
     },
-  ): Mock<T> {
+  ): Mocked<T> {
     // metadata not compatible but it's the same type, maybe problem with
     // overloading of _makeComponent and not _generateMock?
     // @ts-expect-error - unsure why TSC complains here?
@@ -905,7 +905,7 @@ export class ModuleMocker {
       mock.prototype.constructor = mock;
     }
 
-    return mock as Mock<T>;
+    return mock as Mocked<T>;
   }
 
   /**
@@ -913,12 +913,12 @@ export class ModuleMocker {
    * @param metadata Metadata for the mock in the schema returned by the
    * getMetadata method of this module.
    */
-  generateFromMetadata<T extends UnknownFunction>(
-    metadata: MockFunctionMetadata<T>,
-  ): Mock<T> {
+  generateFromMetadata<T extends object>(
+    metadata: MockFunctionMetadata<UnknownFunction>,
+  ): Mocked<T> {
     const callbacks: Array<Function> = [];
     const refs = {};
-    const mock = this._generateMock(metadata, callbacks, refs);
+    const mock = this._generateMock<T>(metadata, callbacks, refs);
     callbacks.forEach(setter => setter());
     return mock;
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -944,7 +944,7 @@ export class ModuleMocker {
       return null;
     }
 
-    const metadata: MockMetadata<T> = {};
+    const metadata: MockMetadata<T> = {type};
     if (
       type === 'constant' ||
       type === 'collection' ||

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -563,18 +563,18 @@ export class ModuleMocker {
     };
   }
 
-  private _makeComponent<T>(
+  private _makeComponent<T extends Record<string, any>>(
     metadata: MockMetadata<T, 'object'>,
     restore?: () => void,
-  ): Record<string, any>;
-  private _makeComponent<T>(
+  ): T;
+  private _makeComponent<T extends Array<unknown>>(
     metadata: MockMetadata<T, 'array'>,
     restore?: () => void,
-  ): Array<unknown>;
-  private _makeComponent<T>(
+  ): T;
+  private _makeComponent<T extends RegExp>(
     metadata: MockMetadata<T, 'regexp'>,
     restore?: () => void,
-  ): RegExp;
+  ): T;
   private _makeComponent<T>(
     metadata: MockMetadata<T, 'constant' | 'collection' | 'null' | 'undefined'>,
     restore?: () => void,

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -32,7 +32,10 @@ export type MockMetadata<T, MetadataType = MockMetadataType> = {
 };
 
 // TODO remove re-export in Jest 30
-export type MockFunctionMetadata<T, U = MockMetadataType> = MockMetadata<T, U>;
+export type MockFunctionMetadata<
+  T = unknown,
+  MetadataType = MockMetadataType,
+> = MockMetadata<T, MetadataType>;
 
 export type ClassLike = {new (...args: any): any};
 export type FunctionLike = (...args: any) => any;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -589,13 +589,7 @@ export class ModuleMocker {
   private _makeComponent<T extends UnknownFunction>(
     metadata: MockMetadata<T>,
     restore?: () => void,
-  ):
-    | Record<string, any>
-    | Array<unknown>
-    | RegExp
-    | ReturnType<T>
-    | undefined
-    | Mock<T> {
+  ): Record<string, any> | Array<unknown> | RegExp | T | Mock | undefined {
     if (metadata.type === 'object') {
       return new this._environmentGlobal.Object();
     } else if (metadata.type === 'array') {
@@ -870,12 +864,7 @@ export class ModuleMocker {
     callbacks: Array<Function>,
     refs: Record<
       number,
-      | Record<string, any>
-      | Array<unknown>
-      | RegExp
-      | UnknownFunction
-      | Mock
-      | undefined
+      Record<string, any> | Array<unknown> | RegExp | T | Mock | undefined
     >,
   ): Mocked<T> {
     // metadata not compatible but it's the same type, maybe problem with

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1710,7 +1710,7 @@ export default class Runtime {
     return Module;
   }
 
-  private _generateMock(from: string, moduleName: string) {
+  private _generateMock<T extends object>(from: string, moduleName: string) {
     const modulePath =
       this._resolver.resolveStubModuleName(from, moduleName) ||
       this._resolveCjsModule(from, moduleName);
@@ -1747,7 +1747,7 @@ export default class Runtime {
       }
       this._mockMetaDataCache.set(modulePath, mockMetadata);
     }
-    return this._moduleMocker.generateFromMetadata(
+    return this._moduleMocker.generateFromMetadata<T>(
       // added above if missing
       this._mockMetaDataCache.get(modulePath)!,
     );

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -50,7 +50,7 @@ import {
 import type {Config, Global} from '@jest/types';
 import HasteMap, {IModuleMap} from 'jest-haste-map';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
-import type {MockFunctionMetadata, ModuleMocker} from 'jest-mock';
+import type {MetaDataValue, MockMetadata, ModuleMocker} from 'jest-mock';
 import {escapePathForRegex} from 'jest-regex-util';
 import Resolver, {ResolveModuleConfig} from 'jest-resolve';
 import {EXTENSION as SnapshotExtension} from 'jest-snapshot';
@@ -168,7 +168,7 @@ export default class Runtime {
   private _isCurrentlyExecutingManualMock: string | null;
   private _mainModule: Module | null;
   private readonly _mockFactories: Map<string, () => unknown>;
-  private readonly _mockMetaDataCache: Map<string, MockFunctionMetadata>;
+  private readonly _mockMetaDataCache: Map<string, MockMetadata<any>>;
   private _mockRegistry: Map<string, any>;
   private _isolatedMockRegistry: Map<string, any> | null;
   private _moduleMockRegistry: Map<string, VMModule>;
@@ -1710,7 +1710,7 @@ export default class Runtime {
     return Module;
   }
 
-  private _generateMock<T extends object>(from: string, moduleName: string) {
+  private _generateMock<T>(from: string, moduleName: string) {
     const modulePath =
       this._resolver.resolveStubModuleName(from, moduleName) ||
       this._resolveCjsModule(from, moduleName);
@@ -1720,7 +1720,7 @@ export default class Runtime {
 
       this._mockMetaDataCache.set(
         modulePath,
-        this._moduleMocker.getMetadata({}) || {},
+        this._moduleMocker.getMetadata({} as MetaDataValue<T>) || {},
       );
 
       // In order to avoid it being possible for automocking to potentially
@@ -1732,7 +1732,10 @@ export default class Runtime {
       this._mockRegistry = new Map();
       this._moduleRegistry = new Map();
 
-      const moduleExports = this.requireModule(from, moduleName);
+      const moduleExports = this.requireModule<MetaDataValue<T>>(
+        from,
+        moduleName,
+      );
 
       // Restore the "real" module/mock registries
       this._mockRegistry = origMockRegistry;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -50,7 +50,7 @@ import {
 import type {Config, Global} from '@jest/types';
 import HasteMap, {IModuleMap} from 'jest-haste-map';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
-import type {MetaDataValue, MockMetadata, ModuleMocker} from 'jest-mock';
+import type {MockMetadata, ModuleMocker} from 'jest-mock';
 import {escapePathForRegex} from 'jest-regex-util';
 import Resolver, {ResolveModuleConfig} from 'jest-resolve';
 import {EXTENSION as SnapshotExtension} from 'jest-snapshot';
@@ -1720,7 +1720,7 @@ export default class Runtime {
 
       this._mockMetaDataCache.set(
         modulePath,
-        this._moduleMocker.getMetadata({} as MetaDataValue<T>) || {},
+        this._moduleMocker.getMetadata({}) || {},
       );
 
       // In order to avoid it being possible for automocking to potentially
@@ -1732,10 +1732,7 @@ export default class Runtime {
       this._mockRegistry = new Map();
       this._moduleRegistry = new Map();
 
-      const moduleExports = this.requireModule<MetaDataValue<T>>(
-        from,
-        moduleName,
-      );
+      const moduleExports = this.requireModule(from, moduleName);
 
       // Restore the "real" module/mock registries
       this._mockRegistry = origMockRegistry;

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -62,7 +62,15 @@ expectError(jest.autoMockOff(true));
 expectType<typeof jest>(jest.autoMockOn());
 expectError(jest.autoMockOn(false));
 
+const someModule = {
+  methodA: () => {},
+  propertyB: 'B',
+};
+
 expectType<unknown>(jest.createMockFromModule('moduleName'));
+expectType<Mocked<typeof someModule>>(
+  jest.createMockFromModule<typeof someModule>('moduleName'),
+);
 expectError(jest.createMockFromModule());
 
 expectType<typeof jest>(jest.deepUnmock('moduleName'));


### PR DESCRIPTION
## Summary

Closes #13201
Resolves #13199

As it was noticed in #13199 currently `jest.createMockFromModule()` returns `unknown` type. This does not align neither with `@jest/types`, nor with the actual behaviour of the method.

The PR adds a possibility to pass a generic type argument `T` to the method. This way the returned value can be typed as `Mocked<T>` which matches the shape of the value.

## Test plan

A type test is added.