### PR TITLE
docs: use admonitions in ECMAScript Modules page

### DIFF
--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-25.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-25.x/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-26.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-26.x/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-27.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-27.x/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-28.x/ECMAScriptModules.md
+++ b/website/versioned_docs/version-28.x/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -11,7 +11,7 @@ The implementation may have bugs and lack features. For the latest status check 
 
 Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
 
-:::caution
+:::
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 

--- a/website/versioned_docs/version-29.0/ECMAScriptModules.md
+++ b/website/versioned_docs/version-29.0/ECMAScriptModules.md
@@ -3,11 +3,15 @@ id: ecmascript-modules
 title: ECMAScript Modules
 ---
 
-Jest ships with _experimental_ support for ECMAScript Modules (ESM).
+:::caution
 
-> Note that due to its experimental nature there are many bugs and missing features in Jest's implementation, both known and unknown. You should check out the [tracking issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker for the latest status.
+Jest ships with **experimental** support for ECMAScript Modules (ESM).
 
-> Also note that the APIs Jest uses to implement ESM support is still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+The implementation may have bugs and lack features. For the latest status check out the [issue](https://github.com/facebook/jest/issues/9430) and the [label](https://github.com/facebook/jest/labels/ES%20Modules) on the issue tracker.
+
+Also note that the APIs Jest uses to implement ESM support are still [considered experimental by Node](https://nodejs.org/api/vm.html#vm_class_vm_module) (as of version `18.8.0`).
+
+:::caution
 
 With the warnings out of the way, this is how you activate ESM support in your tests.
 


### PR DESCRIPTION
## Summary

Let’s use `caution` admonition in ECMAScript Modules page? Felt like the text could be shortened a bit and then one box is really enough. Or?

The change is tiny, so I went for updating versioned docs as well.

## Test plan

Deploy preview.