### PR TITLE
feat(expect, @jest/expect): infer type of `*ReturnedWith` matchers argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ### Features
 
 - `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
+- `[expect, @jest/expect]` Infer type of `*ReturnedWith` matchers argument ([#13278](https://github.com/facebook/jest/pull/13278))
 - `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
-- `[expect, @jest/expect]` Infer type of `*ReturnedWith` matchers argument ([#13278](https://github.com/facebook/jest/pull/13278))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
-- `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 - `[expect, @jest/expect]` Infer type of `*ReturnedWith` matchers argument ([#13278](https://github.com/facebook/jest/pull/13278))
+- `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ### Features
 
-- `[feat(@jest/environment, jest-runtime)]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
-- `[feat(@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
+- `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
+- `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
+- `[expect, @jest/expect]` Infer type of `*ReturnedWith` matchers argument ([#13278](https://github.com/facebook/jest/pull/13278))
 
 ### Fixes
 

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -16,7 +16,8 @@ import {
 } from 'expect';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 
-type M = Matchers<void>;
+type M = Matchers<void, unknown>;
+type N = Matchers<void>;
 
 expectError(() => {
   type E = Matchers;

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -94,9 +94,9 @@ export interface BaseExpect {
 }
 
 export type Expect = {
-  <T = unknown>(actual: T): Matchers<void> &
-    Inverse<Matchers<void>> &
-    PromiseMatchers;
+  <T = unknown>(actual: T): Matchers<void, T> &
+    Inverse<Matchers<void, T>> &
+    PromiseMatchers<T>;
 } & BaseExpect &
   AsymmetricMatchers &
   Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
@@ -118,20 +118,22 @@ export interface AsymmetricMatchers {
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }
 
-type PromiseMatchers = {
+type PromiseMatchers<T = unknown> = {
   /**
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-export interface Matchers<R extends void | Promise<void>> {
+type EnsureFunctionLike<T> = T extends (args: any) => any ? T : never;
+
+export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensures the last call to a mock function was provided specific args.
    */
@@ -139,7 +141,7 @@ export interface Matchers<R extends void | Promise<void>> {
   /**
    * Ensure that the last call to a mock function has returned a specified value.
    */
-  lastReturnedWith(expected: unknown): R;
+  lastReturnedWith<U extends EnsureFunctionLike<T>>(expected: ReturnType<U>): R;
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
    */
@@ -147,7 +149,10 @@ export interface Matchers<R extends void | Promise<void>> {
   /**
    * Ensure that the nth call to a mock function has returned a specified value.
    */
-  nthReturnedWith(nth: number, expected: unknown): R;
+  nthReturnedWith<U extends EnsureFunctionLike<T>>(
+    nth: number,
+    expected: ReturnType<U>,
+  ): R;
   /**
    * Checks that a value is what you expect. It calls `Object.is` to compare values.
    * Don't use `toBe` with floating-point numbers.
@@ -262,7 +267,9 @@ export interface Matchers<R extends void | Promise<void>> {
    * If the last call to the mock function threw an error, then this matcher will fail
    * no matter what value you provided as the expected return value.
    */
-  toHaveLastReturnedWith(expected: unknown): R;
+  toHaveLastReturnedWith<U extends EnsureFunctionLike<T>>(
+    expected: ReturnType<U>,
+  ): R;
   /**
    * Used to check that an object has a `.length` property
    * and it is set to a certain numeric value.
@@ -273,7 +280,10 @@ export interface Matchers<R extends void | Promise<void>> {
    * If the nth call to the mock function threw an error, then this matcher will fail
    * no matter what value you provided as the expected return value.
    */
-  toHaveNthReturnedWith(nth: number, expected: unknown): R;
+  toHaveNthReturnedWith<U extends EnsureFunctionLike<T>>(
+    nth: number,
+    expected: ReturnType<U>,
+  ): R;
   /**
    * Use to check if property at provided reference keyPath exists for an object.
    * For checking deeply nested properties in an object you may use dot notation or an array containing
@@ -303,7 +313,9 @@ export interface Matchers<R extends void | Promise<void>> {
   /**
    * Use to ensure that a mock function returned a specific value.
    */
-  toHaveReturnedWith(expected: unknown): R;
+  toHaveReturnedWith<U extends EnsureFunctionLike<T>>(
+    expected: ReturnType<U>,
+  ): R;
   /**
    * Check that a string matches a regular expression.
    */
@@ -325,7 +337,7 @@ export interface Matchers<R extends void | Promise<void>> {
   /**
    * Ensure that a mock function has returned a specified value at least once.
    */
-  toReturnWith(expected: unknown): R;
+  toReturnWith<U extends EnsureFunctionLike<T>>(expected: ReturnType<U>): R;
   /**
    * Use to test that objects have the same types as well as structure.
    */

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -131,9 +131,7 @@ type PromiseMatchers<T = unknown> = {
   resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-type EnsureFunctionLike<T> = T extends (...args: Array<unknown>) => unknown
-  ? T
-  : never;
+type EnsureFunctionLike<T> = T extends (...args: any) => any ? T : never;
 
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -131,7 +131,9 @@ type PromiseMatchers<T = unknown> = {
   resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-type EnsureFunctionLike<T> = T extends (args: any) => any ? T : never;
+type EnsureFunctionLike<T> = T extends (...args: Array<unknown>) => unknown
+  ? T
+  : never;
 
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -143,7 +143,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that the last call to a mock function has returned a specified value.
    */
-  lastReturnedWith<U extends EnsureFunctionLike<T>>(expected: ReturnType<U>): R;
+  lastReturnedWith(expected: ReturnType<EnsureFunctionLike<T>>): R;
   /**
    * Ensure that a mock function is called with specific arguments on an Nth call.
    */
@@ -151,10 +151,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that the nth call to a mock function has returned a specified value.
    */
-  nthReturnedWith<U extends EnsureFunctionLike<T>>(
-    nth: number,
-    expected: ReturnType<U>,
-  ): R;
+  nthReturnedWith(nth: number, expected: ReturnType<EnsureFunctionLike<T>>): R;
   /**
    * Checks that a value is what you expect. It calls `Object.is` to compare values.
    * Don't use `toBe` with floating-point numbers.
@@ -269,9 +266,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
    * If the last call to the mock function threw an error, then this matcher will fail
    * no matter what value you provided as the expected return value.
    */
-  toHaveLastReturnedWith<U extends EnsureFunctionLike<T>>(
-    expected: ReturnType<U>,
-  ): R;
+  toHaveLastReturnedWith(expected: ReturnType<EnsureFunctionLike<T>>): R;
   /**
    * Used to check that an object has a `.length` property
    * and it is set to a certain numeric value.
@@ -282,9 +277,9 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
    * If the nth call to the mock function threw an error, then this matcher will fail
    * no matter what value you provided as the expected return value.
    */
-  toHaveNthReturnedWith<U extends EnsureFunctionLike<T>>(
+  toHaveNthReturnedWith(
     nth: number,
-    expected: ReturnType<U>,
+    expected: ReturnType<EnsureFunctionLike<T>>,
   ): R;
   /**
    * Use to check if property at provided reference keyPath exists for an object.
@@ -315,9 +310,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Use to ensure that a mock function returned a specific value.
    */
-  toHaveReturnedWith<U extends EnsureFunctionLike<T>>(
-    expected: ReturnType<U>,
-  ): R;
+  toHaveReturnedWith(expected: ReturnType<EnsureFunctionLike<T>>): R;
   /**
    * Check that a string matches a regular expression.
    */
@@ -339,7 +332,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensure that a mock function has returned a specified value at least once.
    */
-  toReturnWith<U extends EnsureFunctionLike<T>>(expected: ReturnType<U>): R;
+  toReturnWith(expected: ReturnType<EnsureFunctionLike<T>>): R;
   /**
    * Use to test that objects have the same types as well as structure.
    */

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -29,7 +29,7 @@ type Inverse<Matchers> = {
   not: Matchers;
 };
 
-type JestMatchers<R extends void | Promise<void>, T> = Matchers<R> &
+type JestMatchers<R extends void | Promise<void>, T> = Matchers<R, T> &
   SnapshotMatchers<R, T>;
 
 type PromiseMatchers<T = unknown> = {

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -247,21 +247,44 @@ expectError(expect(jest.fn()).toHaveReturnedTimes(true));
 expectError(expect(jest.fn()).toHaveReturnedTimes());
 
 expectType<void>(expect(jest.fn()).toReturnWith('value'));
+expectType<void>(expect(jest.fn<() => string>()).toReturnWith('value'));
+expectError(expect(jest.fn<() => number>()).toReturnWith('value'));
+expectError(expect(123).toReturnWith('value'));
 expectError(expect(jest.fn()).toReturnWith());
+
 expectType<void>(expect(jest.fn()).toHaveReturnedWith(123));
+expectType<void>(expect(jest.fn<() => number>()).toHaveReturnedWith(123));
+expectError(expect(jest.fn<() => string>()).toHaveReturnedWith(123));
+expectError(expect(123).toHaveReturnedWith(123));
 expectError(expect(jest.fn()).toHaveReturnedWith());
 
 expectType<void>(expect(jest.fn()).lastReturnedWith('value'));
+expectType<void>(expect(jest.fn<() => string>()).lastReturnedWith('value'));
+expectError(expect(jest.fn<() => number>()).lastReturnedWith('value'));
+expectError(expect(123).lastReturnedWith('value'));
 expectError(expect(jest.fn()).lastReturnedWith());
+
 expectType<void>(expect(jest.fn()).toHaveLastReturnedWith(123));
+expectType<void>(expect(jest.fn<() => number>()).toHaveLastReturnedWith(123));
+expectError(expect(jest.fn<() => string>()).toHaveLastReturnedWith(123));
+expectError(expect(123).toHaveLastReturnedWith(123));
 expectError(expect(jest.fn()).toHaveLastReturnedWith());
 
 expectType<void>(expect(jest.fn()).nthReturnedWith(1, 'value'));
+expectType<void>(expect(jest.fn<() => string>()).nthReturnedWith(2, 'value'));
+expectError(expect(jest.fn<() => number>()).nthReturnedWith(3, 'value'));
+expectError(expect(123).nthReturnedWith(4, 'value'));
+expectError(expect(123).nthReturnedWith(5));
 expectError(expect(jest.fn()).nthReturnedWith());
-expectError(expect(jest.fn()).nthReturnedWith(2));
+
 expectType<void>(expect(jest.fn()).toHaveNthReturnedWith(1, 'value'));
+expectType<void>(
+  expect(jest.fn<() => string>()).toHaveNthReturnedWith(2, 'value'),
+);
+expectError(expect(jest.fn<() => number>()).toHaveNthReturnedWith(3, 'value'));
+expectError(expect(123).toHaveNthReturnedWith(4, 'value'));
+expectError(expect(123).toHaveNthReturnedWith(5));
 expectError(expect(jest.fn()).toHaveNthReturnedWith());
-expectError(expect(jest.fn()).toHaveNthReturnedWith(2));
 
 // snapshot matchers
 


### PR DESCRIPTION
## Summary

Similar to #13268, but `*ReturnedWith` matchers. I have added logic to infer types of `*ReturnedWith` matchers argument from the type of `received` expression.

## Test plan

Type tests added. 