### PR TITLE
fix(e2e): `PackageJson` type usage

### DIFF
--- a/e2e/__tests__/toMatchInlineSnapshotWithJSX.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithJSX.test.ts
@@ -8,7 +8,7 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import {
-  JestPackageJson,
+  PackageJson,
   cleanup,
   createEmptyPackage,
   runYarnInstall,
@@ -25,7 +25,7 @@ const babelConfig = {
   ],
 };
 
-const pkg: JestPackageJson = {
+const pkg: PackageJson = {
   dependencies: {
     react: '^17.0.0',
   },


### PR DESCRIPTION
## Summary

Following up.

Ups.. I forgot to push one file with #13231 (name of the exported type was changed).

## Test plan

Double checked manually, but it would be better to have typecheck in CI.