### PR TITLE
Fix: Yarn build error (ENONENT ERROR)

### DIFF
--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -167,7 +167,7 @@ const excludedPackages = new Set(['@jest/globals']);
       let definitionFile = await fs.promises.readFile(filepath, 'utf8');
 
       rimraf.sync(path.resolve(packageDir, 'build/**/*.d.ts'));
-      fs.rmSync(path.resolve(packageDir, 'dist/'), {
+      fs.rmSync(path.resolve(packageDir, 'dist/**'), {
         force: true,
         recursive: true,
       });


### PR DESCRIPTION
Whiled doing yarn build in the repo, I found this error , seems like it is specific to Windows
![Windows PowerShell 9_1_2022 11_26_34 AM](https://user-images.githubusercontent.com/72331432/187845751-2b683d2b-2984-4ec6-991e-ee5835a99df1.png)

clearing the dist later fixed this issue as you can see below
![Windows PowerShell 9_1_2022 11_47_57 AM](https://user-images.githubusercontent.com/72331432/187845937-3a09a727-1bd9-4510-9c97-e329e16769fb.png)

