### PR TITLE
fix TestScheduler dispatch upon exec error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,9 @@
   },
   "javascript.validate.enable": false,
   "jest.jestCommandLine": "yarn jest",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "jest.autoRun": {
+    "watch": false,
+    "onSave": "test-src-file",
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,5 @@
   },
   "javascript.validate.enable": false,
   "jest.jestCommandLine": "yarn jest",
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "jest.autoRun": {
-    "watch": false,
-    "onSave": "test-src-file",
-  }
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[babel-plugin-jest-hoist]` Support imported `jest` in mock factory ([#13188](https://github.com/facebook/jest/pull/13188))
+- `[jest-core]` Capture execError during `TestScheduler.scheduleTests` and dispatch to reporters. ([#13203](https://github.com/facebook/jest/pull/13203))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[jest-core]` Capture execError during `TestScheduler.scheduleTests` and dispatch to reporters ([#13203](https://github.com/facebook/jest/pull/13203))
+
 ### Chore & Maintenance
 
 ### Performance
@@ -19,7 +21,6 @@
 ### Fixes
 
 - `[babel-plugin-jest-hoist]` Support imported `jest` in mock factory ([#13188](https://github.com/facebook/jest/pull/13188))
-- `[jest-core]` Capture execError during `TestScheduler.scheduleTests` and dispatch to reporters ([#13203](https://github.com/facebook/jest/pull/13203))
 - `[jest-mock]` Align the behavior and return type of `generateFromMetadata` method ([#13207](https://github.com/facebook/jest/pull/13207))
 - `[jest-runtime]` Support `jest.resetModules()` with ESM ([#13211](https://github.com/facebook/jest/pull/13211))
 

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -201,27 +201,6 @@ class TestScheduler {
           aggregatedResults.snapshot.filesRemoved)
       );
     };
-    const strToError = (errString: string): SerializableError => {
-      const {message, stack} = separateMessageFromStack(errString);
-      if (stack.length > 0) {
-        return {message, stack};
-      }
-      const error = new ErrorWithStack(message, buildExecError);
-      return {message, stack: error.stack || ''};
-    };
-    const buildExecError = (err: unknown): SerializableError => {
-      if (typeof err === 'string' || err == null) {
-        return strToError(err || 'Error');
-      }
-      const anyErr = err as any;
-      if (typeof anyErr.message === 'string') {
-        if (typeof anyErr.stack === 'string' && anyErr.stack.length > 0) {
-          return anyErr;
-        }
-        return strToError(anyErr.message);
-      }
-      return strToError(JSON.stringify(err));
-    };
 
     await this._dispatcher.onRunStart(aggregatedResults, {
       estimatedTime,
@@ -458,4 +437,27 @@ const getEstimatedTime = (timings: Array<number>, workers: number) => {
   return timings.length <= workers
     ? max
     : Math.max(timings.reduce((sum, time) => sum + time) / workers, max);
+};
+
+const strToError = (errString: string): SerializableError => {
+  const {message, stack} = separateMessageFromStack(errString);
+  if (stack.length > 0) {
+    return {message, stack};
+  }
+  const error = new ErrorWithStack(message, buildExecError);
+  return {message, stack: error.stack || ''};
+};
+
+const buildExecError = (err: unknown): SerializableError => {
+  if (typeof err === 'string' || err == null) {
+    return strToError(err || 'Error');
+  }
+  const anyErr = err as any;
+  if (typeof anyErr.message === 'string') {
+    if (typeof anyErr.stack === 'string' && anyErr.stack.length > 0) {
+      return anyErr;
+    }
+    return strToError(anyErr.message);
+  }
+  return strToError(JSON.stringify(err));
 };

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -201,26 +201,26 @@ class TestScheduler {
           aggregatedResults.snapshot.filesRemoved)
       );
     };
-    const buildExecError = (err: unknown): SerializableError => {
-      const fromString = (errString: string): SerializableError => {
-        const {message, stack} = separateMessageFromStack(errString);
-        if (stack.length > 0) {
-          return {message, stack};
-        }
-        const error = new ErrorWithStack(message, buildExecError);
-        return {message, stack: error.stack || ''};
-      };
-      if (typeof err === 'string' || err == null) {
-        return fromString(err || 'Error');
+    const strToError = (errString: string): SerializableError => {
+      const {message, stack} = separateMessageFromStack(errString);
+      if (stack.length > 0) {
+        return {message, stack};
       }
-      const anyErr: any = err as any;
+      const error = new ErrorWithStack(message, buildExecError);
+      return {message, stack: error.stack || ''};
+    };
+    const buildExecError = (err: unknown): SerializableError => {
+      if (typeof err === 'string' || err == null) {
+        return strToError(err || 'Error');
+      }
+      const anyErr = err as any;
       if (typeof anyErr.message === 'string') {
         if (typeof anyErr.stack === 'string' && anyErr.stack.length > 0) {
           return anyErr;
         }
-        return fromString(anyErr.message);
+        return strToError(anyErr.message);
       }
-      return fromString(JSON.stringify(err));
+      return strToError(JSON.stringify(err));
     };
 
     await this._dispatcher.onRunStart(aggregatedResults, {

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -231,7 +231,7 @@ class TestScheduler {
     const testRunners: Record<string, JestTestRunner> = Object.create(null);
     const contextsByTestRunner = new WeakMap<JestTestRunner, TestContext>();
 
-    try{
+    try {
       await Promise.all(
         Array.from(testContexts).map(async context => {
           const {config} = context;
@@ -306,7 +306,7 @@ class TestScheduler {
           }
         }
       }
-    } catch(error){
+    } catch (error) {
       aggregatedResults.runExecError = buildExecError(error);
       await this._dispatcher.onRunComplete(testContexts, aggregatedResults);
       throw error;

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -17,6 +17,7 @@ import {
 import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import {createTestScheduler} from '../TestScheduler';
 import * as testSchedulerHelper from '../testSchedulerHelper';
+import * as transform from '@jest/transform';
 
 jest
   .mock('ci-info', () => ({GITHUB_ACTIONS: true}))
@@ -28,8 +29,13 @@ jest
         onTestStart() {},
       })),
     {virtual: true},
-  );
-
+  )
+  .mock('@jest/transform', () => {
+    return {
+      __esModule: true,
+      ...jest.requireActual('@jest/transform'),
+    };
+  })
 const mockSerialRunner = {
   isSerial: true,
   runTests: jest.fn(),
@@ -231,6 +237,134 @@ test('.addReporter() .removeReporter()', async () => {
   expect(scheduler._dispatcher._reporters).toContain(reporter);
   scheduler.removeReporter(SummaryReporter);
   expect(scheduler._dispatcher._reporters).not.toContain(reporter);
+});
+
+describe('scheduleTests should always dispatch runStart and runComplete events', () => {
+  const mockReporter = {
+    onRunStart: jest.fn(),
+    onRunComplete: jest.fn(),
+  };
+
+  const errorMsg = 'runtime-error';
+  let scheduler, t;
+
+  beforeEach(async () => {
+    mockReporter.onRunStart.mockClear();
+    mockReporter.onRunComplete.mockClear();
+
+    t = {
+      context: {
+        config: makeProjectConfig({
+          moduleFileExtensions: ['.js'],
+          rootDir: './',
+          runner: 'jest-runner-serial',
+          transform: [],
+        }),
+        hasteFS: {
+          matchFiles: jest.fn(() => []),
+        },
+      },
+      path: './test/path.js',
+    };
+
+    scheduler = await createTestScheduler(makeGlobalConfig(), {}, {});
+    scheduler.addReporter(mockReporter);
+  });
+
+  test('during normal run', async () => {
+    expect.hasAssertions();
+    const result = await scheduler.scheduleTests([t], {
+      isInterrupted: jest.fn(),
+      isWatchMode: () => true,
+      setState: jest.fn(),
+    });
+
+    expect(result.numTotalTestSuites).toEqual(1);
+
+    expect(mockReporter.onRunStart).toBeCalledTimes(1);
+    expect(mockReporter.onRunComplete).toBeCalledTimes(1);
+    const aggregatedResult = mockReporter.onRunComplete.mock.calls[0][1];
+    expect(aggregatedResult.runExecError).toBeUndefined();
+
+    expect(aggregatedResult).toEqual(result);
+  });
+  test.each`
+    runtimeError                                  | message
+    ${errorMsg}                                   | ${errorMsg}
+    ${123}                                        | ${'123'}
+    ${new Error(errorMsg)}                        | ${errorMsg}
+    ${{message: errorMsg}}                        | ${errorMsg}
+    ${{message: errorMsg, stack: 'stack-string'}} | ${errorMsg}
+    ${`${errorMsg}\n Require stack:xxxx`}         | ${errorMsg}
+  `('with runtime error: $runtimeError', async ({runtimeError, message}) => {
+    expect.hasAssertions();
+
+    const spyCreateScriptTransformer = jest.spyOn(
+      transform,
+      'createScriptTransformer',
+    );
+    spyCreateScriptTransformer.mockImplementation(async () => {
+      throw runtimeError;
+    });
+
+    await expect(
+      scheduler.scheduleTests([t], {
+        isInterrupted: jest.fn(),
+        isWatchMode: () => true,
+        setState: jest.fn(),
+      }),
+    ).rejects.toEqual(runtimeError);
+
+    expect(mockReporter.onRunStart).toBeCalledTimes(1);
+    expect(mockReporter.onRunComplete).toBeCalledTimes(1);
+    const aggregatedResult = mockReporter.onRunComplete.mock.calls[0][1];
+    expect(aggregatedResult.runExecError.message).toEqual(message);
+    expect(aggregatedResult.runExecError.stack.length).toBeGreaterThan(0);
+
+    spyCreateScriptTransformer.mockRestore();
+  });
+  test.each`
+    watchMode | isInterrupted | hasExecError
+    ${false}  | ${false}      | ${true}
+    ${true}   | ${false}      | ${true}
+    ${true}   | ${true}       | ${false}
+  `(
+    'with runner exception: watchMode=$watchMode, isInterrupted=$isInterrupted',
+    async ({watchMode, isInterrupted, hasExecError}) => {
+      expect.hasAssertions();
+
+      mockSerialRunner.runTests.mockImplementation(() => {
+        throw errorMsg;
+      });
+
+      try {
+        const result = await scheduler.scheduleTests([t], {
+          isInterrupted: () => isInterrupted,
+          isWatchMode: () => watchMode,
+          setState: jest.fn(),
+        });
+        if (hasExecError) {
+          throw new Error('should throw exception');
+        }
+        expect(result.runExecError).toBeUndefined();
+      } catch (e) {
+        expect(e).toEqual(errorMsg);
+      }
+
+      expect(mockReporter.onRunStart).toBeCalledTimes(1);
+      expect(mockReporter.onRunComplete).toBeCalledTimes(1);
+
+      const aggregatedResult = mockReporter.onRunComplete.mock.calls[0][1];
+      if (hasExecError) {
+        expect(aggregatedResult.runExecError.message).toEqual(errorMsg);
+        expect(aggregatedResult.runExecError.stack.length).toBeGreaterThan(0);
+      } else {
+        expect(aggregatedResult.runExecError).toBeUndefined();
+      }
+
+      mockSerialRunner.runTests.mockReset();
+    },
+  );
 });
 
 test('schedule tests run in parallel per default', async () => {

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -15,9 +15,9 @@ import {
   VerboseReporter,
 } from '@jest/reporters';
 import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
+import * as transform from '@jest/transform';
 import {createTestScheduler} from '../TestScheduler';
 import * as testSchedulerHelper from '../testSchedulerHelper';
-import * as transform from '@jest/transform';
 
 jest
   .mock('ci-info', () => ({GITHUB_ACTIONS: true}))
@@ -35,7 +35,7 @@ jest
       __esModule: true,
       ...jest.requireActual('@jest/transform'),
     };
-  })
+  });
 const mockSerialRunner = {
   isSerial: true,
   runTests: jest.fn(),
@@ -241,8 +241,8 @@ test('.addReporter() .removeReporter()', async () => {
 
 describe('scheduleTests should always dispatch runStart and runComplete events', () => {
   const mockReporter = {
-    onRunStart: jest.fn(),
     onRunComplete: jest.fn(),
+    onRunStart: jest.fn(),
   };
 
   const errorMsg = 'runtime-error';

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -68,7 +68,7 @@ export type AggregatedResultWithoutCoverage = {
   success: boolean;
   testResults: Array<TestResult>;
   wasInterrupted: boolean;
-  runExecError?: SerializableError; 
+  runExecError?: SerializableError;
 };
 
 export type AggregatedResult = AggregatedResultWithoutCoverage & {

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -68,6 +68,7 @@ export type AggregatedResultWithoutCoverage = {
   success: boolean;
   testResults: Array<TestResult>;
   wasInterrupted: boolean;
+  runExecError?: SerializableError; 
 };
 
 export type AggregatedResult = AggregatedResultWithoutCoverage & {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Modified `TestScheduler.scheduleTests` to capture runtime execError in aggregatedResults and notify reporters via `onRunComplete`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
fix #13187

## Test plan

new tests have been added, all tests should pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
