### PR TITLE
fix(tests): clean up `jest.Mock` usage in tests

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
@@ -182,7 +182,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`lastCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`lastCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
@@ -549,7 +549,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`nthCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`nthCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
@@ -1197,7 +1197,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`toBeCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`toBeCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
@@ -1584,7 +1584,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`toHaveBeenCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`toHaveBeenCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
@@ -1775,7 +1775,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`toHaveBeenLastCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`toHaveBeenLastCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
@@ -1999,7 +1999,7 @@ Expected: not <g>"foo"</>, <g>undefined</>
 Number of calls: <r>1</>
 `;
 
-exports[`toHaveBeenNthCalledWith works with trailing undefined arguments when explicitely requested as optional by matcher 1`] = `
+exports[`toHaveBeenNthCalledWith works with trailing undefined arguments when explicitly requested as optional by matcher 1`] = `
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1

--- a/packages/expect/src/__tests__/spyMatchers.test.ts
+++ b/packages/expect/src/__tests__/spyMatchers.test.ts
@@ -12,11 +12,17 @@ import jestExpect from '../';
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 jestExpect.extend({
-  optionalFn(fn) {
+  optionalFn(fn?: unknown) {
     const pass = fn === undefined || typeof fn === 'function';
     return {message: () => 'expect either a function or undefined', pass};
   },
 });
+
+declare module '../types' {
+  interface AsymmetricMatchers {
+    optionalFn(fn?: unknown): void;
+  }
+}
 
 // Given a Jest mock function, return a minimal mock of a Jasmine spy.
 const createSpy = (fn: jest.Mock) => {
@@ -351,7 +357,7 @@ const createSpy = (fn: jest.Mock) => {
       ).toThrowErrorMatchingSnapshot();
     });
 
-    test('works with trailing undefined arguments when explicitely requested as optional by matcher', () => {
+    test('works with trailing undefined arguments when explicitly requested as optional by matcher', () => {
       // issue 12463
       const fn = jest.fn();
       fn('foo', undefined);
@@ -652,7 +658,7 @@ const createSpy = (fn: jest.Mock) => {
 
     test('incomplete recursive calls are handled properly', () => {
       // sums up all integers from 0 -> value, using recursion
-      const fn: jest.Mock = jest.fn(value => {
+      const fn: jest.Mock<number, [value: number]> = jest.fn(value => {
         if (value === 0) {
           // Before returning from the base case of recursion, none of the
           // calls have returned yet.
@@ -821,7 +827,7 @@ const createSpy = (fn: jest.Mock) => {
 
     test('incomplete recursive calls are handled properly', () => {
       // sums up all integers from 0 -> value, using recursion
-      const fn: jest.Mock = jest.fn(value => {
+      const fn: jest.Mock<number, [value: number]> = jest.fn(value => {
         if (value === 0) {
           return 0;
         } else {
@@ -1041,7 +1047,7 @@ const createSpy = (fn: jest.Mock) => {
     if (basicReturnedWith.indexOf(returnedWith) >= 0) {
       describe('returnedWith', () => {
         test('works with more calls than the limit', () => {
-          const fn = jest.fn();
+          const fn = jest.fn<string, []>();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
           fn.mockReturnValueOnce('foo3');
@@ -1065,12 +1071,12 @@ const createSpy = (fn: jest.Mock) => {
 
         test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
-          const fn: jest.Mock = jest.fn(value => {
+          const fn: jest.Mock<number, [value: number]> = jest.fn(value => {
             if (value === 0) {
               // Before returning from the base case of recursion, none of the
               // calls have returned yet.
               // This test ensures that the incomplete calls are not incorrectly
-              // interpretted as have returned undefined
+              // interpreted as have returned undefined
               jestExpect(fn).not[returnedWith](undefined);
               expect(() =>
                 jestExpect(fn)[returnedWith](undefined),
@@ -1091,7 +1097,7 @@ const createSpy = (fn: jest.Mock) => {
     if (nthReturnedWith.indexOf(returnedWith) >= 0) {
       describe('nthReturnedWith', () => {
         test('works with three calls', () => {
-          const fn = jest.fn();
+          const fn = jest.fn<string, []>();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
           fn.mockReturnValueOnce('foo3');
@@ -1111,7 +1117,7 @@ const createSpy = (fn: jest.Mock) => {
         });
 
         test('should replace 1st, 2nd, 3rd with first, second, third', async () => {
-          const fn = jest.fn();
+          const fn = jest.fn<string, []>();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
           fn.mockReturnValueOnce('foo3');
@@ -1153,7 +1159,7 @@ const createSpy = (fn: jest.Mock) => {
         });
 
         test('positive throw matcher error for n that is not integer', async () => {
-          const fn: jest.Mock = jest.fn(() => 'foo');
+          const fn = jest.fn<string, [string]>(() => 'foo');
           fn('foo');
 
           expect(() => {
@@ -1162,7 +1168,7 @@ const createSpy = (fn: jest.Mock) => {
         });
 
         test('negative throw matcher error for n that is not number', async () => {
-          const fn: jest.Mock = jest.fn(() => 'foo');
+          const fn = jest.fn<string, [string]>(() => 'foo');
           fn('foo');
 
           expect(() => {
@@ -1172,7 +1178,7 @@ const createSpy = (fn: jest.Mock) => {
 
         test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
-          const fn: jest.Mock = jest.fn(value => {
+          const fn: jest.Mock<number, [value: number]> = jest.fn(value => {
             if (value === 0) {
               return 0;
             } else {
@@ -1212,7 +1218,7 @@ const createSpy = (fn: jest.Mock) => {
     if (lastReturnedWith.indexOf(returnedWith) >= 0) {
       describe('lastReturnedWith', () => {
         test('works with three calls', () => {
-          const fn = jest.fn();
+          const fn = jest.fn<string, []>();
           fn.mockReturnValueOnce('foo1');
           fn.mockReturnValueOnce('foo2');
           fn.mockReturnValueOnce('foo3');
@@ -1229,7 +1235,7 @@ const createSpy = (fn: jest.Mock) => {
 
         test('incomplete recursive calls are handled properly', () => {
           // sums up all integers from 0 -> value, using recursion
-          const fn: jest.Mock = jest.fn(value => {
+          const fn: jest.Mock<number, [number]> = jest.fn(value => {
             if (value === 0) {
               // Before returning from the base case of recursion, none of the
               // calls have returned yet.

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -16,11 +16,11 @@ import {DependencyResolver} from '../index';
 const maxWorkers = 1;
 let dependencyResolver: DependencyResolver;
 let runtimeContextResolver: Resolver;
-let Runtime: typeof import('jest-runtime');
+let Runtime: typeof import('jest-runtime').default;
 let config: Config.ProjectConfig;
-const cases: Record<string, jest.Mock> = {
-  fancyCondition: jest.fn(path => path.length > 10),
-  testRegex: jest.fn(path => /.test.js$/.test(path)),
+const cases: Record<string, (path: string) => boolean> = {
+  fancyCondition: path => path.length > 10,
+  testRegex: path => /.test.js$/.test(path),
 };
 const filter = (path: string) =>
   Object.keys(cases).every(key => cases[key](path));
@@ -84,7 +84,7 @@ test('resolves dependencies for scoped packages', () => {
 });
 
 test('resolves no inverse dependencies for empty paths set', () => {
-  const paths = new Set();
+  const paths = new Set<string>();
   const resolved = dependencyResolver.resolveInverse(paths, filter);
   expect(resolved.length).toEqual(0);
 });


### PR DESCRIPTION
Following up #13235

## Summary

Cleaning up `jest.Mock` usage in tests. The type was unnecessary or used to manually reset a mock function (`jest.clearAllMocks()` seemed like better idea). Otherwise I used generic type arguments to have it typed it properly. Also fixed other type errors in these tests and a couple of typos caught by [cspell](https://github.com/streetsidesoftware/cspell).

This should help migrating to build-in Jest types and to setup typecheck for test files one day.

## Test plan

Green CI.
