### PR TITLE
chore: remove `expect` from dev dependencies of `pretty-format`.

### DIFF
--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -27,7 +27,6 @@
     "@types/react": "^17.0.3",
     "@types/react-is": "^17.0.0",
     "@types/react-test-renderer": "17.0.2",
-    "expect": "workspace:^",
     "immutable": "^4.0.0",
     "jest-util": "workspace:^",
     "react": "17.0.2",

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {AsymmetricMatcher as AbstractAsymmetricMatcher} from 'expect';
 import prettyFormat, {plugins} from '../';
 import type {OptionsReceived} from '../types';
 
@@ -349,10 +348,10 @@ test('min option', () => {
   );
 });
 
-class DummyMatcher extends AbstractAsymmetricMatcher<number> {
-  constructor(sample: number) {
-    super(sample);
-  }
+class DummyMatcher {
+  $$typeof = Symbol.for('jest.asymmetricMatcher');
+
+  constructor(private sample: number) {}
 
   asymmetricMatch(other: number) {
     return this.sample === other;
@@ -362,7 +361,7 @@ class DummyMatcher extends AbstractAsymmetricMatcher<number> {
     return 'DummyMatcher';
   }
 
-  override getExpectedType() {
+  getExpectedType() {
     return 'number';
   }
 }

--- a/packages/pretty-format/tsconfig.json
+++ b/packages/pretty-format/tsconfig.json
@@ -7,6 +7,5 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  // no `expect`, only used in tests
   "references": [{"path": "../jest-schemas"}, {"path": "../jest-util"}]
 }

--- a/scripts/buildTs.mjs
+++ b/scripts/buildTs.mjs
@@ -62,13 +62,6 @@ import {getPackages} from './buildUtils.mjs';
           }
         }
 
-        // dev dep
-        if (pkg.name === 'pretty-format') {
-          if (dep === 'expect') {
-            return false;
-          }
-        }
-
         return true;
       })
       .map(dep =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -16862,7 +16862,6 @@ __metadata:
     "@types/react-is": ^17.0.0
     "@types/react-test-renderer": 17.0.2
     ansi-styles: ^5.0.0
-    expect: "workspace:^"
     immutable: ^4.0.0
     jest-util: "workspace:^"
     react: 17.0.2


### PR DESCRIPTION
From https://github.com/facebook/jest/pull/13283#discussion_r975232573

## Summary

Here is a quick idea how `expect` could be removed from the dev dependencies of `pretty-format`.

`expect` is needed only for one test, which is testing `DummyMatcher` class which is defined in the test file. This class is extending `AsymmetricMatcher` abstract class which is imported from `expect`.

The imported `AsymmetricMatcher` abstract class looks like this:

https://github.com/facebook/jest/blob/561907ce5d1e9065311cf585f75b9c5864036193/packages/expect/src/asymmetricMatchers.ts#L67-L89

All what the test needs is `toAsymmetricMatcher` method, but as one can see above it is not implemented in the parent class. This means that only the constructor and `$$typeof` property of `AsymmetricMatcher` are useful. I think we can safely copy these to `DummyMatcher` class and remove `expect` as a dependency. Or?

## Test plan

Green CI.