### PR TITLE
feat(expect): Expose toThrowMatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[@jest/environment]` Allow `jest.mock` and `jest.doMock` to take a type argument ([#13254](https://github.com/facebook/jest/pull/13254))
 - `[@jest/fake-timers]` Add `jest.now()` to return the current fake clock time ([#13244](https://github.com/facebook/jest/pull/13244), [13246](https://github.com/facebook/jest/pull/13246))
 - `[@jest/mock]` Add `withImplementation` method for temporarily overriding a mock.
+- `[expect]` Export `toThrow*` matchers ([#13328](https://github.com/facebook/jest/pull/13328))
 
 ### Fixes
 

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -15,7 +15,8 @@
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",
-    "./build/matchers": "./build/matchers.js"
+    "./build/matchers": "./build/matchers.js",
+    "./build/toThrowMatchers": "./build/toThrowMatchers.js"
   },
   "dependencies": {
     "@jest/expect-utils": "workspace:^",

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -67,7 +67,10 @@ export function getPackages() {
         ),
         ...(pkg.name === 'jest-circus' ? {'./runner': './runner.js'} : {}),
         ...(pkg.name === 'expect'
-          ? {'./build/matchers': './build/matchers.js'}
+          ? {
+              './build/matchers': './build/matchers.js',
+              './build/toThrowMatchers': './build/toThrowMatchers.js',
+            }
           : {}),
       },
       `Package "${pkg.name}" does not export correct files`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Required for https://github.com/facebook/react/pull/21575
Prior art: https://github.com/facebook/jest/pull/11932

React currently extends `toThrow` to normalize error messages across v8 versions: https://github.com/facebook/react/pull/22477

Being able to extend this specific matcher was asked in https://github.com/facebook/jest/issues/2547#issuecomment-346500017 but the issue was closed.

Without this change `yarn test` in facebook/react throw:
```
Cannot find module 'expect/build/toThrowMatchers' from 'scripts/jest/matchers/toThrow.js'

    Require stack:
      scripts/jest/matchers/toThrow.js
      scripts/jest/setupTests.js
``` 

## Test plan

- [x] Applied patch locally 