### PR TITLE
docs: use admonition in Testing Asynchronous Code page

### DIFF
--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is done as a precaution to avoid memory leaks in your tests.
 
 :::
 

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-25.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-25.x/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/website/versioned_docs/version-26.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-26.x/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/website/versioned_docs/version-27.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-27.x/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/website/versioned_docs/version-27.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-27.x/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is done as a precaution to avoid memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-27.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-27.x/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-28.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-28.x/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/website/versioned_docs/version-28.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-28.x/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is done as a precaution to avoid memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-28.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-28.x/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-29.0/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.0/TestingAsyncCode.md
@@ -115,7 +115,11 @@ If `done()` is never called, the test will fail (with timeout error), which is w
 
 If the `expect` statement fails, it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in a `try` block and pass the error in the `catch` block to `done`. Otherwise, we end up with an opaque timeout error that doesn't show what value was received by `expect(data)`.
 
-_Note: `done()` should not be mixed with Promises as this tends to lead to memory leaks in your tests._
+:::caution
+
+`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+
+:::
 
 ## `.resolves` / `.rejects`
 

--- a/website/versioned_docs/version-29.0/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.0/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is done as a precaution to avoid memory leaks in your tests.
 
 :::
 

--- a/website/versioned_docs/version-29.0/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.0/TestingAsyncCode.md
@@ -117,7 +117,7 @@ If the `expect` statement fails, it throws an error and `done()` is not called. 
 
 :::caution
 
-`done()` should not be mixed with promises as this tends to lead to memory leaks in your tests.
+Jest will throw an error, if the same test function is passed a `done()` callback and returns a promise. This is a precaution of memory leaks in your tests.
 
 :::
 


### PR DESCRIPTION
## Summary

Adds missing admonition in Testing Asynchronous Code page. Tiny change, so I have done all versions in one go.

## Test plan

Deploy preview.