### PR TITLE
docs: simplify example repo name

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-25.x/Webpack.md
+++ b/website/versioned_docs/version-25.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-25.x/Webpack.md
+++ b/website/versioned_docs/version-25.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-25.x/Webpack.md
+++ b/website/versioned_docs/version-25.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-26.x/Webpack.md
+++ b/website/versioned_docs/version-26.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-26.x/Webpack.md
+++ b/website/versioned_docs/version-26.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-26.x/Webpack.md
+++ b/website/versioned_docs/version-26.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-27.x/Webpack.md
+++ b/website/versioned_docs/version-27.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-27.x/Webpack.md
+++ b/website/versioned_docs/version-27.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-27.x/Webpack.md
+++ b/website/versioned_docs/version-27.x/Webpack.md
@@ -232,4 +232,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-28.x/Webpack.md
+++ b/website/versioned_docs/version-28.x/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-28.x/Webpack.md
+++ b/website/versioned_docs/version-28.x/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-28.x/Webpack.md
+++ b/website/versioned_docs/version-28.x/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-29.0/Webpack.md
+++ b/website/versioned_docs/version-29.0/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-29.0/Webpack.md
+++ b/website/versioned_docs/version-29.0/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-29.0/Webpack.md
+++ b/website/versioned_docs/version-29.0/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-29.1/Webpack.md
+++ b/website/versioned_docs/version-29.1/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).

--- a/website/versioned_docs/version-29.1/Webpack.md
+++ b/website/versioned_docs/version-29.1/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_webpack_example).
+For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).

--- a/website/versioned_docs/version-29.1/Webpack.md
+++ b/website/versioned_docs/version-29.1/Webpack.md
@@ -235,4 +235,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 
 :::
 
-For an example of how to use Jest with Webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).
+For an example of how to use Jest with webpack with React, you can view one [here](https://github.com/jenniferabowd/jest_webpack_example).


### PR DESCRIPTION
## Summary
I wrote this VERY convoluted example 5 years ago. I'm hoping to work on modernizing this example and simplifying it. I don't think this needs a server and redux. The name of the repo certainly doesn't need to be this long. So I updated the repo name and now I'm updating the docs to properly link to the new repo.

## Test plan
Not applicable. This is updating a link in some documentation.
