### PR TITLE
feat(expect, @jest/expect): support type inference for function parame…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 - `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
-- `feat([@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
+- `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 - `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
+- `[feat(expect, ject-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13267](https://github.com/facebook/jest/issues/13267))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### Features
 
+- `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 - `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
-- `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### Features
 
-- `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
-- `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
+- `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
+- `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
-- `[feat(expect, jest-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
+- `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Features
 
-- `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
-- `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
+- `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
+- `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
+- `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Features
 
-- `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
-- `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
+- `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
+- `feat([@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 - `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
-- `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
-- `[feat(expect, ject-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13267](https://github.com/facebook/jest/issues/13267))
+- `[feat(expect, ject-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
-- `[feat(expect, ject-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
+- `[feat(expect, jest-expect)]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 
 ### Fixes
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -118,13 +118,6 @@ export interface AsymmetricMatchers {
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }
 
-// if T is a function, return its parameters array type, otherwise return an unknown array type
-type ConditionalFunctionParameters<T> = T extends (
-  ...args: Array<unknown>
-) => unknown
-  ? Parameters<T>
-  : Array<unknown>;
-
 type PromiseMatchers<T = unknown> = {
   /**
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
@@ -138,11 +131,15 @@ type PromiseMatchers<T = unknown> = {
   resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
+type EnsureFunctionLike<T> = T extends (...args: Array<unknown>) => unknown
+  ? T
+  : never;
+
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensures the last call to a mock function was provided specific args.
    */
-  lastCalledWith(...expected: ConditionalFunctionParameters<T>): R;
+  lastCalledWith(...expected: Parameters<EnsureFunctionLike<T>>): R;
   /**
    * Ensure that the last call to a mock function has returned a specified value.
    */
@@ -150,7 +147,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
    */
-  nthCalledWith(nth: number, ...expected: ConditionalFunctionParameters<T>): R;
+  nthCalledWith(nth: number, ...expected: Parameters<EnsureFunctionLike<T>>): R;
   /**
    * Ensure that the nth call to a mock function has returned a specified value.
    */
@@ -171,7 +168,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that a mock function is called with specific arguments.
    */
-  toBeCalledWith(...expected: ConditionalFunctionParameters<T>): R;
+  toBeCalledWith(...expected: Parameters<EnsureFunctionLike<T>>): R;
   /**
    * Using exact equality with floating point numbers is a bad idea.
    * Rounding means that intuitive things fail.
@@ -254,19 +251,19 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that a mock function is called with specific arguments.
    */
-  toHaveBeenCalledWith(...expected: ConditionalFunctionParameters<T>): R;
+  toHaveBeenCalledWith(...expected: Parameters<EnsureFunctionLike<T>>): R;
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
    */
   toHaveBeenNthCalledWith(
     nth: number,
-    ...expected: ConditionalFunctionParameters<T>
+    ...expected: Parameters<EnsureFunctionLike<T>>
   ): R;
   /**
    * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
    * to test what arguments it was last called with.
    */
-  toHaveBeenLastCalledWith(...expected: ConditionalFunctionParameters<T>): R;
+  toHaveBeenLastCalledWith(...expected: Parameters<EnsureFunctionLike<T>>): R;
   /**
    * Use to test the specific value that a mock function last returned.
    * If the last call to the mock function threw an error, then this matcher will fail

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -131,9 +131,7 @@ type PromiseMatchers<T = unknown> = {
   resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-type EnsureFunctionLike<T> = T extends (...args: Array<unknown>) => unknown
-  ? T
-  : never;
+type EnsureFunctionLike<T> = T extends (...args: any) => any ? T : never;
 
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -120,8 +120,8 @@ export interface AsymmetricMatchers {
 
 // if T is a function, return its parameters array type, otherwise return an unknown array type
 type ConditionalFunctionParameters<T> = T extends (
-    ...args: Array<unknown>
-  ) => unknown
+  ...args: Array<unknown>
+) => unknown
   ? Parameters<T>
   : Array<unknown>;
 
@@ -258,7 +258,10 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
    */
-  toHaveBeenNthCalledWith(nth: number, ...expected: ConditionalFunctionParameters<T>): R;
+  toHaveBeenNthCalledWith(
+    nth: number,
+    ...expected: ConditionalFunctionParameters<T>
+  ): R;
   /**
    * If you have a mock function, you can use `.toHaveBeenLastCalledWith`
    * to test what arguments it was last called with.

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -29,7 +29,7 @@ type Inverse<Matchers> = {
   not: Matchers;
 };
 
-type JestMatchers<R extends void | Promise<void>, T> = Matchers<R> &
+type JestMatchers<R extends void | Promise<void>, T> = Matchers<R, T> &
   SnapshotMatchers<R, T>;
 
 type PromiseMatchers<T = unknown> = {

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -241,7 +241,7 @@ expectType<void>(
 );
 expectError(
   expect(
-    jest.fn<(a: number, b: string, c?: boolean) => void>(),
+    jest.fn<(a: string, b: number, c?: boolean) => void>(),
   ).toHaveBeenCalledWith(123, 'value'),
 );
 expectError(

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -219,10 +219,26 @@ expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 
-// type inference for "CalledWith" matchers parameters
-const jestFnWithParams = jest.fn((a: string, b: number) => {});
-expectType<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
-expectError(expect(jestFnWithParams).toHaveBeenCalledWith(123, 'value'));
+expectType<void>(
+  expect(
+    jest.fn<(a: string, b: number, c?: boolean) => void>(),
+  ).toHaveBeenCalledWith('value', 123),
+);
+expectType<void>(
+  expect(
+    jest.fn<(a: string, b: number, c?: boolean) => void>(),
+  ).toHaveBeenCalledWith('value', 123, true),
+);
+expectError(
+  expect(
+    jest.fn<(a: string, b: number, c?: boolean) => void>(),
+  ).toHaveBeenCalledWith(123, 'value'),
+);
+expectError(
+  expect(
+    jest.fn<(a: string, b: number, c?: boolean) => void>(),
+  ).toHaveBeenCalledWith('value', 123, 'nope'),
+);
 
 expectType<void>(expect(jest.fn()).lastCalledWith());
 expectType<void>(expect(jest.fn()).lastCalledWith('value'));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -219,6 +219,16 @@ expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 
+/**
+ * type inference for "CalledWith" matchers parameters
+ */
+expectError(expect(jest.fn<(a: string) => void>()).toHaveBeenCalledWith(123));
+expectError(
+  expect(jest.fn<(a: string) => void>()).toHaveBeenNthCalledWith(123),
+);
+expectError(
+  expect(jest.fn<(a: string) => void>()).toHaveBeenLastCalledWith(123),
+);
 expectType<void>(
   expect(
     jest.fn<(a: string, b: number, c?: boolean) => void>(),
@@ -231,13 +241,13 @@ expectType<void>(
 );
 expectError(
   expect(
-    jest.fn<(a: string, b: number, c?: boolean) => void>(),
+    jest.fn<(a: number, b: string, c?: boolean) => void>(),
   ).toHaveBeenCalledWith(123, 'value'),
 );
 expectError(
   expect(
     jest.fn<(a: string, b: number, c?: boolean) => void>(),
-  ).toHaveBeenCalledWith('value', 123, 'nope'),
+  ).toHaveBeenCalledWith('value', 123, 'not a boolean'),
 );
 
 expectType<void>(expect(jest.fn()).lastCalledWith());

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -7,10 +7,8 @@
 
 import {expectError, expectType} from 'tsd-lite';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
-// import {expect, jest} from '@jest/globals';
-import {jest} from '@jest/globals';
+import {expect, jest} from '@jest/globals';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
-import {expect} from '../../expect/build/index';
 
 // asymmetric matchers
 
@@ -225,7 +223,6 @@ expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 const jestFnWithParams = jest.fn((a: string, b: number) => {});
 expectType<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
 expectError<void>(expect(jestFnWithParams).toHaveBeenCalledWith(123, 'value'));
-expectError<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
 
 expectType<void>(expect(jest.fn()).lastCalledWith());
 expectType<void>(expect(jest.fn()).lastCalledWith('value'));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -222,7 +222,7 @@ expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 // type inference for "CalledWith" matchers parameters
 const jestFnWithParams = jest.fn((a: string, b: number) => {});
 expectType<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
-expectError<void>(expect(jestFnWithParams).toHaveBeenCalledWith(123, 'value'));
+expectError(expect(jestFnWithParams).toHaveBeenCalledWith(123, 'value'));
 
 expectType<void>(expect(jest.fn()).lastCalledWith());
 expectType<void>(expect(jest.fn()).lastCalledWith('value'));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -217,7 +217,6 @@ expectType<void>(expect(jest.fn()).toBeCalledWith('value', 123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith());
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
-expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
 
 /**
  * type inference for "CalledWith" matchers parameters

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -224,7 +224,7 @@ expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
  */
 expectError(expect(jest.fn<(a: string) => void>()).toHaveBeenCalledWith(123));
 expectError(
-  expect(jest.fn<(a: string) => void>()).toHaveBeenNthCalledWith(123),
+  expect(jest.fn<(a: string) => void>()).toHaveBeenNthCalledWith(1, 123),
 );
 expectError(
   expect(jest.fn<(a: string) => void>()).toHaveBeenLastCalledWith(123),

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -7,8 +7,10 @@
 
 import {expectError, expectType} from 'tsd-lite';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
-import {expect, jest} from '@jest/globals';
+// import {expect, jest} from '@jest/globals';
+import {jest} from '@jest/globals';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
+import {expect} from '../../expect/build/index';
 
 // asymmetric matchers
 
@@ -217,6 +219,13 @@ expectType<void>(expect(jest.fn()).toBeCalledWith('value', 123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith());
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
+expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));
+
+// type inference for "CalledWith" matchers parameters
+const jestFnWithParams = jest.fn((a: string, b: number) => {});
+expectType<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
+expectError<void>(expect(jestFnWithParams).toHaveBeenCalledWith(123, 'value'));
+expectError<void>(expect(jestFnWithParams).toHaveBeenCalledWith('value', 123));
 
 expectType<void>(expect(jest.fn()).lastCalledWith());
 expectType<void>(expect(jest.fn()).lastCalledWith('value'));


### PR DESCRIPTION
…ters in `CalledWith` assertions

## Summary
Closes https://github.com/facebook/jest/issues/13267
Let me know where I missed something, I'm a first-time contributor 😊 

## Test plan
To test it out, either use `expect` or `jestExpect` with `toBeCalledWith`, you should get automatic type inference for the function arguments assertion.
Any ideas for a way to add an automated test?

![Screen Shot 2022-09-15 at 17 55 51](https://user-images.githubusercontent.com/39004075/190437083-c249aaba-afc5-4520-94a9-90813ac6d9f0.png)


