### PR TITLE
chore: remove `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-
-# Pings orta when PRs are to this module
-packages/jest-editor-support/src/*  @orta


### PR DESCRIPTION
## Summary

Seems like it does nothing. It was relevant only for `jest-editor-support` package, but this one was moved to Jest Community (#7232). Save to remove the `CODEOWNERS` file as well?

## Test plan

👀