### PR TITLE
feat(@jest/mock): Add withImplementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### Features
 
-- `[@jest/mock]` Add `withImplementation` method for temporarily overriding a mock.
 - `[expect, @jest/expect]` support type inference for function parameters in `CalledWith` assertions ([#13268](https://github.com/facebook/jest/pull/13268))
 - `[expect, @jest/expect]` Infer type of `*ReturnedWith` matchers argument ([#13278](https://github.com/facebook/jest/pull/13278))
 - `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
+- `[@jest/mock]` Add `withImplementation` method for temporarily overriding a mock.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[@jest/mock]` Add `withImplementation` method for temporarily overriding a mock.
 - `[@jest/environment, jest-runtime]` Allow `jest.requireActual` and `jest.requireMock` to take a type argument ([#13253](https://github.com/facebook/jest/pull/13253))
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -497,7 +497,7 @@ test('test', () => {
 });
 ```
 
-`mockFn.withImplementation` can be used regardless of whether or not the callback is asynchronous (returns a promise like object). If the callback is asynchronous a promise will be returned. Awaiting the promise will await the callback and reset the implementation.
+`mockFn.withImplementation` can be used regardless of whether or not the callback is asynchronous (returns a `thenable`). If the callback is asynchronous a promise will be returned. Awaiting the promise will await the callback and reset the implementation.
 
 ```js
 test('async test', async () => {

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -478,6 +478,43 @@ test('async test', async () => {
 });
 ```
 
+### `mockFn.withImplementation(fn, callback)`
+
+Accepts a function which should be temporarily used as the implementation of the mock while the callback is being executed.
+
+```js tab
+test('test', () => {
+  const mock = jest.fn(() => 'outside callback');
+
+  mock.withImplementation(
+    () => 'inside callback',
+    () => {
+      mock(); // 'inside callback'
+    },
+  );
+
+  mock(); // 'outside callback'
+});
+```
+
+`mockFn.withImplementation` can be used regardless of whether or not the callback is asynchronous (returns a promise like object). If the callback is asynchronous a promise will be returned. Awaiting the promise will await the callback and reset the implementation.
+
+```js
+test('async test', async () => {
+  const mock = jest.fn(() => 'outside callback');
+
+  // We await this call since the callback is async
+  await mock.withImplementation(
+    () => 'inside callback',
+    async () => {
+      mock(); // 'inside callback'
+    },
+  );
+
+  mock(); // 'outside callback'
+});
+```
+
 ## TypeScript Usage
 
 :::tip

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -482,7 +482,7 @@ test('async test', async () => {
 
 Accepts a function which should be temporarily used as the implementation of the mock while the callback is being executed.
 
-```js tab
+```js
 test('test', () => {
   const mock = jest.fn(() => 'outside callback');
 

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -98,3 +98,9 @@ In case both `.mockImplementationOnce()` / `.mockImplementation()` and `.mockRet
 
 - if the last call is `.mockReturnValueOnce()` or `.mockReturnValue()`, use the specific return value or default return value. If specific return values are used up or no default return value is set, fall back to try `.mockImplementation()`;
 - if the last call is `.mockImplementationOnce()` or `.mockImplementation()`, run the specific implementation and return the result or run default implementation and return the result.
+
+##### `.withImplementation(function, callback)`
+
+Temporarily overrides the default mock implementation within the callback, then restores it's previous implementation.
+
+If the callback is async or returns a promise like object, `withImplementation` will return a promise. Awaiting the promise will await the callback and reset the implementation.

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -103,4 +103,4 @@ In case both `.mockImplementationOnce()` / `.mockImplementation()` and `.mockRet
 
 Temporarily overrides the default mock implementation within the callback, then restores it's previous implementation.
 
-If the callback is async or returns a promise like object, `withImplementation` will return a promise. Awaiting the promise will await the callback and reset the implementation.
+If the callback is async or returns a `thenable`, `withImplementation` will return a promise. Awaiting the promise will await the callback and reset the implementation.

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -255,7 +255,7 @@ expectType<Promise<void>>(
   mockFn.withImplementation(mockFnImpl, async () => {}),
 );
 
-expectError(mockFn.withImplementation(mockFnImpl);
+expectError(mockFn.withImplementation(mockFnImpl));
 
 // jest.spyOn()
 

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -250,7 +250,12 @@ expectType<Mock<() => Promise<string>>>(
 );
 expectError(fn(() => Promise.resolve('')).mockRejectedValueOnce());
 
-// jest.spyOn()
+expectType<void>(mockFn.withImplementation(mockFnImpl, () => {}));
+expectType<Promise<void>>(
+  mockFn.withImplementation(mockFnImpl, async () => {}),
+);
+
+expectError(mockFn.withImplementation(mockFnImpl, () => {}).then());
 
 const spiedArray = ['a', 'b'];
 

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -255,7 +255,9 @@ expectType<Promise<void>>(
   mockFn.withImplementation(mockFnImpl, async () => {}),
 );
 
-expectError(mockFn.withImplementation(mockFnImpl, () => {}).then());
+expectError(mockFn.withImplementation(mockFnImpl);
+
+// jest.spyOn()
 
 const spiedArray = ['a', 'b'];
 

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@jest/types": "workspace:^",
-    "@types/node": "*"
+    "@types/node": "*",
+    "jest-util": "workspace:^"
   },
   "devDependencies": {
     "@tsd/typescript": "~4.8.2",

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1073,6 +1073,59 @@ describe('moduleMocker', () => {
     });
   });
 
+  describe('withImplementation', () => {
+    it('sets an implementation which is available within the callback', async () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      const Module = jest.fn(() => ({someFn: mock1}));
+      const testFn = function () {
+        const m = new Module();
+        m.someFn();
+      };
+
+      Module.withImplementation(
+        () => ({someFn: mock2}),
+        () => {
+          testFn();
+          expect(mock2).toHaveBeenCalled();
+          expect(mock1).not.toHaveBeenCalled();
+        },
+      );
+
+      testFn();
+      expect(mock1).toHaveBeenCalled();
+    });
+
+    it('returns a promise if the provided callback is asynchronous', async () => {
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+
+      const Module = jest.fn(() => ({someFn: mock1}));
+      const testFn = function () {
+        const m = new Module();
+        m.someFn();
+      };
+
+      const promise = Module.withImplementation(
+        () => ({someFn: mock2}),
+        async () => {
+          testFn();
+          expect(mock2).toHaveBeenCalled();
+          expect(mock1).not.toHaveBeenCalled();
+        },
+      );
+
+      // Is there a better way to detect a promise?
+      expect(typeof promise.then).toBe('function');
+
+      await promise;
+
+      testFn();
+      expect(mock1).toHaveBeenCalled();
+    });
+  });
+
   test('mockReturnValue does not override mockImplementationOnce', () => {
     const mockFn = jest
       .fn()

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@
 
 /* eslint-disable local/ban-types-eventually, local/prefer-rest-params-eventually */
 
+import * as util from 'util';
 import vm, {Context} from 'vm';
 import {ModuleMocker, fn, mocked, spyOn} from '../';
 
@@ -1116,8 +1117,7 @@ describe('moduleMocker', () => {
         },
       );
 
-      // Is there a better way to detect a promise?
-      expect(typeof promise.then).toBe('function');
+      expect(util.types.isPromise(promise)).toBe(true);
 
       await promise;
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1075,7 +1075,7 @@ describe('moduleMocker', () => {
   });
 
   describe('withImplementation', () => {
-    it('sets an implementation which is available within the callback', async () => {
+    it('sets an implementation which is available within the callback', () => {
       const mock1 = jest.fn();
       const mock2 = jest.fn();
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1096,6 +1096,8 @@ describe('moduleMocker', () => {
 
       testFn();
       expect(mock1).toHaveBeenCalled();
+
+      expect.assertions(3);
     });
 
     it('returns a promise if the provided callback is asynchronous', async () => {
@@ -1123,6 +1125,8 @@ describe('moduleMocker', () => {
 
       testFn();
       expect(mock1).toHaveBeenCalled();
+
+      expect.assertions(4);
     });
   });
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -124,6 +124,12 @@ type RejectType<T extends FunctionLike> = ReturnType<T> extends PromiseLike<any>
   ? unknown
   : never;
 
+type WithImplementationSyncCallbackReturn = void | undefined;
+type WithImplementationAsyncCallbackReturn = Promise<unknown>;
+type WithImplementationCallbackReturn =
+  | WithImplementationSyncCallbackReturn
+  | WithImplementationAsyncCallbackReturn;
+
 export interface MockInstance<T extends FunctionLike = UnknownFunction> {
   _isMockFunction: true;
   _protoImpl: Function;
@@ -135,6 +141,12 @@ export interface MockInstance<T extends FunctionLike = UnknownFunction> {
   mockRestore(): void;
   mockImplementation(fn: T): this;
   mockImplementationOnce(fn: T): this;
+  withImplementation<R extends WithImplementationCallbackReturn>(
+    fn: T,
+    callback: () => R,
+  ): R extends WithImplementationAsyncCallbackReturn
+    ? Promise<void>
+    : undefined;
   mockName(name: string): this;
   mockReturnThis(): this;
   mockReturnValue(value: ReturnType<T>): this;
@@ -766,6 +778,34 @@ export class ModuleMocker {
         const mockConfig = this._ensureMockConfig(f);
         mockConfig.specificMockImpls.push(fn);
         return f;
+      };
+
+      f.withImplementation = <R extends WithImplementationCallbackReturn>(
+        fn: UnknownFunction,
+        callback: () => R,
+        // @ts-expect-error: Type guards are not advanced enough for this use case
+      ): R extends WithImplementationAsyncCallbackReturn
+        ? Promise<void>
+        : undefined => {
+        // Remember previous mock implementation, then set new one
+        const mockConfig = this._ensureMockConfig(f);
+        const previousImplementation = mockConfig.mockImpl;
+        mockConfig.mockImpl = fn;
+
+        const returnedValue = callback();
+
+        if (
+          typeof returnedValue === 'object' &&
+          returnedValue !== null &&
+          typeof returnedValue.then === 'function'
+        ) {
+          // @ts-expect-error: Type guards are not advanced enough for this use case
+          return returnedValue.then(() => {
+            mockConfig.mockImpl = previousImplementation;
+          });
+        } else {
+          mockConfig.mockImpl = previousImplementation;
+        }
       };
 
       f.mockImplementation = (fn: UnknownFunction) => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -790,8 +790,8 @@ export class ModuleMocker {
         const returnedValue = callback();
 
         if (
+          returnedValue != null &&
           typeof returnedValue === 'object' &&
-          returnedValue !== null &&
           typeof returnedValue.then === 'function'
         ) {
           return returnedValue.then(() => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -7,6 +7,8 @@
 
 /* eslint-disable local/ban-types-eventually, local/prefer-rest-params-eventually */
 
+import {isPromise} from 'jest-util';
+
 export type MockMetadataType =
   | 'object'
   | 'array'
@@ -789,11 +791,7 @@ export class ModuleMocker {
 
         const returnedValue = callback();
 
-        if (
-          returnedValue != null &&
-          typeof returnedValue === 'object' &&
-          typeof returnedValue.then === 'function'
-        ) {
+        if (isPromise(returnedValue)) {
           return returnedValue.then(() => {
             mockConfig.mockImpl = previousImplementation;
           });

--- a/packages/jest-mock/tsconfig.json
+++ b/packages/jest-mock/tsconfig.json
@@ -6,5 +6,5 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-types"}]
+  "references": [{"path": "../jest-types"}, {"path": "../jest-util"}]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12578,6 +12578,7 @@ __metadata:
     "@jest/types": "workspace:^"
     "@tsd/typescript": ~4.8.2
     "@types/node": "*"
+    jest-util: "workspace:^"
     tsd-lite: ^0.6.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

A follow-up for https://github.com/facebook/jest/pull/9270

It's often useful to override mock implementations for specific tests, and `mockImplementationOnce` is there to help out.

It is however not a very elegant solution for situations where the mock will get called multiple times:
- It's not intuitive that you can call the method multiple times to "plan" for multiple calls
- The number of calls to the mock might be unimportant to the test. `mockImplementationOnce` makes the number of calls unecessarily important.
- The number of calls to the mock becomes part of the "arrange" phase of the test rather than the "assert" phase.
- `mockImplementationOnce` will bleed into the next test if the implementation does not end up getting called.

This PR implements a new method `withImplementation` which sets a temporary default implementation which will be available within a callback, after which the default implementation will be set back to what it was before. If the callback returns a promise, `withImplemenation` will return a promise that can be awaited in the test.

I had to add a couple of `@ts-expect-error` comments to get the returned value of `withImplementation` (promise or void) match the return value of the callback implementation. If you know a better way of achieving this, let me know.

Also, I could potentially be useful to print a warning if the callback does not trigger a call to the mock - in which case `withImplementation` was redundant. What do you think about that idea?

## Test plan

I've added unit tests for the feature. Let me know if I need to add more tests.