### PR TITLE
chore: use `@jest/globals` in the Angular example

### DIFF
--- a/examples/angular/app.component.spec.ts
+++ b/examples/angular/app.component.spec.ts
@@ -1,10 +1,11 @@
-import {ComponentFixture, TestBed, async} from '@angular/core/testing';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {describe, expect, it, jest} from '@jest/globals';
 
 import {AppComponent} from './app.component';
 import {DataService} from './shared/data.service';
 
 const title = 'Test';
-const getTitleFn = jest.fn().mockReturnValue(title);
+const getTitleFn = jest.fn<DataService['getTitle']>().mockReturnValue(title);
 const dataServiceSpy = jest.fn().mockImplementation(
   (): Partial<DataService> => ({
     getTitle: getTitleFn,
@@ -15,7 +16,7 @@ describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let app: AppComponent;
 
-  beforeEach(async(() => {
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AppComponent],
       providers: [{provide: DataService, useClass: dataServiceSpy}],

--- a/examples/angular/app.module.ts
+++ b/examples/angular/app.module.ts
@@ -1,5 +1,5 @@
-import {BrowserModule} from '@angular/platform-browser';
 import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
 
 import {AppComponent} from './app.component';
 

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -23,7 +23,6 @@
     "@babel/plugin-proposal-decorators": "*",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-typescript": "^7.0.0",
-    "@types/jest": "^27.4.0",
     "babel-jest": "workspace:^",
     "babel-plugin-transform-typescript-metadata": "*",
     "jest": "workspace:^",

--- a/examples/angular/shared/data.service.spec.ts
+++ b/examples/angular/shared/data.service.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed} from '@angular/core/testing';
+import {beforeEach, describe, expect, it, jest} from '@jest/globals';
 
 import {DataService} from './data.service';
 import {SubService} from './sub.service';

--- a/examples/angular/shared/sub.service.spec.ts
+++ b/examples/angular/shared/sub.service.spec.ts
@@ -1,4 +1,5 @@
 import {TestBed} from '@angular/core/testing';
+import {beforeEach, describe, expect, it} from '@jest/globals';
 
 import {SubService} from './sub.service';
 

--- a/examples/angular/shared/sub.service.ts
+++ b/examples/angular/shared/sub.service.ts
@@ -3,6 +3,6 @@ import {Injectable} from '@angular/core';
 @Injectable()
 export class SubService {
   public getTitle() {
-    return 'Angular App with Jest24';
+    return 'Angular App with Jest';
   }
 }

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "strict": true
+  },
+  "include": ["./**/*"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5661,7 +5661,6 @@ __metadata:
     "@babel/plugin-proposal-decorators": "*"
     "@babel/preset-env": ^7.1.0
     "@babel/preset-typescript": ^7.0.0
-    "@types/jest": ^27.4.0
     babel-jest: "workspace:^"
     babel-plugin-transform-typescript-metadata: "*"
     core-js: ^3.2.1


### PR DESCRIPTION
Part of #13344

## Summary

There was more work to replace `@types/jest` with `@jest/globals` in the Angular example. So this is done as separate PR.

## Test plan

Green CI.