### PR TITLE
feat(config): add read initial options helper 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,9 @@
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
+      "env": {
+        "NODE_OPTIONS": "--experimental-vm-modules"
+      },
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest"
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "clean-e2e": "node ./scripts/cleanE2e.mjs",
     "crowdin:upload": "echo 'Uploading sources to Crowdin' && crowdin upload sources --config ./crowdin.yaml",
     "crowdin:download": "echo 'Downloading translations from Crowdin' && crowdin download --config ./crowdin.yaml",
-    "jest": "node ./packages/jest-cli/bin/jest.js",
+    "jest": "node --experimental-vm-modules ./packages/jest-cli/bin/jest.js",
     "jest-jasmine": "JEST_JASMINE=1 yarn jest",
     "jest-jasmine-ci": "yarn jest-jasmine --color --config jest.config.ci.mjs",
     "jest-coverage": "yarn jest --coverage",

--- a/packages/jest-config/src/__fixtures__/async-config/jest.config.js
+++ b/packages/jest-config/src/__fixtures__/async-config/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = async function () {
+  return {
+    jestConfig: 'async-config',
+  };
+};

--- a/packages/jest-config/src/__fixtures__/js-config/jest.config.js
+++ b/packages/jest-config/src/__fixtures__/js-config/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  jestConfig: 'jest.config.js',
+};

--- a/packages/jest-config/src/__fixtures__/json-config/jest.config.json
+++ b/packages/jest-config/src/__fixtures__/json-config/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "jestConfig": "jest.config.json"
+}

--- a/packages/jest-config/src/__fixtures__/multiple-config-files/jest.config.js
+++ b/packages/jest-config/src/__fixtures__/multiple-config-files/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  jestConfig: 'jest.config.js',
+};

--- a/packages/jest-config/src/__fixtures__/multiple-config-files/jest.config.json
+++ b/packages/jest-config/src/__fixtures__/multiple-config-files/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "jestConfig": "jest.config.json"
+}

--- a/packages/jest-config/src/__fixtures__/pkg-config/package.json
+++ b/packages/jest-config/src/__fixtures__/pkg-config/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "jestConfig": "package.json"
+  }
+}

--- a/packages/jest-config/src/__fixtures__/ts-config/jest.config.ts
+++ b/packages/jest-config/src/__fixtures__/ts-config/jest.config.ts
@@ -1,0 +1,3 @@
+export default {
+  jestConfig: 'jest.config.ts',
+};

--- a/packages/jest-config/src/__tests__/readInitialOptions.test.ts
+++ b/packages/jest-config/src/__tests__/readInitialOptions.test.ts
@@ -1,0 +1,118 @@
+import path = require('path');
+import type {Config} from 'jest-runner';
+import {readInitialOptions} from '../index';
+
+function resolveFixture(...pathSegments: Array<string>) {
+  return path.resolve(__dirname, '..', '__fixtures__', ...pathSegments);
+}
+
+describe(readInitialOptions.name, () => {
+  test('should read from the cwd by default', async () => {
+    const configFile = resolveFixture('js-config', 'jest.config.js');
+    const rootDir = resolveFixture('js-config');
+    jest.spyOn(process, 'cwd').mockReturnValue(rootDir);
+    const {config, configPath} = await readInitialOptions();
+    expect(config).toEqual({jestConfig: 'jest.config.js', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should read a jest.config.js file', async () => {
+    const configFile = resolveFixture('js-config', 'jest.config.js');
+    const rootDir = resolveFixture('js-config');
+    const {config, configPath} = await readInitialOptions(configFile);
+    expect(config).toEqual({jestConfig: 'jest.config.js', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should read a package.json file', async () => {
+    const configFile = resolveFixture('pkg-config', 'package.json');
+    const rootDir = resolveFixture('pkg-config');
+    const {config, configPath} = await readInitialOptions(configFile);
+    expect(config).toEqual({jestConfig: 'package.json', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should read a jest.config.ts file', async () => {
+    const configFile = resolveFixture('ts-config', 'jest.config.ts');
+    const rootDir = resolveFixture('ts-config');
+    const {config, configPath} = await readInitialOptions(configFile);
+    expect(config).toEqual({jestConfig: 'jest.config.ts', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should read a jest.config.json file', async () => {
+    const configFile = resolveFixture('json-config', 'jest.config.json');
+    const rootDir = resolveFixture('json-config');
+    const {config, configPath} = await readInitialOptions(configFile);
+    expect(config).toEqual({jestConfig: 'jest.config.json', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should read a jest config exporting an async function', async () => {
+    const configFile = resolveFixture('async-config', 'jest.config.js');
+    const rootDir = resolveFixture('async-config');
+    const {config, configPath} = await readInitialOptions(configFile);
+    expect(config).toEqual({jestConfig: 'async-config', rootDir});
+    expect(configPath).toEqual(configFile);
+  });
+  test('should be able to use serialized jest config', async () => {
+    const inputConfig = {jestConfig: 'serialized'};
+    const {config, configPath} = await readInitialOptions(
+      JSON.stringify(inputConfig),
+    );
+    expect(config).toEqual({...inputConfig, rootDir: process.cwd()});
+    expect(configPath).toEqual(null);
+  });
+
+  test('should allow deserialized options', async () => {
+    const inputConfig = {jestConfig: 'deserialized'};
+    const {config, configPath} = await readInitialOptions(undefined, {
+      packageRootOrConfig: inputConfig as Config.InitialOptions,
+      parentConfigDirname: process.cwd(),
+    });
+    expect(config).toEqual({...inputConfig, rootDir: process.cwd()});
+    expect(configPath).toEqual(null);
+  });
+
+  test('should be able to skip config reading, instead read from cwd', async () => {
+    const expectedConfigFile = resolveFixture(
+      'json-config',
+      'jest.config.json',
+    );
+    jest.spyOn(process, 'cwd').mockReturnValue(resolveFixture('json-config'));
+    const {config, configPath} = await readInitialOptions(
+      resolveFixture('js-config', 'jest.config.js'),
+      {
+        readFromCwdInstead: true,
+      },
+    );
+    expect(config).toEqual({
+      jestConfig: 'jest.config.json',
+      rootDir: path.dirname(expectedConfigFile),
+    });
+    expect(configPath).toEqual(expectedConfigFile);
+  });
+
+  test('should give an error when there are multiple config files', async () => {
+    const cwd = resolveFixture('multiple-config-files');
+    jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const error: Error = await readInitialOptions().catch(error => error);
+    expect(error.message).toContain('Multiple configurations found');
+    expect(error.message).toContain(
+      resolveFixture('multiple-config-files', 'jest.config.js'),
+    );
+    expect(error.message).toContain(
+      resolveFixture('multiple-config-files', 'jest.config.json'),
+    );
+  });
+
+  test('should be able to ignore multiple config files error', async () => {
+    const cwd = resolveFixture('multiple-config-files');
+    jest.spyOn(process, 'cwd').mockReturnValue(cwd);
+    const {config, configPath} = await readInitialOptions(undefined, {
+      skipMultipleConfigError: true,
+    });
+    expect(config).toEqual({
+      jestConfig: 'jest.config.js',
+      rootDir: resolveFixture('multiple-config-files'),
+    });
+    expect(configPath).toEqual(
+      resolveFixture('multiple-config-files', 'jest.config.js'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Add `readInitialOptions` function to the jest-config package. This helper function can be useful for consumers of the jest programmatic API. It exposes the functionality that jest uses to read config from different sources.

## Test plan

I've added integration tests to the jest-config package. I couldn't add tests for a `jest.config.mjs` file, because it kept being read as a cjs file. I think this has to do with babel transforming.

To add a test for a `jest.config.ts` file, I had to enable `--experimental-vm-modules` to run jest on jest. If you see problems with this, I can also remove the `jest.config.ts` test altogether (or we can fix it somehow?)
