### PR TITLE
docs: update `--filter` to match code implementation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -202,11 +202,13 @@ Alias: `-e`. Use this flag to show full diffs and errors instead of a patch.
 
 ### `--filter=<file>`
 
-Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with the "filtered" property. Especially useful when used in conjunction with a testing infrastructure to filter known broken, e.g.
+Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with shape `{ filtered: Array<{ test: string }> }`. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests, e.g.
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction); // ["path1.spec.js", "path2.spec.js", etc]
+  const allowedPaths = testPaths.filter(filteringFunction)
+    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+  
   return {
     filtered: allowedPaths,
   };

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -206,9 +206,10 @@ Path to a module exporting a filtering function. This asynchronous function rece
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction)
-    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
-  
+  const allowedPaths = testPaths
+    .filter(filteringFunction)
+    .map(test => ({test})); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+
   return {
     filtered: allowedPaths,
   };

--- a/website/versioned_docs/version-28.x/CLI.md
+++ b/website/versioned_docs/version-28.x/CLI.md
@@ -212,8 +212,9 @@ Path to a module exporting a filtering function. This asynchronous function rece
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction)
-    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+  const allowedPaths = testPaths
+    .filter(filteringFunction)
+    .map(test => ({test})); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
 
   return {
     filtered: allowedPaths,

--- a/website/versioned_docs/version-28.x/CLI.md
+++ b/website/versioned_docs/version-28.x/CLI.md
@@ -208,11 +208,13 @@ Alias: `-e`. Use this flag to show full diffs and errors instead of a patch.
 
 ### `--filter=<file>`
 
-Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with the "filtered" property. Especially useful when used in conjunction with a testing infrastructure to filter known broken, e.g.
+Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with shape `{ filtered: Array<{ test: string }> }`. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests, e.g.
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction); // ["path1.spec.js", "path2.spec.js", etc]
+  const allowedPaths = testPaths.filter(filteringFunction)
+    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+
   return {
     filtered: allowedPaths,
   };

--- a/website/versioned_docs/version-29.0/CLI.md
+++ b/website/versioned_docs/version-29.0/CLI.md
@@ -202,11 +202,13 @@ Alias: `-e`. Use this flag to show full diffs and errors instead of a patch.
 
 ### `--filter=<file>`
 
-Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with the "filtered" property. Especially useful when used in conjunction with a testing infrastructure to filter known broken, e.g.
+Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with shape `{ filtered: Array<{ test: string }> }`. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests, e.g.
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction); // ["path1.spec.js", "path2.spec.js", etc]
+  const allowedPaths = testPaths.filter(filteringFunction)
+    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+
   return {
     filtered: allowedPaths,
   };

--- a/website/versioned_docs/version-29.0/CLI.md
+++ b/website/versioned_docs/version-29.0/CLI.md
@@ -206,8 +206,9 @@ Path to a module exporting a filtering function. This asynchronous function rece
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction)
-    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+  const allowedPaths = testPaths
+    .filter(filteringFunction)
+    .map(test => ({test})); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
 
   return {
     filtered: allowedPaths,

--- a/website/versioned_docs/version-29.1/CLI.md
+++ b/website/versioned_docs/version-29.1/CLI.md
@@ -202,11 +202,13 @@ Alias: `-e`. Use this flag to show full diffs and errors instead of a patch.
 
 ### `--filter=<file>`
 
-Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with the "filtered" property. Especially useful when used in conjunction with a testing infrastructure to filter known broken, e.g.
+Path to a module exporting a filtering function. This asynchronous function receives a list of test paths which can be manipulated to exclude tests from running by returning an object with shape `{ filtered: Array<{ test: string }> }`. Especially useful when used in conjunction with a testing infrastructure to filter known broken tests, e.g.
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction); // ["path1.spec.js", "path2.spec.js", etc]
+  const allowedPaths = testPaths.filter(filteringFunction)
+    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+
   return {
     filtered: allowedPaths,
   };

--- a/website/versioned_docs/version-29.1/CLI.md
+++ b/website/versioned_docs/version-29.1/CLI.md
@@ -206,8 +206,9 @@ Path to a module exporting a filtering function. This asynchronous function rece
 
 ```js title="my-filter.js"
 module.exports = testPaths => {
-  const allowedPaths = testPaths.filter(filteringFunction)
-    .map(test => ({ test })); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
+  const allowedPaths = testPaths
+    .filter(filteringFunction)
+    .map(test => ({test})); // [{ test: "path1.spec.js" }, { test: "path2.spec.js" }, etc]
 
   return {
     filtered: allowedPaths,


### PR DESCRIPTION
Updates --filter docs to match code implementation. Issue #13222

## Summary

Updates the ` --filter` CLI option docs to match code implementation. The return type specified in the current document version does not match what is expected by code, as per #13222 

## Test plan

As described in issue #13222
