### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '*/10 * * * *'
 
+permissions:
+  issues: write # to close stale issues (actions/stale)
+  pull-requests: write # to close stale PRs (actions/stale)
+
 jobs:
   stale:
     name: 'Close month old issues and PRs'

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  issues: write # to close issues (peter-evans/close-issue)
+
 jobs:
   questions:
     name: Questions

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,8 +4,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
 jobs:
   lock:
+    permissions:
+      issues: write # to lock issues (dessant/lock-threads)
+      pull-requests: write # to lock PRs (dessant/lock-threads)
+
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   prepare-yarn-cache-ubuntu:
     uses: ./.github/workflows/prepare-cache.yml


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.