### PR TITLE
chore: increase timeout in `complexItemsInErrors` end-to-end test

### DIFF
--- a/e2e/__tests__/complexItemsInErrors.ts
+++ b/e2e/__tests__/complexItemsInErrors.ts
@@ -50,7 +50,7 @@ test('handles functions that close over outside variables', async () => {
     tempDir,
     ['--no-watchman', '--watch-all'],
     // timeout in case the `waitUntil` below doesn't fire
-    {stripAnsi: true, timeout: 5000},
+    {stripAnsi: true, timeout: 10000},
   );
 
   await waitUntil(({stderr}) => stderr.includes('Ran all test suites.'));


### PR DESCRIPTION
## Summary

The `complexItemsInErrors` end-to-end test is sometimes failing on Windows in CI. Looking at the error message it seems that the process is being killed by `execa` because of timeout. Would it make sense to increase to try increasing the timeout? Here is the [error message](https://github.com/facebook/jest/actions/runs/3072004988/jobs/4963178591#step:7:7):

<img width="554" alt="Screenshot 2022-09-17 at 07 20 18" src="https://user-images.githubusercontent.com/72159681/190840253-058aae83-030a-48c3-810c-f1eea8a09f9e.png">


## Test plan

Green CI.