### PR TITLE
fix(jest-fake-timers): Return real `Date.now()` from `jest.now()` when real timers are in use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[@jest/fake-timers]` `jest.now()` returns `Date.now()` if real timers are in use ([13246](https://github.com/facebook/jest/pull/13246))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ### Features
 
-- `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244))
+- `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 
 ### Fixes
-
-- `[@jest/fake-timers]` `jest.now()` returns `Date.now()` if real timers are in use ([13246](https://github.com/facebook/jest/pull/13246))
 
 ### Chore & Maintenance
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -801,7 +801,7 @@ Returns the number of fake timers still left to run.
 
 ### `jest.now()`
 
-Returns the time in ms of the current fake clock. This is equivalent to `Date.now()` if `Date` has been mocked.
+Returns the time in ms of the current fake clock.
 
 ### `jest.setSystemTime(now?: number | Date)`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -801,7 +801,7 @@ Returns the number of fake timers still left to run.
 
 ### `jest.now()`
 
-Returns the time in ms of the current fake clock.
+Returns the time in ms of the current fake clock. This is equivalent to `Date.now()` if `Date` has been mocked.
 
 ### `jest.setSystemTime(now?: number | Date)`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -801,7 +801,7 @@ Returns the number of fake timers still left to run.
 
 ### `jest.now()`
 
-Returns the time in ms of the current fake clock. This is equivalent to `Date.now()` if `Date` has been mocked.
+Returns the time in ms of the current clock. This is equivalent to `Date.now()` if real timers are in use, or if `Date` is mocked. In other cases (such as legacy timers) it may be useful for implementing custom mocks of `Date.now()`, `performance.now()`, etc.
 
 ### `jest.setSystemTime(now?: number | Date)`
 

--- a/packages/jest-fake-timers/src/modernFakeTimers.ts
+++ b/packages/jest-fake-timers/src/modernFakeTimers.ts
@@ -123,7 +123,10 @@ export default class FakeTimers {
   }
 
   now(): number {
-    return this._clock.now;
+    if (this._fakingTime) {
+      return this._clock.now;
+    }
+    return Date.now();
   }
 
   getTimerCount(): number {


### PR DESCRIPTION
## Summary

Quick follow up to https://github.com/facebook/jest/pull/13244, applying the review suggestion that `jest.now()` should return real `Date.now()` if real timers are in use. Currently, it will throw if the clock has not previously been initialised.

## Test plan

Added unit tests for the real timer case - also cleared up some `global` pollution in adjacent tests.