### PR TITLE
Priotize parser used in the project. #12929

### DIFF
--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -267,14 +267,15 @@ const runPrettier = (
     ? prettier.resolveConfig.sync(sourceFilePath, {editorconfig: true})
     : null;
 
-  // Detect the parser for the test file.
+  // Prioritize parser found in the project config.
+  // If not found detect the parser for the test file.
   // For older versions of Prettier, fallback to a simple parser detection.
   // @ts-expect-error - `inferredParser` is `string`
   const inferredParser: PrettierParserName | null | undefined =
-    prettier.getFileInfo
+    (config && typeof config.parser === 'string' && config.parser) ||
+    (prettier.getFileInfo
       ? prettier.getFileInfo.sync(sourceFilePath).inferredParser
-      : (config && typeof config.parser === 'string' && config.parser) ||
-        simpleDetectParser(sourceFilePath);
+      : simpleDetectParser(sourceFilePath));
 
   if (!inferredParser) {
     throw new Error(

--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -629,3 +629,42 @@ test('saveInlineSnapshots() does not indent empty lines', () => {
       '  `));\n',
   );
 });
+
+test('saveInlineSnapshots() prioritize parser from project/editor configuration', () => {
+  const filename = path.join(dir, 'my.test.js');
+  fs.writeFileSync(
+    filename,
+    'const foo = {\n' +
+      '  "1": "Some value",\n' +
+      '};\n' +
+      'test("something", () => {\n' +
+      '  expect("a").toMatchInlineSnapshot();\n' +
+      '});\n',
+  );
+
+  (prettier.resolveConfig.sync as jest.Mock).mockReturnValue({
+    parser: 'flow',
+  });
+
+  const prettierSpy = jest.spyOn(prettier.getFileInfo, 'sync');
+
+  saveInlineSnapshots(
+    [
+      {
+        frame: {column: 15, file: filename, line: 5} as Frame,
+        snapshot: 'a',
+      },
+    ],
+    'prettier',
+  );
+
+  expect(prettierSpy).not.toBeCalled();
+  expect(fs.readFileSync(filename, 'utf-8')).toBe(
+    'const foo = {\n' +
+      '  "1": "Some value",\n' +
+      '};\n' +
+      'test("something", () => {\n' +
+      '  expect("a").toMatchInlineSnapshot(`a`);\n' +
+      '});\n',
+  );
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes https://github.com/facebook/jest/issues/12929

Right know Jest prioritize prettier deciding the parser who is going to be used for the snapshot and let the parser used in the project as a fallback.

I simple change the logic to prioritize the parser found in the projects prettier config file or editors config. If not found prettier will decide which parser is going to be used.
 
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
 You can test using the reproduction repo from the issue.
