### PR TITLE
chore: fix day count numbers in stale bot's message

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -13,8 +13,8 @@ jobs:
           start-date: '2022-01-01T00:00:00Z'
           stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
           stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. Please open a new issue if the issue is still relevant, linking to this one.'
-          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity. Please open a new PR if the issue is still relevant, linking to this one.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity. Please open a new issue if the issue is still relevant, linking to this one.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity. Please open a new PR if the issue is still relevant, linking to this one.'
           days-before-issue-stale: 30
           days-before-pr-stale: 90
           days-before-issue-close: 30
@@ -31,8 +31,8 @@ jobs:
         with:
           stale-issue-message: 'This issue is stale because it has been open for 1 year with no activity. Remove stale label or comment or this will be closed in 30 days.'
           stale-pr-message: 'This PR is stale because it has been open 1 year with no activity. Remove stale label or comment or this will be closed in 30 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 7 days with no activity. Please open a new issue if the issue is still relevant, linking to this one.'
-          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity. Please open a new PR if the issue is still relevant, linking to this one.'
+          close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity. Please open a new issue if the issue is still relevant, linking to this one.'
+          close-pr-message: 'This PR was closed because it has been stalled for 30 days with no activity. Please open a new PR if the issue is still relevant, linking to this one.'
           days-before-issue-stale: 365
           days-before-pr-stale: 365
           days-before-issue-close: 30


### PR DESCRIPTION
## Summary

The day count numbers were tweaked in https://github.com/facebook/jest/commit/3a411d19405a207216e5af5079e1e56898a7ab0e making issues and PRs to be closed after 30 days of inactivity.

Currently the messages posted by the bot say: "because it has been stalled for 7 days" or "for 14 days". This has to be adjusted as well. Or?

## Test plan

👀
