### PR TITLE
feat(@jest/globals): add `jest.Mock` type helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[@jest/environment, jest-runtime]` Allow passing a generic type argument to `jest.createMockFromModule<T>()` method ([#13202](https://github.com/facebook/jest/pull/13202))
+- `[@jest/globals]` Add `jest.Mock` type helper ([#13235](https://github.com/facebook/jest/pull/13235))
 
 ### Fixes
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -515,6 +515,22 @@ test('calculate calls add', () => {
 });
 ```
 
+### `jest.Mock<T>`
+
+Constructs the type of a mock function, e.g. the return type of `jest.fn()`. It can be useful if you have to defined a recursive mock function:
+
+```ts
+import {jest} from '@jest/globals';
+
+const sumRecursively: jest.Mock<(value: number) => number> = jest.fn(value => {
+  if (value === 0) {
+    return 0;
+  } else {
+    return value + fn(value - 1);
+  }
+});
+```
+
 ### `jest.Mocked<Source>`
 
 The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with type definitions of Jest mock function.

--- a/packages/jest-globals/src/index.ts
+++ b/packages/jest-globals/src/index.ts
@@ -11,10 +11,12 @@ import type {Global} from '@jest/types';
 import type {
   ClassLike,
   FunctionLike,
+  Mock as JestMock,
   Mocked as JestMocked,
   MockedClass as JestMockedClass,
   MockedFunction as JestMockedFunction,
   MockedObject as JestMockedObject,
+  UnknownFunction,
 } from 'jest-mock';
 
 export declare const expect: JestExpect;
@@ -36,6 +38,10 @@ declare const jest: Jest;
 
 // eslint-disable-next-line @typescript-eslint/no-namespace
 declare namespace jest {
+  /**
+   * Constructs the type of a mock function, e.g. the return type of `jest.fn()`.
+   */
+  export type Mock<T extends FunctionLike = UnknownFunction> = JestMock<T>;
   /**
    * Wraps a class, function or object type with Jest mock type definitions.
    */

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -227,6 +227,11 @@ expectType<ModuleMocker['fn']>(jest.fn);
 
 expectType<ModuleMocker['spyOn']>(jest.spyOn);
 
+// Mock<T>
+
+expectType<Mock<() => boolean>>({} as jest.Mock<() => boolean>);
+expectType<Mock<(a: string) => string>>({} as jest.Mock<(a: string) => string>);
+
 // Mocked*<T>
 
 class SomeClass {


### PR DESCRIPTION
## Summary

Let’s add `Mock` type helper to `jest` namespace. The example of `jest.Mock` usage in docs is inspired by this test:

https://github.com/facebook/jest/blob/448eed8de9c2226dcc824573a5f859f7c06e6f4c/packages/expect/src/__tests__/spyMatchers.test.ts#L653-L656

## Test plan

The `Mock` type already has extensive test in `jest-mock` package. So I added just a minimal test to make sure it is exposed in the namespace.