### PR TITLE
chore(lint): apply `eslint-plugin-jest` rules only for test and test related files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,7 +27,6 @@ function getPackages() {
 module.exports = {
   env: {
     es2020: true,
-    'jest/globals': true,
   },
   extends: [
     'eslint:recommended',
@@ -148,6 +147,29 @@ module.exports = {
       },
     },
 
+    // 'eslint-plugin-jest' rules for test and test related files
+    {
+      files: [
+        '**/__mocks__/**',
+        '**/__tests__/**',
+        '**/*.md/**',
+        '**/*.test.*',
+        'e2e/babel-plugin-jest-hoist/mockFile.js',
+        'e2e/failures/macros.js',
+        'e2e/test-in-root/*.js',
+        'e2e/test-match/test-suites/*',
+        'packages/test-utils/src/ConditionalTest.ts',
+      ],
+      env: {'jest/globals': true},
+      excludedFiles: ['**/__typetests__/**'],
+      plugins: ['jest'],
+      rules: {
+        'jest/no-focused-tests': 'error',
+        'jest/no-identical-title': 'error',
+        'jest/valid-expect': 'error',
+      },
+    },
+
     // to make it more suitable for running on code examples in docs/ folder
     {
       files: ['**/*.md/**'],
@@ -161,6 +183,7 @@ module.exports = {
         'import/export': 'off',
         'import/no-extraneous-dependencies': 'off',
         'import/no-unresolved': 'off',
+        'jest/no-focused-tests': 'off',
         'no-console': 'off',
         'no-undef': 'off',
         'no-unused-vars': 'off',
@@ -168,6 +191,7 @@ module.exports = {
         'sort-keys': 'off',
       },
     },
+
     // snapshots in examples plus inline snapshots need to keep backtick
     {
       files: ['**/*.md/**', 'e2e/custom-inline-snapshot-matchers/__tests__/*'],
@@ -274,20 +298,6 @@ module.exports = {
       },
     },
     {
-      files: [
-        '**/__typetests__/**',
-        '**/*.md/**',
-        'e2e/circus-concurrent/__tests__/concurrent-only-each.test.js',
-        'e2e/jasmine-async/__tests__/concurrent-only-each.test.js',
-        'e2e/test-failing/__tests__/worksWithOnlyMode.test.js',
-      ],
-      rules: {
-        'jest/no-focused-tests': 'off',
-        'jest/no-identical-title': 'off',
-        'jest/valid-expect': 'off',
-      },
-    },
-    {
       env: {node: true},
       files: ['*.js', '*.jsx', '*.mjs', '*.cjs'],
     },
@@ -323,7 +333,7 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
-  plugins: ['import', 'jest'],
+  plugins: ['import'],
   rules: {
     'accessor-pairs': ['warn', {setWithoutGet: true}],
     'block-scoped-var': 'off',
@@ -380,9 +390,6 @@ module.exports = {
       },
     ],
     'init-declarations': 'off',
-    'jest/no-focused-tests': 'error',
-    'jest/no-identical-title': 'error',
-    'jest/valid-expect': 'error',
     'lines-around-comment': 'off',
     'max-depth': 'off',
     'max-nested-callbacks': 'off',
@@ -467,10 +474,7 @@ module.exports = {
     'no-regex-spaces': 'warn',
     'no-restricted-globals': [
       'error',
-      {
-        message: 'Use `globalThis` instead.',
-        name: 'global',
-      },
+      {message: 'Use `globalThis` instead.', name: 'global'},
     ],
     'no-restricted-imports': [
       'error',

--- a/e2e/__tests__/__snapshots__/testFailing.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testFailing.test.ts.snap
@@ -297,67 +297,67 @@ exports[`works with only mode 1`] = `
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      11 |   });
-      12 |
-    > 13 |   it.only.failing.each([
+      13 |   });
+      14 |
+    > 15 |   it.only.failing.each([
          |   ^
-      14 |     {a: 1, b: 1, expected: 2},
-      15 |     {a: 1, b: 2, expected: 3},
-      16 |     {a: 2, b: 1, expected: 3},
+      16 |     {a: 1, b: 1, expected: 2},
+      17 |     {a: 1, b: 2, expected: 3},
+      18 |     {a: 2, b: 1, expected: 3},
 
       at ../../packages/jest-each/build/bind.js:45:11
           at Array.forEach (<anonymous>)
-      at __tests__/worksWithOnlyMode.test.js:13:3
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:8:1)
+      at __tests__/worksWithOnlyMode.test.js:15:3
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:10:1)
 
   ● block with only, should pass › .add(1, 2)
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      11 |   });
-      12 |
-    > 13 |   it.only.failing.each([
+      13 |   });
+      14 |
+    > 15 |   it.only.failing.each([
          |   ^
-      14 |     {a: 1, b: 1, expected: 2},
-      15 |     {a: 1, b: 2, expected: 3},
-      16 |     {a: 2, b: 1, expected: 3},
+      16 |     {a: 1, b: 1, expected: 2},
+      17 |     {a: 1, b: 2, expected: 3},
+      18 |     {a: 2, b: 1, expected: 3},
 
       at ../../packages/jest-each/build/bind.js:45:11
           at Array.forEach (<anonymous>)
-      at __tests__/worksWithOnlyMode.test.js:13:3
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:8:1)
+      at __tests__/worksWithOnlyMode.test.js:15:3
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:10:1)
 
   ● block with only, should pass › .add(2, 1)
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      11 |   });
-      12 |
-    > 13 |   it.only.failing.each([
+      13 |   });
+      14 |
+    > 15 |   it.only.failing.each([
          |   ^
-      14 |     {a: 1, b: 1, expected: 2},
-      15 |     {a: 1, b: 2, expected: 3},
-      16 |     {a: 2, b: 1, expected: 3},
+      16 |     {a: 1, b: 1, expected: 2},
+      17 |     {a: 1, b: 2, expected: 3},
+      18 |     {a: 2, b: 1, expected: 3},
 
       at ../../packages/jest-each/build/bind.js:45:11
           at Array.forEach (<anonymous>)
-      at __tests__/worksWithOnlyMode.test.js:13:3
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:8:1)
+      at __tests__/worksWithOnlyMode.test.js:15:3
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:10:1)
 
   ● block with only, should fail › failing passes = fails, should fail
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      29 |
-      30 | describe('block with only, should fail', () => {
-    > 31 |   it.only.failing('failing passes = fails, should fail', () => {
+      31 |
+      32 | describe('block with only, should fail', () => {
+    > 33 |   it.only.failing('failing passes = fails, should fail', () => {
          |           ^
-      32 |     expect(10).toBe(10);
-      33 |   });
-      34 |
+      34 |     expect(10).toBe(10);
+      35 |   });
+      36 |
 
-      at failing (__tests__/worksWithOnlyMode.test.js:31:11)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:30:1)
+      at failing (__tests__/worksWithOnlyMode.test.js:33:11)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:32:1)
 
   ● block with only in other it, should skip › failing test
 
@@ -366,45 +366,45 @@ exports[`works with only mode 1`] = `
     Expected: 101
     Received: 10
 
-      48 |
-      49 |   it.only('failing test', () => {
-    > 50 |     expect(10).toBe(101);
+      50 |
+      51 |   it.only('failing test', () => {
+    > 52 |     expect(10).toBe(101);
          |                ^
-      51 |   });
-      52 |
-      53 |   it('passing test but skipped', () => {
+      53 |   });
+      54 |
+      55 |   it('passing test but skipped', () => {
 
-      at Object.toBe (__tests__/worksWithOnlyMode.test.js:50:16)
+      at Object.toBe (__tests__/worksWithOnlyMode.test.js:52:16)
 
   ● block with only with different syntax, should fail › failing passes = fails, should fail 1
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      57 |
-      58 | describe('block with only with different syntax, should fail', () => {
-    > 59 |   fit.failing('failing passes = fails, should fail 1', () => {
+      59 |
+      60 | describe('block with only with different syntax, should fail', () => {
+    > 61 |   fit.failing('failing passes = fails, should fail 1', () => {
          |       ^
-      60 |     expect(10).toBe(10);
-      61 |   });
-      62 |
+      62 |     expect(10).toBe(10);
+      63 |   });
+      64 |
 
-      at failing (__tests__/worksWithOnlyMode.test.js:59:7)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:58:1)
+      at failing (__tests__/worksWithOnlyMode.test.js:61:7)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:60:1)
 
   ● block with only with different syntax, should fail › failing passes = fails, should fail 2
 
     Failing test passed even though it was supposed to fail. Remove \`.failing\` to remove error.
 
-      61 |   });
-      62 |
-    > 63 |   test.only.failing('failing passes = fails, should fail 2', () => {
+      63 |   });
+      64 |
+    > 65 |   test.only.failing('failing passes = fails, should fail 2', () => {
          |             ^
-      64 |     expect(10).toBe(10);
-      65 |   });
-      66 |
+      66 |     expect(10).toBe(10);
+      67 |   });
+      68 |
 
-      at failing (__tests__/worksWithOnlyMode.test.js:63:13)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:58:1)"
+      at failing (__tests__/worksWithOnlyMode.test.js:65:13)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:60:1)"
 `;
 
 exports[`works with skip mode 1`] = `

--- a/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
@@ -89,61 +89,61 @@ FAIL __tests__/worksWithOnlyMode.test.js
 
     Jest: \`failing\` tests are only supported in \`jest-circus\`.
 
-       7 |
-       8 | describe('block with only, should pass', () => {
-    >  9 |   it.only.failing('failing fails = passes, should pass', () => {
+       9 |
+      10 | describe('block with only, should pass', () => {
+    > 11 |   it.only.failing('failing fails = passes, should pass', () => {
          |           ^
-      10 |     expect(10).toBe(101);
-      11 |   });
-      12 |
+      12 |     expect(10).toBe(101);
+      13 |   });
+      14 |
 
-      at Suite.failing (__tests__/worksWithOnlyMode.test.js:9:11)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:8:1)
+      at Suite.failing (__tests__/worksWithOnlyMode.test.js:11:11)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:10:1)
 
   ● block with only, should fail › encountered a declaration exception
 
     Jest: \`failing\` tests are only supported in \`jest-circus\`.
 
-      29 |
-      30 | describe('block with only, should fail', () => {
-    > 31 |   it.only.failing('failing passes = fails, should fail', () => {
+      31 |
+      32 | describe('block with only, should fail', () => {
+    > 33 |   it.only.failing('failing passes = fails, should fail', () => {
          |           ^
-      32 |     expect(10).toBe(10);
-      33 |   });
-      34 |
+      34 |     expect(10).toBe(10);
+      35 |   });
+      36 |
 
-      at Suite.failing (__tests__/worksWithOnlyMode.test.js:31:11)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:30:1)
+      at Suite.failing (__tests__/worksWithOnlyMode.test.js:33:11)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:32:1)
 
   ● block with only in other it, should skip › encountered a declaration exception
 
     Jest: \`failing\` tests are only supported in \`jest-circus\`.
 
-      43 |
-      44 | describe('block with only in other it, should skip', () => {
-    > 45 |   it.failing('failing passes = fails, should fail but skipped', () => {
+      45 |
+      46 | describe('block with only in other it, should skip', () => {
+    > 47 |   it.failing('failing passes = fails, should fail but skipped', () => {
          |      ^
-      46 |     expect(10).toBe(10);
-      47 |   });
-      48 |
+      48 |     expect(10).toBe(10);
+      49 |   });
+      50 |
 
-      at Suite.failing (__tests__/worksWithOnlyMode.test.js:45:6)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:44:1)
+      at Suite.failing (__tests__/worksWithOnlyMode.test.js:47:6)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:46:1)
 
   ● block with only with different syntax, should fail › encountered a declaration exception
 
     Jest: \`failing\` tests are only supported in \`jest-circus\`.
 
-      57 |
-      58 | describe('block with only with different syntax, should fail', () => {
-    > 59 |   fit.failing('failing passes = fails, should fail 1', () => {
+      59 |
+      60 | describe('block with only with different syntax, should fail', () => {
+    > 61 |   fit.failing('failing passes = fails, should fail 1', () => {
          |       ^
-      60 |     expect(10).toBe(10);
-      61 |   });
-      62 |
+      62 |     expect(10).toBe(10);
+      63 |   });
+      64 |
 
-      at Suite.failing (__tests__/worksWithOnlyMode.test.js:59:7)
-      at Object.describe (__tests__/worksWithOnlyMode.test.js:58:1)
+      at Suite.failing (__tests__/worksWithOnlyMode.test.js:61:7)
+      at Object.describe (__tests__/worksWithOnlyMode.test.js:60:1)
 
 FAIL __tests__/worksWithSkipMode.test.js
   ● block with only, should pass › encountered a declaration exception

--- a/e2e/__tests__/locationInResults.test.ts
+++ b/e2e/__tests__/locationInResults.test.ts
@@ -31,39 +31,39 @@ it('adds correct location info when provided with flag', () => {
 
   expect(assertions[0].location).toEqual({
     column: 1,
-    line: 12,
+    line: 10,
   });
 
   expect(assertions[1].location).toEqual({
     column: 1,
-    line: 16,
+    line: 14,
   });
 
   expect(assertions[2].location).toEqual({
     column: 1,
-    line: 20,
+    line: 19,
   });
 
   expect(assertions[3].location).toEqual({
     column: isJestJasmineRun() ? 22 : 1,
-    line: 24,
+    line: 23,
   });
 
   expect(assertions[4].location).toEqual({
     column: isJestJasmineRun() ? 22 : 1,
-    line: 24,
+    line: 23,
   });
 
   // Technically the column should be 3, but callsites is not correct.
   // jest-circus uses stack-utils + asyncErrors which resolves this.
   expect(assertions[5].location).toEqual({
     column: isJestJasmineRun() ? 2 : 3,
-    line: 29,
+    line: 28,
   });
 
   expect(assertions[6].location).toEqual({
     column: isJestJasmineRun() ? 2 : 3,
-    line: 33,
+    line: 32,
   });
 
   expect(assertions[7].location).toEqual({

--- a/e2e/circus-concurrent/__tests__/concurrent-only-each.test.js
+++ b/e2e/circus-concurrent/__tests__/concurrent-only-each.test.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable jest/no-focused-tests */
+
 'use strict';
 
 it.concurrent.only.each([

--- a/e2e/each/__tests__/describeOnly.test.js
+++ b/e2e/each/__tests__/describeOnly.test.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line jest/no-focused-tests
+/* eslint-disable jest/no-focused-tests */
+
 describe.only.each([
   [true, true],
   [true, true],

--- a/e2e/each/__tests__/eachOnly.test.js
+++ b/e2e/each/__tests__/eachOnly.test.js
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line jest/no-focused-tests
+/* eslint-disable jest/no-focused-tests */
+
 it.only.each([
   [true, true],
   [true, true],
@@ -20,7 +21,6 @@ it.each([
   expect(left).toBe(right);
 });
 
-// eslint-disable-next-line jest/no-focused-tests
 it.only.each`
   left    | right
   ${true} | ${true}

--- a/e2e/jasmine-async/__tests__/concurrent-only-each.test.js
+++ b/e2e/jasmine-async/__tests__/concurrent-only-each.test.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable jest/no-focused-tests */
+
 'use strict';
 
 it.concurrent.only.each([

--- a/e2e/location-in-results/__tests__/test.js
+++ b/e2e/location-in-results/__tests__/test.js
@@ -7,8 +7,6 @@
 // This file is missing 'use strict' to force babel into doing something
 // as we have `transform-strict-mode`
 
-/* eslint jest/no-focused-tests: 0 */
-
 it('it no ancestors', () => {
   expect(true).toBeTruthy();
 });
@@ -17,6 +15,7 @@ xit('xit no ancestors', () => {
   expect(true).toBeTruthy();
 });
 
+// eslint-disable-next-line jest/no-focused-tests
 fit('fit no ancestors', () => {
   expect(true).toBeTruthy();
 });
@@ -34,6 +33,7 @@ describe('nested', () => {
     expect(true).toBeTruthy();
   });
 
+  // eslint-disable-next-line jest/no-focused-tests
   fit('fit nested', () => {
     expect(true).toBeTruthy();
   });

--- a/e2e/test-failing/__tests__/worksWithOnlyMode.test.js
+++ b/e2e/test-failing/__tests__/worksWithOnlyMode.test.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable jest/no-focused-tests */
+
 describe('block with only, should pass', () => {
   it.only.failing('failing fails = passes, should pass', () => {
     expect(10).toBe(101);


### PR DESCRIPTION
## Summary

Currently `eslint-plugin-jest` rules are applied for all files. Perhaps it makes sense to select only test and test related files (e.g. mocks)?

EDIT: The goal is to add more `eslint-plugin-jest` rules in near future (e.g. `prefer-to-be`). Reworking `eslintrc` makes it easier to spot where do they live and for which files the rules apply.

## Test plan

Green CI.