### PR TITLE
Fix typo `error?.stack` -> `error.stack` in cli index.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-haste-map]` Remove `__proto__` usage ([#13256](https://github.com/facebook/jest/pull/13256))
 - `[jest-mock]` Improve `spyOn` typings to handle optional properties ([#13247](https://github.com/facebook/jest/pull/13247))
 - `[jest-snapshot]` Throw useful error when an array is passed as property matchers ([#13263](https://github.com/facebook/jest/pull/13263))
+- `[jest-cli]` Fix typo `error?.stack` -> `error.stack` ([#13269](https://github.com/facebook/jest/pull/13269))
 
 ### Chore & Maintenance
 

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -37,7 +37,7 @@ export async function run(
   } catch (error: any) {
     clearLine(process.stderr);
     clearLine(process.stdout);
-    if (error?.stack) {
+    if (error.stack) {
       console.error(chalk.red(error.stack));
     } else {
       console.error(chalk.red(error));


### PR DESCRIPTION
### Summary

This resolves issue when running tests in CI build:
```
../node_modules/jest-cli/build/cli/index.js:161
    if (error?.stack) {
              ^

SyntaxError: Unexpected token '.'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
