### PR TITLE
fix: add jest-worker's missing dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[expect, @jest/expect]` Revert buggy inference of argument types for `*CalledWith` and `*ReturnedWith` matchers introduced in 29.1.0 ([#13339](https://github.com/facebook/jest/pull/13339))
+- `[jest-worker]` Add missing dependency on `jest-util` ([#13341](https://github.com/facebook/jest/pull/13341))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@types/node": "*",
+    "jest-util": "^29.1.0",
     "merge-stream": "^2.0.0",
     "supports-color": "^8.0.0"
   },

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@types/node": "*",
-    "jest-util": "^29.1.0",
+    "jest-util": "workspace:^",
     "merge-stream": "^2.0.0",
     "supports-color": "^8.0.0"
   },

--- a/packages/jest-worker/tsconfig.json
+++ b/packages/jest-worker/tsconfig.json
@@ -6,5 +6,5 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-leak-detector"}]
+  "references": [{"path": "../jest-leak-detector"}, {"path": "../jest-util"}]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12869,21 +12869,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"jest-util@^29.1.0, jest-util@workspace:^, jest-util@workspace:packages/jest-util":
-  version: 0.0.0-use.local
-  resolution: "jest-util@workspace:packages/jest-util"
-  dependencies:
-    "@jest/types": "workspace:^"
-    "@types/graceful-fs": ^4.1.3
-    "@types/node": "*"
-    "@types/picomatch": ^2.2.2
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  languageName: unknown
-  linkType: soft
-
 "jest-util@npm:^26.0.0":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
@@ -12925,6 +12910,21 @@ __metadata:
   checksum: fd6459742c941f070223f25e38a2ac0719aad92561591e9fb2a50d602a5d19d754750b79b4074327a42b00055662b95da3b006542ceb8b54309da44d4a62e721
   languageName: node
   linkType: hard
+
+"jest-util@workspace:^, jest-util@workspace:packages/jest-util":
+  version: 0.0.0-use.local
+  resolution: "jest-util@workspace:packages/jest-util"
+  dependencies:
+    "@jest/types": "workspace:^"
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    "@types/picomatch": ^2.2.2
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  languageName: unknown
+  linkType: soft
 
 "jest-validate@npm:^26.5.2":
   version: 26.6.2
@@ -13038,7 +13038,7 @@ __metadata:
     "@types/supports-color": ^8.1.0
     get-stream: ^6.0.0
     jest-leak-detector: "workspace:^"
-    jest-util: ^29.1.0
+    jest-util: "workspace:^"
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
     tsd-lite: ^0.6.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -12869,6 +12869,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"jest-util@^29.1.0, jest-util@workspace:^, jest-util@workspace:packages/jest-util":
+  version: 0.0.0-use.local
+  resolution: "jest-util@workspace:packages/jest-util"
+  dependencies:
+    "@jest/types": "workspace:^"
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    "@types/picomatch": ^2.2.2
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  languageName: unknown
+  linkType: soft
+
 "jest-util@npm:^26.0.0":
   version: 26.6.2
   resolution: "jest-util@npm:26.6.2"
@@ -12910,21 +12925,6 @@ __metadata:
   checksum: fd6459742c941f070223f25e38a2ac0719aad92561591e9fb2a50d602a5d19d754750b79b4074327a42b00055662b95da3b006542ceb8b54309da44d4a62e721
   languageName: node
   linkType: hard
-
-"jest-util@workspace:^, jest-util@workspace:packages/jest-util":
-  version: 0.0.0-use.local
-  resolution: "jest-util@workspace:packages/jest-util"
-  dependencies:
-    "@jest/types": "workspace:^"
-    "@types/graceful-fs": ^4.1.3
-    "@types/node": "*"
-    "@types/picomatch": ^2.2.2
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    graceful-fs: ^4.2.9
-    picomatch: ^2.2.3
-  languageName: unknown
-  linkType: soft
 
 "jest-validate@npm:^26.5.2":
   version: 26.6.2
@@ -13038,6 +13038,7 @@ __metadata:
     "@types/supports-color": ^8.1.0
     get-stream: ^6.0.0
     jest-leak-detector: "workspace:^"
+    jest-util: ^29.1.0
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
     tsd-lite: ^0.6.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We use it here https://github.com/facebook/jest/blob/main/packages/jest-worker/src/workers/threadChild.ts#L9, but no in deps https://github.com/facebook/jest/blob/main/packages/jest-worker/package.json#L19

Ref: https://github.com/webpack-contrib/css-minimizer-webpack-plugin/issues/198

## Test plan

No need, but make sense to setup the linter (the rule for eslint) to catch these problems
