### PR TITLE
Replace deprecated call to `__proto__` with `Object.setPrototypeOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- `[jest-haste-map]` Remove `__proto__` usage ([#13256](https://github.com/facebook/jest/pull/13256))
 - `[jest-mock]` Improve `spyOn` typings to handle optional properties ([#13247](https://github.com/facebook/jest/pull/13247))
 
 ### Chore & Maintenance

--- a/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
+++ b/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
@@ -35,7 +35,7 @@ export default function WatchmanWatcher(dir, opts) {
 }
 
 // eslint-disable-next-line no-proto
-WatchmanWatcher.prototype.__proto__ = EventEmitter.prototype;
+Object.setPrototypeOf(WatchmanWatcher.prototype, EventEmitter.prototype);
 
 /**
  * Run the watchman `watch` command on the root and subscribe to changes.

--- a/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
+++ b/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
@@ -34,7 +34,6 @@ export default function WatchmanWatcher(dir, opts) {
   this.init();
 }
 
-// eslint-disable-next-line no-proto
 Object.setPrototypeOf(WatchmanWatcher.prototype, EventEmitter.prototype);
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The use of __proto__ is deprecated (see #13255). Note that it is not enough to launch jest with `node --disable-proto=throw`, at least @sinonjs/commons has to be patched _(see [Debian patch](https://salsa.debian.org/js-team/node-sinon/-/blob/master/debian/patches/dont-try-to-access-to-__proto__.patch))_
