### PR TITLE
fix(@jest/test-utils): use build-in Jest types instead of `@types/jest`

### DIFF
--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable jest/no-focused-tests */
-
 import semver = require('semver');
+import type {Global} from '@jest/types';
+
+declare const describe: Global.TestFrameworkGlobals['describe'];
+declare const test: Global.TestFrameworkGlobals['test'];
 
 export function isJestJasmineRun(): boolean {
   return process.env.JEST_JASMINE === '1';

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build"
+    "outDir": "build",
+    // we don't want `@types/jest` to be referenced
+    "types": ["node"]
   },
   "include": ["./src/**/*"],
   "references": [{"path": "../jest-types"}, {"path": "../pretty-format"}]


### PR DESCRIPTION
## Summary

As it was noticed in #12856, `test-utils` could use build-in Jest types instead of `@types/jest`. Bumped into this again while working on another idea. Perhaps it makes sense to land this separately?

## Test plan

Should build without type errors.