### PR TITLE
chore: use a single root tsconfig for type tests

### DIFF
--- a/packages/expect-utils/__typetests__/tsconfig.json
+++ b/packages/expect-utils/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/expect/__typetests__/tsconfig.json
+++ b/packages/expect/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-expect/__typetests__/tsconfig.json
+++ b/packages/jest-expect/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-mock/__typetests__/tsconfig.json
+++ b/packages/jest-mock/__typetests__/tsconfig.json
@@ -1,11 +1,6 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.typetest.json",
   "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
     "types": ["node"]
   },
   "include": ["./**/*"]

--- a/packages/jest-reporters/__typetests__/tsconfig.json
+++ b/packages/jest-reporters/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-resolve/__typetests__/tsconfig.json
+++ b/packages/jest-resolve/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-runner/__typetests__/tsconfig.json
+++ b/packages/jest-runner/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-snapshot/__typetests__/tsconfig.json
+++ b/packages/jest-snapshot/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-types/__typetests__/tsconfig.json
+++ b/packages/jest-types/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/packages/jest-worker/__typetests__/tsconfig.json
+++ b/packages/jest-worker/__typetests__/tsconfig.json
@@ -1,11 +1,6 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.typetest.json",
   "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
     "types": ["node"]
   },
   "include": ["./**/*"]

--- a/packages/jest/__typetests__/tsconfig.json
+++ b/packages/jest/__typetests__/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "extends": "../../../tsconfig.json",
-  "compilerOptions": {
-    "composite": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "skipLibCheck": true,
-
-    "types": []
-  },
+  "extends": "../../../tsconfig.typetest.json",
   "include": ["./**/*"]
 }

--- a/tsconfig.typetest.json
+++ b/tsconfig.typetest.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "skipLibCheck": true,
+
+    "types": []
+  }
+}


### PR DESCRIPTION
## Summary

Let’s use a single root tsconfig for type tests as well? Easier to maintain and there is no need to copy the file around.

## Test plan

Green CI.