### PR TITLE
chore(deps): remove `type-fest`

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import dedent = require('dedent');
 import {ExecaReturnValue, sync as spawnSync} from 'execa';
 import * as fs from 'graceful-fs';
-import type {PackageJson} from 'type-fest';
 import which = require('which');
 import type {Config} from '@jest/types';
 
@@ -172,11 +171,13 @@ export const sortLines = (output: string) =>
     .map(str => str.trim())
     .join('\n');
 
-export interface JestPackageJson extends PackageJson {
-  jest: Config.InitialOptions;
+export interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  jest?: Config.InitialOptions;
 }
 
-const DEFAULT_PACKAGE_JSON: JestPackageJson = {
+const DEFAULT_PACKAGE_JSON: PackageJson = {
   jest: {
     testEnvironment: 'node',
   },
@@ -184,7 +185,7 @@ const DEFAULT_PACKAGE_JSON: JestPackageJson = {
 
 export const createEmptyPackage = (
   directory: string,
-  packageJson: JestPackageJson = DEFAULT_PACKAGE_JSON,
+  packageJson: PackageJson = DEFAULT_PACKAGE_JSON,
 ) => {
   const packageJsonWithDefaults = {
     ...packageJson,

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "type-fest": "^2.11.2",
     "typescript": "^4.8.2",
     "which": "^2.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,7 +2808,6 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    type-fest: ^2.11.2
     typescript: ^4.8.2
     which: ^2.0.1
   languageName: unknown
@@ -20236,7 +20235,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.0.0, type-fest@npm:^2.11.2, type-fest@npm:^2.5.0":
+"type-fest@npm:^2.0.0, type-fest@npm:^2.5.0":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278


### PR DESCRIPTION
## Summary

One type error in e2e utilities drew my attention. The `jest` key of `JestPackageJson` interface should be marked as optional:

https://github.com/facebook/jest/blob/2c31c26d976f4fa7f7e99fa3ad79c64fd78d2627/e2e/Utils.ts#L175-L177

The type error can be see in `dependencyClash.test.ts`:

https://github.com/facebook/jest/blob/2c31c26d976f4fa7f7e99fa3ad79c64fd78d2627/e2e/__tests__/dependencyClash.test.ts#L21

<img width="343" alt="Screenshot 2022-09-09 at 07 48 09" src="https://user-images.githubusercontent.com/72159681/189274373-dd8fc96d-19f3-4791-ac58-db354910688c.png">

Easy to fix. Just one `?` is missing.

---

While we are here, another question: is there really a need to have `type-fest` as dev dependency? If it can be replaced with two lines of code, is a dependency needed for that?

## Test plan

Tests are not yet typechecked. So I looked at each place where `createEmptyPackage` is used and made sure there are no type errors.
