### PR TITLE
chore: run eslint with type information on CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,6 +54,8 @@ jobs:
         run: yarn typecheck:examples
       - name: typecheck tests
         run: yarn typecheck:tests
+      - name: run ESLint with type info
+        run: yarn lint-ts-files
 
   lint:
     name: Lint

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:896:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:891:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;
@@ -71,7 +71,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:896:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:891:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "lint:prettier-script": "prettier . \"!**/*.{js,jsx,cjs,mjs,ts,tsx}\" --cache",
     "lint:prettier": "yarn lint:prettier-script --write",
     "lint:prettier:ci": "yarn lint:prettier-script --check",
+    "lint-ts-files": "node scripts/lintTs.mjs",
     "remove-examples": "node ./scripts/remove-examples.mjs",
     "test-ci-partial": "yarn test-ci-partial:parallel -i",
     "test-ci-partial:parallel": "yarn jest --color --config jest.config.ci.mjs",

--- a/packages/babel-jest/src/__tests__/getCacheKey.test.ts
+++ b/packages/babel-jest/src/__tests__/getCacheKey.test.ts
@@ -52,7 +52,8 @@ describe('getCacheKey', () => {
       readFileSync: () => 'new this file',
     }));
 
-    const {createTransformer}: typeof import('../index') = require('../index');
+    const {createTransformer} =
+      require('../index') as typeof import('../index');
 
     const newCacheKey = createTransformer().getCacheKey!(
       sourceText,
@@ -65,7 +66,7 @@ describe('getCacheKey', () => {
 
   test('if `babelOptions.options` value is changing', () => {
     jest.doMock('../loadBabelConfig', () => {
-      const babel: typeof import('@babel/core') = require('@babel/core');
+      const babel = require('@babel/core') as typeof import('@babel/core');
 
       return {
         loadPartialConfig: (options: BabelTransformOptions) => ({
@@ -75,7 +76,8 @@ describe('getCacheKey', () => {
       };
     });
 
-    const {createTransformer}: typeof import('../index') = require('../index');
+    const {createTransformer} =
+      require('../index') as typeof import('../index');
 
     const newCacheKey = createTransformer().getCacheKey!(
       sourceText,
@@ -117,7 +119,7 @@ describe('getCacheKey', () => {
 
   test('if `babelOptions.config` value is changing', () => {
     jest.doMock('../loadBabelConfig', () => {
-      const babel: typeof import('@babel/core') = require('@babel/core');
+      const babel = require('@babel/core') as typeof import('@babel/core');
 
       return {
         loadPartialConfig: (options: BabelTransformOptions) => ({
@@ -127,7 +129,8 @@ describe('getCacheKey', () => {
       };
     });
 
-    const {createTransformer}: typeof import('../index') = require('../index');
+    const {createTransformer} =
+      require('../index') as typeof import('../index');
 
     const newCacheKey = createTransformer().getCacheKey!(
       sourceText,
@@ -140,7 +143,7 @@ describe('getCacheKey', () => {
 
   test('if `babelOptions.babelrc` value is changing', () => {
     jest.doMock('../loadBabelConfig', () => {
-      const babel: typeof import('@babel/core') = require('@babel/core');
+      const babel = require('@babel/core') as typeof import('@babel/core');
 
       return {
         loadPartialConfig: (options: BabelTransformOptions) => ({
@@ -150,7 +153,8 @@ describe('getCacheKey', () => {
       };
     });
 
-    const {createTransformer}: typeof import('../index') = require('../index');
+    const {createTransformer} =
+      require('../index') as typeof import('../index');
 
     const newCacheKey = createTransformer().getCacheKey!(
       sourceText,

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -51,7 +51,7 @@ function addIstanbulInstrumentation(
     const copiedBabelOptions: TransformOptions = {...babelOptions};
     copiedBabelOptions.auxiliaryCommentBefore = ' istanbul ignore next ';
     // Copied from jest-runtime transform.js
-    copiedBabelOptions.plugins = (copiedBabelOptions.plugins || []).concat([
+    copiedBabelOptions.plugins = (copiedBabelOptions.plugins ?? []).concat([
       [
         babelIstanbulPlugin,
         {
@@ -76,7 +76,7 @@ function getCacheKeyFromConfig(
 ): string {
   const {config, configString, instrument} = transformOptions;
 
-  const configPath = [babelOptions.config || '', babelOptions.babelrc || ''];
+  const configPath = [babelOptions.config ?? '', babelOptions.babelrc ?? ''];
 
   return createHash('sha256')
     .update(THIS_FILE)
@@ -93,9 +93,9 @@ function getCacheKeyFromConfig(
     .update('\0', 'utf8')
     .update(instrument ? 'instrument' : '')
     .update('\0', 'utf8')
-    .update(process.env.NODE_ENV || '')
+    .update(process.env.NODE_ENV ?? '')
     .update('\0', 'utf8')
-    .update(process.env.BABEL_ENV || '')
+    .update(process.env.BABEL_ENV ?? '')
     .update('\0', 'utf8')
     .update(process.version)
     .digest('hex')

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -142,7 +142,7 @@ FUNCTIONS.mock = args => {
       let scope = id.scope;
 
       while (scope !== parentScope) {
-        if (scope.bindings[name]) {
+        if (scope.bindings[name] != null) {
           found = true;
           break;
         }

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -114,10 +114,10 @@ const IDVisitor = {
   ],
 };
 
-const FUNCTIONS: Record<
+const FUNCTIONS = Object.create(null) as Record<
   string,
   <T extends Node>(args: Array<NodePath<T>>) => boolean
-> = Object.create(null);
+>;
 
 FUNCTIONS.mock = args => {
   if (args.length === 1) {

--- a/packages/diff-sequences/src/__tests__/index.property.test.ts
+++ b/packages/diff-sequences/src/__tests__/index.property.test.ts
@@ -27,7 +27,7 @@ const findCommonItems = (a: Array<string>, b: Array<string>): Array<string> => {
 const extractCount = (data: Array<string>): Map<string, number> => {
   const countPerChar = new Map<string, number>();
   for (const item of data) {
-    const currentCount = countPerChar.get(item) || 0;
+    const currentCount = countPerChar.get(item) ?? 0;
     countPerChar.set(item, currentCount + 1);
   }
   return countPerChar;
@@ -93,7 +93,7 @@ it('should have at most the same number of each character as its inputs', () => 
       const commonCount = extractCount(commonItems);
       const aCount = extractCount(a);
       for (const [item, count] of commonCount) {
-        const countOfItemInA = aCount.get(item) || 0;
+        const countOfItemInA = aCount.get(item) ?? 0;
         expect(countOfItemInA).toBeGreaterThanOrEqual(count);
       }
     }),

--- a/packages/diff-sequences/src/__tests__/index.test.ts
+++ b/packages/diff-sequences/src/__tests__/index.test.ts
@@ -15,7 +15,8 @@ describe('invalid arg', () => {
   describe('length', () => {
     test('is not a number', () => {
       expect(() => {
-        diff('0' as any, 0, isCommon, foundSubsequence);
+        // @ts-expect-error: Testing runtime errors here
+        diff('0', 0, isCommon, foundSubsequence);
       }).toThrow(/aLength/);
     });
     test('Infinity is not a safe integer', () => {
@@ -49,12 +50,14 @@ describe('invalid arg', () => {
   describe('callback', () => {
     test('null is not a function', () => {
       expect(() => {
-        diff(0, 0, null as any, foundSubsequence);
+        // @ts-expect-error: Testing runtime errors here
+        diff(0, 0, null, foundSubsequence);
       }).toThrow(/isCommon/);
     });
     test('undefined is not a function', () => {
       expect(() => {
-        diff(0, 0, isCommon, undefined as any);
+        // @ts-expect-error: Testing runtime errors here
+        diff(0, 0, isCommon, undefined);
       }).toThrow(/foundSubsequence/);
     });
   });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -211,9 +211,7 @@ function keys(obj: object, hasKey: (obj: object, key: string) => boolean) {
   }
   return keys.concat(
     (Object.getOwnPropertySymbols(obj) as Array<any>).filter(
-      symbol =>
-        (Object.getOwnPropertyDescriptor(obj, symbol) as PropertyDescriptor)
-          .enumerable,
+      symbol => Object.getOwnPropertyDescriptor(obj, symbol)!.enumerable,
     ),
   );
 }

--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -458,9 +458,9 @@ matchers.forEach(toThrow => {
           err = new Err('async apple');
         }
         if (resolve) {
-          return await Promise.resolve(err || 'apple');
+          return Promise.resolve(err || 'apple');
         } else {
-          return await Promise.reject(err || 'apple');
+          return Promise.reject(err || 'apple');
         }
       };
 

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -296,7 +296,7 @@ class StringMatching extends AsymmetricMatcher<RegExp> {
 }
 
 class CloseTo extends AsymmetricMatcher<number> {
-  private precision: number;
+  private readonly precision: number;
 
   constructor(sample: number, precision = 2, inverse = false) {
     if (!isA('Number', sample)) {

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -39,7 +39,6 @@ import toThrowMatchers, {
   createMatcher as createThrowMatcher,
 } from './toThrowMatchers';
 import type {
-  AsyncExpectationResult,
   Expect,
   ExpectationResult,
   MatcherContext,
@@ -363,19 +362,16 @@ const makeThrowingMatcher = (
             })();
 
       if (isPromise(potentialResult)) {
-        const asyncResult = potentialResult as AsyncExpectationResult;
         const asyncError = new JestAssertionError();
         if (Error.captureStackTrace) {
           Error.captureStackTrace(asyncError, throwingMatcher);
         }
 
-        return asyncResult
+        return potentialResult
           .then(aResult => processResult(aResult, asyncError))
           .catch(handleError);
       } else {
-        const syncResult = potentialResult as SyncExpectationResult;
-
-        return processResult(syncResult);
+        return processResult(potentialResult);
       }
     } catch (error: any) {
       return handleError(error);

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -1061,14 +1061,14 @@ export default async function normalize(
   );
   newOptions.maxWorkers = getMaxWorkers(argv, options);
 
-  if (newOptions.testRegex!.length && options.testMatch) {
+  if (newOptions.testRegex.length > 0 && options.testMatch) {
     throw createConfigError(
       `  Configuration options ${chalk.bold('testMatch')} and` +
         ` ${chalk.bold('testRegex')} cannot be used together.`,
     );
   }
 
-  if (newOptions.testRegex!.length && !options.testMatch) {
+  if (newOptions.testRegex.length > 0 && !options.testMatch) {
     // Prevent the default testMatch conflicting with any explicitly
     // configured `testRegex` value
     newOptions.testMatch = [];
@@ -1101,7 +1101,7 @@ export default async function normalize(
         if (
           micromatch(
             [replacePathSepForGlob(path.relative(options.rootDir, filename))],
-            newOptions.collectCoverageFrom!,
+            newOptions.collectCoverageFrom,
           ).length === 0
         ) {
           return patterns;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -108,8 +108,8 @@ const mergeGlobalsWithPreset = (
   options: Config.InitialOptions,
   preset: Config.InitialOptions,
 ) => {
-  if (options['globals'] && preset['globals']) {
-    options['globals'] = merge(preset['globals'], options['globals']);
+  if (options.globals && preset.globals) {
+    options.globals = merge(preset.globals, options.globals);
   }
 };
 

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -48,7 +48,7 @@ export const resolve = (
     );
   }
   /// can cast as string since nulls will be thrown
-  return module as string;
+  return module!;
 };
 
 export const escapeGlobCharacters = (path: string): string =>

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -106,10 +106,7 @@ export const _replaceRootDirTags = <T extends ReplaceRootDirConfigValues>(
         return config;
       }
 
-      return _replaceRootDirInObject(
-        rootDir,
-        config as ReplaceRootDirConfigObj,
-      ) as T;
+      return _replaceRootDirInObject(rootDir, config) as T;
     case 'string':
       return replaceRootDirInPath(rootDir, config) as T;
   }

--- a/packages/jest-console/src/BufferedConsole.ts
+++ b/packages/jest-console/src/BufferedConsole.ts
@@ -19,7 +19,7 @@ import type {
 } from './types';
 
 export default class BufferedConsole extends Console {
-  private _buffer: ConsoleBuffer = [];
+  private readonly _buffer: ConsoleBuffer = [];
   private _counters: LogCounters = {};
   private _timers: LogTimers = {};
   private _groupDepth = 0;

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -15,9 +15,9 @@ import type {LogCounters, LogMessage, LogTimers, LogType} from './types';
 type Formatter = (type: LogType, message: LogMessage) => string;
 
 export default class CustomConsole extends Console {
-  private _stdout: NodeJS.WriteStream;
-  private _stderr: NodeJS.WriteStream;
-  private _formatBuffer: Formatter;
+  private readonly _stdout: NodeJS.WriteStream;
+  private readonly _stderr: NodeJS.WriteStream;
+  private readonly _formatBuffer: Formatter;
   private _counters: LogCounters = {};
   private _timers: LogTimers = {};
   private _groupDepth = 0;

--- a/packages/jest-core/src/FailedTestsInteractiveMode.ts
+++ b/packages/jest-core/src/FailedTestsInteractiveMode.ts
@@ -28,7 +28,7 @@ export default class FailedTestsInteractiveMode {
   private _testAssertions: Array<AssertionLocation> = [];
   private _updateTestRunnerConfig?: RunnerUpdateFunction;
 
-  constructor(private _pipe: NodeJS.WritableStream) {}
+  constructor(private readonly _pipe: NodeJS.WritableStream) {}
 
   isActive(): boolean {
     return this._isActive;

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -55,9 +55,9 @@ const hasSCM = (changedFilesInfo: ChangedFiles) => {
 };
 
 export default class SearchSource {
-  private _context: TestContext;
+  private readonly _context: TestContext;
   private _dependencyResolver: DependencyResolver | null;
-  private _testPathCases: TestPathCases = [];
+  private readonly _testPathCases: TestPathCases = [];
 
   constructor(context: TestContext) {
     const {config} = context;

--- a/packages/jest-core/src/SnapshotInteractiveMode.ts
+++ b/packages/jest-core/src/SnapshotInteractiveMode.ts
@@ -14,7 +14,7 @@ import {KEYS} from 'jest-watcher';
 const {ARROW, CLEAR} = specialChars;
 
 export default class SnapshotInteractiveMode {
-  private _pipe: NodeJS.WritableStream;
+  private readonly _pipe: NodeJS.WritableStream;
   private _isActive: boolean;
   private _updateTestRunnerConfig!: (
     assertion: AssertionLocation | null,

--- a/packages/jest-core/src/__tests__/watchFileChanges.test.ts
+++ b/packages/jest-core/src/__tests__/watchFileChanges.test.ts
@@ -167,7 +167,7 @@ describe('Watch mode flows with changed files', () => {
 });
 
 class MockStdin {
-  private _callbacks: Array<unknown>;
+  private readonly _callbacks: Array<unknown>;
 
   constructor() {
     this._callbacks = [];

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -242,7 +242,7 @@ const runWatch = async (
   if (hasDeprecationWarnings) {
     try {
       await handleDeprecationWarnings(outputStream, process.stdin);
-      return watch(
+      return await watch(
         globalConfig,
         contexts,
         outputStream,

--- a/packages/jest-core/src/plugins/TestPathPattern.ts
+++ b/packages/jest-core/src/plugins/TestPathPattern.ts
@@ -16,7 +16,7 @@ import TestPathPatternPrompt from '../TestPathPatternPrompt';
 import activeFilters from '../lib/activeFiltersMessage';
 
 class TestPathPatternPlugin extends BaseWatchPlugin {
-  private _prompt: Prompt;
+  private readonly _prompt: Prompt;
   isInternal: true;
 
   constructor(options: {stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream}) {

--- a/packages/jest-core/src/plugins/UpdateSnapshotsInteractive.ts
+++ b/packages/jest-core/src/plugins/UpdateSnapshotsInteractive.ts
@@ -13,7 +13,7 @@ import {BaseWatchPlugin, JestHookSubscriber, UsageData} from 'jest-watcher';
 import SnapshotInteractiveMode from '../SnapshotInteractiveMode';
 
 class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
-  private _snapshotInteractiveMode: SnapshotInteractiveMode =
+  private readonly _snapshotInteractiveMode: SnapshotInteractiveMode =
     new SnapshotInteractiveMode(this._stdout);
   private _failedSnapshotTestAssertions: Array<AssertionLocation> = [];
   isInternal = true as const;

--- a/packages/jest-diff/src/getAlignedDiffs.ts
+++ b/packages/jest-diff/src/getAlignedDiffs.ts
@@ -30,10 +30,10 @@ const concatenateRelevantDiffs = (
 
 // Encapsulate change lines until either a common newline or the end.
 class ChangeBuffer {
-  private op: number;
+  private readonly op: number;
   private line: Array<Diff>; // incomplete line
   private lines: Array<Diff>; // complete lines
-  private changeColor: DiffOptionsColor;
+  private readonly changeColor: DiffOptionsColor;
 
   constructor(op: number, changeColor: DiffOptionsColor) {
     this.op = op;
@@ -114,9 +114,9 @@ class ChangeBuffer {
 
 // Encapsulate common and change lines.
 class CommonBuffer {
-  private deleteBuffer: ChangeBuffer;
-  private insertBuffer: ChangeBuffer;
-  private lines: Array<Diff>;
+  private readonly deleteBuffer: ChangeBuffer;
+  private readonly insertBuffer: ChangeBuffer;
+  private readonly lines: Array<Diff>;
 
   constructor(deleteBuffer: ChangeBuffer, insertBuffer: ChangeBuffer) {
     this.deleteBuffer = deleteBuffer;

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -67,7 +67,7 @@ const MS_IN_A_YEAR = 31536000000;
 export default class FakeTimers<TimerRef = unknown> {
   private _cancelledTicks!: Record<string, boolean>;
   private readonly _config: StackTraceConfig;
-  private _disposed?: boolean;
+  private _disposed: boolean;
   private _fakeTimerAPIs!: FakeTimerAPI;
   private _fakingTime = false;
   private _global: typeof globalThis;
@@ -113,6 +113,8 @@ export default class FakeTimers<TimerRef = unknown> {
       setInterval: global.setInterval,
       setTimeout: global.setTimeout,
     };
+
+    this._disposed = false;
 
     this.reset();
   }
@@ -510,11 +512,13 @@ export default class FakeTimers<TimerRef = unknown> {
     });
 
     this._timerAPIs.setImmediate(() => {
-      if (this._immediates.find(x => x.uuid === uuid)) {
-        try {
-          callback.apply(null, args);
-        } finally {
-          this._fakeClearImmediate(uuid);
+      if (!this._disposed) {
+        if (this._immediates.find(x => x.uuid === uuid)) {
+          try {
+            callback.apply(null, args);
+          } finally {
+            this._fakeClearImmediate(uuid);
+          }
         }
       }
     });

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -66,20 +66,20 @@ const MS_IN_A_YEAR = 31536000000;
 
 export default class FakeTimers<TimerRef = unknown> {
   private _cancelledTicks!: Record<string, boolean>;
-  private _config: StackTraceConfig;
+  private readonly _config: StackTraceConfig;
   private _disposed?: boolean;
   private _fakeTimerAPIs!: FakeTimerAPI;
   private _fakingTime = false;
   private _global: typeof globalThis;
   private _immediates!: Array<Tick>;
-  private _maxLoops: number;
-  private _moduleMocker: ModuleMocker;
+  private readonly _maxLoops: number;
+  private readonly _moduleMocker: ModuleMocker;
   private _now!: number;
   private _ticks!: Array<Tick>;
-  private _timerAPIs: TimerAPI;
+  private readonly _timerAPIs: TimerAPI;
   private _timers!: Map<string, Timer>;
   private _uuidCounter: number;
-  private _timerConfig: TimerConfig<TimerRef>;
+  private readonly _timerConfig: TimerConfig<TimerRef>;
 
   constructor({
     global,

--- a/packages/jest-fake-timers/src/modernFakeTimers.ts
+++ b/packages/jest-fake-timers/src/modernFakeTimers.ts
@@ -17,10 +17,10 @@ import {formatStackTrace} from 'jest-message-util';
 
 export default class FakeTimers {
   private _clock!: InstalledClock;
-  private _config: Config.ProjectConfig;
+  private readonly _config: Config.ProjectConfig;
   private _fakingTime: boolean;
-  private _global: typeof globalThis;
-  private _fakeTimers: FakeTimerWithContext;
+  private readonly _global: typeof globalThis;
+  private readonly _fakeTimers: FakeTimerWithContext;
 
   constructor({
     global,

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -217,7 +217,7 @@ class HasteMap extends EventEmitter implements IHasteMap {
   private _buildPromise: Promise<InternalHasteMapObject> | null = null;
   private _cachePath = '';
   private _changeInterval?: ReturnType<typeof setInterval>;
-  private _console: Console;
+  private readonly _console: Console;
   private _isWatchmanInstalledPromise: Promise<boolean> | null = null;
   private _options: InternalOptions;
   private _watchers: Array<Watcher> = [];
@@ -797,7 +797,7 @@ class HasteMap extends EventEmitter implements IHasteMap {
     };
 
     try {
-      return crawl(crawlerOptions).catch(retry);
+      return await crawl(crawlerOptions);
     } catch (error: any) {
       return retry(error);
     }

--- a/packages/jest-haste-map/src/watchers/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/watchers/FSEventsWatcher.ts
@@ -46,7 +46,7 @@ export class FSEventsWatcher extends EventEmitter {
   readonly hasIgnore: boolean;
   readonly doIgnore: (path: string) => boolean;
   readonly fsEventsWatchStopper: () => Promise<void>;
-  private _tracked: Set<string>;
+  private readonly _tracked: Set<string>;
 
   static isSupported(): boolean {
     return fsevents !== null;

--- a/packages/jest-jasmine2/src/PCancelable.ts
+++ b/packages/jest-jasmine2/src/PCancelable.ts
@@ -15,7 +15,7 @@ class CancelError extends Error {
 export default class PCancelable<T> implements PromiseLike<T> {
   private _pending = true;
   private _canceled = false;
-  private _promise: Promise<T>;
+  private readonly _promise: Promise<T>;
   private _cancel?: () => void;
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   private _reject: (reason?: unknown) => void = () => {};

--- a/packages/jest-jasmine2/src/jasmine/Suite.ts
+++ b/packages/jest-jasmine2/src/jasmine/Suite.ts
@@ -159,7 +159,7 @@ export default class Suite {
   }
 
   getResult() {
-    this.result.status! = this.status();
+    this.result.status = this.status();
     return this.result;
   }
 

--- a/packages/jest-jasmine2/src/jasmine/spyRegistry.ts
+++ b/packages/jest-jasmine2/src/jasmine/spyRegistry.ts
@@ -64,7 +64,7 @@ export default class SpyRegistry {
   clearSpies: () => void;
   respy: unknown;
 
-  private _spyOnProperty: (
+  private readonly _spyOnProperty: (
     obj: Record<string, Spy>,
     propertyName: string,
     accessType: keyof PropertyDescriptor,

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -19,14 +19,14 @@ import type {Reporter, RunDetails} from './types';
 type Microseconds = number;
 
 export default class Jasmine2Reporter implements Reporter {
-  private _testResults: Array<AssertionResult>;
-  private _globalConfig: Config.GlobalConfig;
-  private _config: Config.ProjectConfig;
-  private _currentSuites: Array<string>;
+  private readonly _testResults: Array<AssertionResult>;
+  private readonly _globalConfig: Config.GlobalConfig;
+  private readonly _config: Config.ProjectConfig;
+  private readonly _currentSuites: Array<string>;
   private _resolve: any;
-  private _resultsPromise: Promise<TestResult>;
-  private _startTimes: Map<string, Microseconds>;
-  private _testPath: string;
+  private readonly _resultsPromise: Promise<TestResult>;
+  private readonly _startTimes: Map<string, Microseconds>;
+  private readonly _testPath: string;
 
   constructor(
     globalConfig: Config.GlobalConfig,

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -16,7 +16,7 @@ const tick = promisify(setImmediate);
 
 export default class LeakDetector {
   private _isReferenceBeingHeld: boolean;
-  private _finalizationRegistry?: FinalizationRegistry<undefined>;
+  private readonly _finalizationRegistry?: FinalizationRegistry<undefined>;
 
   constructor(value: unknown) {
     if (isPrimitive(value)) {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -463,7 +463,7 @@ function isReadonlyProp(object: unknown, prop: string): boolean {
 }
 
 export class ModuleMocker {
-  private _environmentGlobal: typeof globalThis;
+  private readonly _environmentGlobal: typeof globalThis;
   private _mockState: WeakMap<Mock, MockFunctionState>;
   private _mockConfigRegistry: WeakMap<Function, MockFunctionConfig>;
   private _spyState: Set<() => void>;

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -37,11 +37,11 @@ const FAIL_COLOR = chalk.bold.red;
 const RUNNING_TEST_COLOR = chalk.bold.dim;
 
 export default class CoverageReporter extends BaseReporter {
-  private _context: ReporterContext;
-  private _coverageMap: istanbulCoverage.CoverageMap;
-  private _globalConfig: Config.GlobalConfig;
-  private _sourceMapStore: libSourceMaps.MapStore;
-  private _v8CoverageResults: Array<V8CoverageResult>;
+  private readonly _context: ReporterContext;
+  private readonly _coverageMap: istanbulCoverage.CoverageMap;
+  private readonly _globalConfig: Config.GlobalConfig;
+  private readonly _sourceMapStore: libSourceMaps.MapStore;
+  private readonly _v8CoverageResults: Array<V8CoverageResult>;
 
   static readonly filename = __filename;
 

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -33,11 +33,11 @@ const TITLE_BULLET = chalk.bold('\u25cf ');
 
 export default class DefaultReporter extends BaseReporter {
   private _clear: string; // ANSI clear sequence for the last printed status
-  private _err: write;
+  private readonly _err: write;
   protected _globalConfig: Config.GlobalConfig;
-  private _out: write;
-  private _status: Status;
-  private _bufferedOutput: Set<FlushBufferedOutput>;
+  private readonly _out: write;
+  private readonly _status: Status;
+  private readonly _bufferedOutput: Set<FlushBufferedOutput>;
 
   static readonly filename = __filename;
 

--- a/packages/jest-reporters/src/NotifyReporter.ts
+++ b/packages/jest-reporters/src/NotifyReporter.ts
@@ -19,8 +19,8 @@ const isDarwin = process.platform === 'darwin';
 const icon = path.resolve(__dirname, '../assets/jest_logo.png');
 
 export default class NotifyReporter extends BaseReporter {
-  private _notifier = loadNotifier();
-  private _globalConfig: Config.GlobalConfig;
+  private readonly _notifier = loadNotifier();
+  private readonly _globalConfig: Config.GlobalConfig;
   private _context: ReporterContext;
 
   static readonly filename = __filename;

--- a/packages/jest-reporters/src/Status.ts
+++ b/packages/jest-reporters/src/Status.ts
@@ -160,7 +160,7 @@ export default class Status {
       return {clear: '', content: ''};
     }
 
-    const width: number = process.stdout.columns!;
+    const width = process.stdout.columns;
     let content = '\n';
     this._currentTests.get().forEach(record => {
       if (record) {

--- a/packages/jest-reporters/src/Status.ts
+++ b/packages/jest-reporters/src/Status.ts
@@ -73,7 +73,7 @@ type Cache = {
 export default class Status {
   private _cache: Cache | null;
   private _callback?: () => void;
-  private _currentTests: CurrentTestList;
+  private readonly _currentTests: CurrentTestList;
   private _currentTestCases: Array<{
     test: Test;
     testCaseResult: TestCaseResult;

--- a/packages/jest-reporters/src/SummaryReporter.ts
+++ b/packages/jest-reporters/src/SummaryReporter.ts
@@ -53,7 +53,7 @@ const {npm_config_user_agent, npm_lifecycle_event, npm_lifecycle_script} =
 
 export default class SummaryReporter extends BaseReporter {
   private _estimatedTime: number;
-  private _globalConfig: Config.GlobalConfig;
+  private readonly _globalConfig: Config.GlobalConfig;
 
   static readonly filename = __filename;
 

--- a/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
+++ b/packages/jest-reporters/src/__tests__/NotifyReporter.test.ts
@@ -248,7 +248,7 @@ describe('node-notifier is an optional dependency', () => {
     const mockNodeNotifier = {notify: jest.fn()};
     jest.doMock('node-notifier', () => mockNodeNotifier);
     const result = ctor();
-    expect(result['_notifier']).toBe(mockNodeNotifier);
+    expect(result._notifier).toBe(mockNodeNotifier);
   });
 });
 

--- a/packages/jest-reporters/src/wrapAnsiString.ts
+++ b/packages/jest-reporters/src/wrapAnsiString.ts
@@ -23,7 +23,7 @@ export default function wrapAnsiString(
 
   while ((match = ANSI_REGEXP.exec(string))) {
     const ansi = match[0];
-    const index = match['index'];
+    const index = match.index;
     if (index != lastIndex) {
       tokens.push(['string', string.slice(lastIndex, index)]);
     }

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -20,9 +20,9 @@ export type ResolvedModule = {
  * to retrieve a list of all transitive inverse dependencies.
  */
 export class DependencyResolver {
-  private _hasteFS: IHasteFS;
-  private _resolver: Resolver;
-  private _snapshotResolver: SnapshotResolver;
+  private readonly _hasteFS: IHasteFS;
+  private readonly _resolver: Resolver;
+  private readonly _snapshotResolver: SnapshotResolver;
 
   constructor(
     resolver: Resolver,

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -89,7 +89,7 @@ export default class Resolver {
     error: unknown,
   ): ModuleNotFoundError | null {
     if (error instanceof ModuleNotFoundError) {
-      return error as ModuleNotFoundError;
+      return error;
     }
 
     const casted = error as ModuleNotFoundError;

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -295,7 +295,7 @@ export default class Resolver {
         return name;
       }
 
-      return await Resolver.findNodeModuleAsync(name, {
+      return Resolver.findNodeModuleAsync(name, {
         basedir: dirname,
         conditions: options?.conditions,
         extensions,
@@ -636,12 +636,7 @@ export default class Resolver {
     );
     return isModuleResolved
       ? this.getModule(moduleName)
-      : await this._getVirtualMockPathAsync(
-          virtualMocks,
-          from,
-          moduleName,
-          options,
-        );
+      : this._getVirtualMockPathAsync(virtualMocks, from, moduleName, options);
   }
 
   private _getMockPath(from: string, moduleName: string): string | null {
@@ -655,7 +650,7 @@ export default class Resolver {
     moduleName: string,
   ): Promise<string | null> {
     return !this.isCoreModule(moduleName)
-      ? await this.getMockModuleAsync(from, moduleName)
+      ? this.getMockModuleAsync(from, moduleName)
       : null;
   }
 
@@ -683,7 +678,7 @@ export default class Resolver {
     return virtualMocks.get(virtualMockPath)
       ? virtualMockPath
       : moduleName
-      ? await this.resolveModuleAsync(from, moduleName, options)
+      ? this.resolveModuleAsync(from, moduleName, options)
       : from;
   }
 

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -47,9 +47,9 @@ export default class TestRunner extends EmittingTestRunner {
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
-    return await (options.serial
+    return options.serial
       ? this.#createInBandTestRun(tests, watcher)
-      : this.#createParallelTestRun(tests, watcher));
+      : this.#createParallelTestRun(tests, watcher);
   }
 
   async #createInBandTestRun(tests: Array<Test>, watcher: TestWatcher) {

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -348,7 +348,7 @@ async function runTestInternal(
     }
 
     // Delay the resolution to allow log messages to be output.
-    return new Promise(resolve => {
+    return await new Promise(resolve => {
       setImmediate(() => resolve({leakDetector, result}));
     });
   } finally {

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -198,6 +198,16 @@ async function runTestInternal(
     path,
   );
 
+  let isTornDown = false;
+
+  const tearDownEnv = async () => {
+    if (!isTornDown) {
+      runtime.teardown();
+      await environment.teardown();
+      isTornDown = true;
+    }
+  };
+
   const start = Date.now();
 
   for (const path of projectConfig.setupFiles) {
@@ -347,13 +357,14 @@ async function runTestInternal(
       result.memoryUsage = process.memoryUsage().heapUsed;
     }
 
+    await tearDownEnv();
+
     // Delay the resolution to allow log messages to be output.
     return await new Promise(resolve => {
       setImmediate(() => resolve({leakDetector, result}));
     });
   } finally {
-    runtime.teardown();
-    await environment.teardown();
+    await tearDownEnv();
 
     sourcemapSupport.resetRetrieveHandlers();
   }

--- a/packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_require_resolve.test.ts
@@ -19,7 +19,7 @@ let createRuntime: (
 ) => Promise<Runtime & {__mockRootPath: string}>;
 
 const getTmpDir = async () =>
-  await fs.mkdtemp(path.join(os.tmpdir(), 'jest-resolve-test-'));
+  fs.mkdtemp(path.join(os.tmpdir(), 'jest-resolve-test-'));
 
 describe('Runtime require.resolve', () => {
   beforeEach(() => {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -171,7 +171,7 @@ export default class Runtime {
   private readonly _mockMetaDataCache: Map<string, MockMetadata<any>>;
   private _mockRegistry: Map<string, any>;
   private _isolatedMockRegistry: Map<string, any> | null;
-  private _moduleMockRegistry: Map<string, VMModule>;
+  private readonly _moduleMockRegistry: Map<string, VMModule>;
   private readonly _moduleMockFactories: Map<string, () => unknown>;
   private readonly _moduleMocker: ModuleMocker;
   private _isolatedModuleRegistry: ModuleRegistry | null;

--- a/packages/jest-snapshot/src/SnapshotResolver.ts
+++ b/packages/jest-snapshot/src/SnapshotResolver.ts
@@ -52,7 +52,7 @@ async function createSnapshotResolver(
   snapshotResolverPath?: string | null,
 ): Promise<SnapshotResolver> {
   return typeof snapshotResolverPath === 'string'
-    ? await createCustomSnapshotResolver(snapshotResolverPath, localRequire)
+    ? createCustomSnapshotResolver(snapshotResolverPath, localRequire)
     : createDefaultSnapshotResolver();
 }
 

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -33,13 +33,16 @@ const addSourceMapConsumer = (
   Object.defineProperties(callsite, {
     getColumnNumber: {
       value() {
-        return getPosition().column ?? getColumnNumber();
+        const value = getPosition().column;
+        return value == null || value === 0 ? getColumnNumber() : value;
       },
       writable: false,
     },
     getLineNumber: {
       value() {
-        return getPosition().line ?? getLineNumber();
+        const value = getPosition().line;
+
+        return value == null || value === 0 ? getLineNumber() : value;
       },
       writable: false,
     },

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -15,15 +15,15 @@ const addSourceMapConsumer = (
   callsite: callsites.CallSite,
   tracer: TraceMap,
 ) => {
-  const getLineNumber = callsite.getLineNumber;
-  const getColumnNumber = callsite.getColumnNumber;
+  const getLineNumber = callsite.getLineNumber.bind(callsite);
+  const getColumnNumber = callsite.getColumnNumber.bind(callsite);
   let position: ReturnType<typeof originalPositionFor> | null = null;
 
   function getPosition() {
     if (!position) {
       position = originalPositionFor(tracer, {
-        column: getColumnNumber.call(callsite) || -1,
-        line: getLineNumber.call(callsite) || -1,
+        column: getColumnNumber() || -1,
+        line: getLineNumber() || -1,
       });
     }
 

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -22,8 +22,8 @@ const addSourceMapConsumer = (
   function getPosition() {
     if (!position) {
       position = originalPositionFor(tracer, {
-        column: getColumnNumber() || -1,
-        line: getLineNumber() || -1,
+        column: getColumnNumber() ?? -1,
+        line: getLineNumber() ?? -1,
       });
     }
 
@@ -33,13 +33,13 @@ const addSourceMapConsumer = (
   Object.defineProperties(callsite, {
     getColumnNumber: {
       value() {
-        return getPosition().column || getColumnNumber.call(callsite);
+        return getPosition().column ?? getColumnNumber();
       },
       writable: false,
     },
     getLineNumber: {
       value() {
-        return getPosition().line || getLineNumber.call(callsite);
+        return getPosition().line ?? getLineNumber();
       },
       writable: false,
     },
@@ -52,9 +52,9 @@ export default function getCallsite(
 ): callsites.CallSite {
   const levelAfterThisCall = level + 1;
   const stack = callsites()[levelAfterThisCall];
-  const sourceMapFileName = sourceMaps?.get(stack.getFileName() || '');
+  const sourceMapFileName = sourceMaps?.get(stack.getFileName() ?? '');
 
-  if (sourceMapFileName) {
+  if (sourceMapFileName != null && sourceMapFileName !== '') {
     try {
       const sourceMap = readFileSync(sourceMapFileName, 'utf8');
       addSourceMapConsumer(stack, new TraceMap(sourceMap));

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -38,7 +38,7 @@ export type ShardOptions = {
  * is called to store/update this information on the cache map.
  */
 export default class TestSequencer {
-  private _cache: Map<TestContext, Cache> = new Map();
+  private readonly _cache: Map<TestContext, Cache> = new Map();
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -797,7 +797,7 @@ class ScriptTransformer {
       const cbResult = callback(module);
 
       if (isPromise(cbResult)) {
-        return waitForPromiseWithCleanup(cbResult, revertHook).then(
+        return await waitForPromiseWithCleanup(cbResult, revertHook).then(
           () => module,
         );
       }

--- a/packages/jest-watcher/src/JestHooks.ts
+++ b/packages/jest-watcher/src/JestHooks.ts
@@ -19,14 +19,14 @@ type AvailableHooks =
   | 'shouldRunTestSuite';
 
 class JestHooks {
-  private _listeners: {
+  private readonly _listeners: {
     onFileChange: Array<FileChange>;
     onTestRunComplete: Array<TestRunComplete>;
     shouldRunTestSuite: Array<ShouldRunTestSuite>;
   };
 
-  private _subscriber: JestHookSubscriber;
-  private _emitter: JestHookEmitter;
+  private readonly _subscriber: JestHookSubscriber;
+  private readonly _emitter: JestHookEmitter;
 
   constructor() {
     this._listeners = {

--- a/packages/jest-watcher/src/TestWatcher.ts
+++ b/packages/jest-watcher/src/TestWatcher.ts
@@ -13,7 +13,7 @@ type State = {
 
 export default class TestWatcher extends Emittery<{change: State}> {
   state: State;
-  private _isWatchMode: boolean;
+  private readonly _isWatchMode: boolean;
 
   constructor({isWatchMode}: {isWatchMode: boolean}) {
     super();

--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -33,7 +33,7 @@ export default class Prompt {
     /* eslint-enable */
   }
 
-  private _onResize = (): void => {
+  private readonly _onResize = (): void => {
     this._onChange();
   };
 

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -31,8 +31,8 @@ export default class Farm {
   private readonly _taskQueue: TaskQueue;
 
   constructor(
-    private _numOfWorkers: number,
-    private _callback: WorkerCallback,
+    private readonly _numOfWorkers: number,
+    private readonly _callback: WorkerCallback,
     options: WorkerFarmOptions = {},
   ) {
     this._computeWorkerKey = options.computeWorkerKey;

--- a/packages/jest-worker/src/FifoQueue.ts
+++ b/packages/jest-worker/src/FifoQueue.ts
@@ -27,7 +27,7 @@ type WorkerQueueValue = {
 export default class FifoQueue implements TaskQueue {
   private _workerQueues: Array<InternalQueue<WorkerQueueValue> | undefined> =
     [];
-  private _sharedQueue = new InternalQueue<QueueChildMessage>();
+  private readonly _sharedQueue = new InternalQueue<QueueChildMessage>();
 
   enqueue(task: QueueChildMessage, workerId?: number): void {
     if (workerId == null) {

--- a/packages/jest-worker/src/PriorityQueue.ts
+++ b/packages/jest-worker/src/PriorityQueue.ts
@@ -28,9 +28,9 @@ type QueueItem = {
  */
 export default class PriorityQueue implements TaskQueue {
   private _queue: Array<MinHeap<QueueItem>> = [];
-  private _sharedQueue = new MinHeap<QueueItem>();
+  private readonly _sharedQueue = new MinHeap<QueueItem>();
 
-  constructor(private _computePriority: ComputeTaskPriorityCallback) {}
+  constructor(private readonly _computePriority: ComputeTaskPriorityCallback) {}
 
   enqueue(task: QueueChildMessage, workerId?: number): void {
     if (workerId == null) {
@@ -86,7 +86,7 @@ type HeapItem = {
 };
 
 class MinHeap<TItem extends HeapItem> {
-  private _heap: Array<TItem | null> = [];
+  private readonly _heap: Array<TItem | null> = [];
 
   peek(): TItem | null {
     return this._heap[0] ?? null;

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -81,9 +81,9 @@ function getExposedMethods(
  */
 export class Worker {
   private _ending: boolean;
-  private _farm: Farm;
-  private _options: WorkerFarmOptions;
-  private _workerPool: WorkerPoolInterface;
+  private readonly _farm: Farm;
+  private readonly _options: WorkerFarmOptions;
+  private readonly _workerPool: WorkerPoolInterface;
 
   constructor(workerPath: string, options?: WorkerFarmOptions) {
     this._options = {...options};

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -58,7 +58,7 @@ export default class ChildProcessWorker
   implements WorkerInterface
 {
   private _child!: ChildProcess;
-  private _options: WorkerOptions;
+  private readonly _options: WorkerOptions;
 
   private _request: ChildMessage | null;
   private _retries!: number;
@@ -74,10 +74,10 @@ export default class ChildProcessWorker
   private _resolveMemoryUsage: ((arg0: number) => void) | undefined;
 
   private _childIdleMemoryUsage: number | null;
-  private _childIdleMemoryUsageLimit: number | null;
+  private readonly _childIdleMemoryUsageLimit: number | null;
   private _memoryUsageCheck = false;
 
-  private _childWorkerPath: string;
+  private readonly _childWorkerPath: string;
 
   constructor(options: WorkerOptions) {
     super(options);

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -32,7 +32,7 @@ export default class ExperimentalWorker
   implements WorkerInterface
 {
   private _worker!: Worker;
-  private _options: WorkerOptions;
+  private readonly _options: WorkerOptions;
 
   private _request: ChildMessage | null;
   private _retries!: number;
@@ -45,10 +45,10 @@ export default class ExperimentalWorker
   private _memoryUsagePromise: Promise<number> | undefined;
   private _resolveMemoryUsage: ((arg0: number) => void) | undefined;
 
-  private _childWorkerPath: string;
+  private readonly _childWorkerPath: string;
 
   private _childIdleMemoryUsage: number | null;
-  private _childIdleMemoryUsageLimit: number | null;
+  private readonly _childIdleMemoryUsageLimit: number | null;
   private _memoryUsageCheck = false;
 
   constructor(options: WorkerOptions) {

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -139,7 +139,7 @@ function execMethod(method: string, args: Array<unknown>): void {
   let fn: UnknownFunction;
 
   if (method === 'default') {
-    fn = main.__esModule ? main['default'] : main;
+    fn = main.__esModule ? main.default : main;
   } else {
     fn = main[method];
   }

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -141,7 +141,7 @@ function execMethod(method: string, args: Array<unknown>): void {
   let fn: UnknownFunction;
 
   if (method === 'default') {
-    fn = main.__esModule ? main['default'] : main;
+    fn = main.__esModule ? main.default : main;
   } else {
     fn = main[method];
   }

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -351,7 +351,7 @@ test('min option', () => {
 class DummyMatcher {
   $$typeof = Symbol.for('jest.asymmetricMatcher');
 
-  constructor(private sample: number) {}
+  constructor(private readonly sample: number) {}
 
   asymmetricMatch(other: number) {
     return this.sample === other;

--- a/scripts/buildTs.mjs
+++ b/scripts/buildTs.mjs
@@ -14,13 +14,9 @@ import globby from 'globby';
 import fs from 'graceful-fs';
 import pLimit from 'p-limit';
 import stripJsonComments from 'strip-json-comments';
-import {getPackages} from './buildUtils.mjs';
+import {getPackagesWithTsConfig} from './buildUtils.mjs';
 
-const packages = getPackages();
-
-const packagesWithTs = packages.filter(p =>
-  fs.existsSync(path.resolve(p.packageDir, 'tsconfig.json')),
-);
+const packagesWithTs = getPackagesWithTsConfig();
 
 const {stdout: allWorkspacesString} = await execa('yarn', [
   'workspaces',

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -121,3 +121,9 @@ export function adjustToTerminalWidth(str) {
   }
   return strs.slice(0, -1).concat(lastString).join('\n');
 }
+
+export function getPackagesWithTsConfig() {
+  return getPackages().filter(p =>
+    fs.existsSync(path.resolve(p.packageDir, 'tsconfig.json')),
+  );
+}

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -25,6 +25,7 @@ const packagesToTest = [
   'babel-jest',
   'babel-plugin-jest-hoist',
   'diff-sequences',
+  'jest-source-map',
 ];
 
 const packagesWithTs = getPackagesWithTsConfig()

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -58,13 +58,13 @@ try {
             },
             plugins: ['@typescript-eslint'],
             root: true,
-            // TODO: activate the commented rules at some point
             rules: {
               '@typescript-eslint/consistent-type-exports': 'error',
               '@typescript-eslint/dot-notation': 'error',
               '@typescript-eslint/non-nullable-type-assertion-style': 'error',
               '@typescript-eslint/prefer-nullish-coalescing': 'error',
               '@typescript-eslint/prefer-readonly': 'error',
+              // TODO: activate this at some point
               // '@typescript-eslint/prefer-readonly-parameter-types': 'error',
               '@typescript-eslint/prefer-reduce-type-parameter': 'error',
               '@typescript-eslint/return-await': 'error',

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as url from 'url';
+import chalk from 'chalk';
+import {ESLint} from 'eslint';
+import pLimit from 'p-limit';
+import {getPackagesWithTsConfig} from './buildUtils.mjs';
+
+// we want to limit the number of processes we spawn
+const cpus = Math.max(1, os.cpus().length - 1);
+const mutex = pLimit(cpus);
+
+const fix = process.argv.slice(2).some(arg => arg === '--fix');
+
+const monorepoRoot = path.resolve(url.fileURLToPath(import.meta.url), '../..');
+
+const packagesWithTs = getPackagesWithTsConfig()
+  .map(({packageDir}) => packageDir)
+  .concat(path.resolve(monorepoRoot, 'e2e'))
+  // TODO: run all all projects
+  .slice(0, 3);
+
+try {
+  await Promise.all(
+    packagesWithTs.map(packageDir =>
+      mutex(async () => {
+        const eslint = new ESLint({
+          cache: true,
+          cacheLocation: path.resolve(packageDir, '.eslintcache'),
+          cwd: monorepoRoot,
+          extensions: ['.ts'],
+          fix,
+          overrideConfig: {
+            extends: [
+              'plugin:@typescript-eslint/recommended-requiring-type-checking',
+            ],
+            parser: '@typescript-eslint/parser',
+            parserOptions: {
+              project: ['./tsconfig.json', `${packageDir}/tsconfig.json`],
+              tsconfigRootDir: monorepoRoot,
+            },
+            plugins: ['@typescript-eslint'],
+            root: true,
+          },
+        });
+
+        const filesToLint = packageDir.endsWith('e2e')
+          ? `${packageDir}/__tests__/`
+          : `${packageDir}/src/`;
+
+        let results = await eslint.lintFiles(filesToLint);
+
+        if (fix) {
+          await ESLint.outputFixes(results);
+
+          // re-run after outputting fixes
+          results = await eslint.lintFiles(filesToLint);
+        }
+
+        const filteredResults = ESLint.getErrorResults(results);
+
+        if (filteredResults.length > 0) {
+          const formatter = await eslint.loadFormatter('stylish');
+          const resultText = formatter.format(results);
+
+          console.error(resultText);
+
+          throw new Error('Got lint errors');
+        }
+      }),
+    ),
+  );
+} catch (e) {
+  console.error(
+    chalk.inverse.red(' Unable to lint using TypeScript info files '),
+  );
+
+  throw e;
+}
+
+console.log(
+  chalk.inverse.green(' Successfully linted using TypeScript info files '),
+);

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -21,6 +21,7 @@ const fix = process.argv.slice(2).some(arg => arg === '--fix');
 
 const monorepoRoot = path.resolve(url.fileURLToPath(import.meta.url), '../..');
 
+// TODO: remove this list at some point and run against all packages
 const packagesToTest = [
   'babel-jest',
   'babel-plugin-jest-hoist',

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -58,6 +58,19 @@ try {
             },
             plugins: ['@typescript-eslint'],
             root: true,
+            // TODO: activate the commented rules at some point
+            rules: {
+              '@typescript-eslint/consistent-type-exports': 'error',
+              '@typescript-eslint/dot-notation': 'error',
+              '@typescript-eslint/non-nullable-type-assertion-style': 'error',
+              '@typescript-eslint/prefer-nullish-coalescing': 'error',
+              '@typescript-eslint/prefer-readonly': 'error',
+              // '@typescript-eslint/prefer-readonly-parameter-types': 'error',
+              '@typescript-eslint/prefer-reduce-type-parameter': 'error',
+              '@typescript-eslint/return-await': 'error',
+              '@typescript-eslint/strict-boolean-expressions': 'error',
+              '@typescript-eslint/switch-exhaustiveness-check': 'error',
+            },
           },
         });
 

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -21,11 +21,16 @@ const fix = process.argv.slice(2).some(arg => arg === '--fix');
 
 const monorepoRoot = path.resolve(url.fileURLToPath(import.meta.url), '../..');
 
+const packagesToTest = [
+  'babel-jest',
+  'babel-plugin-jest-hoist',
+  'diff-sequences',
+];
+
 const packagesWithTs = getPackagesWithTsConfig()
   .map(({packageDir}) => packageDir)
   .concat(path.resolve(monorepoRoot, 'e2e'))
-  // TODO: run all all projects
-  .slice(0, 3);
+  .filter(packageDir => packagesToTest.some(pkg => packageDir.endsWith(pkg)));
 
 try {
   await Promise.all(

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -46,6 +46,7 @@ try {
           cwd: monorepoRoot,
           extensions: ['.ts'],
           fix,
+          fixTypes: ['problem', 'suggestion', 'layout'],
           overrideConfig: {
             extends: [
               'plugin:@typescript-eslint/recommended-requiring-type-checking',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

We OOM if we run the entire lint run with type info (see https://typescript-eslint.io/docs/linting/typed-linting/monorepos/#important-note-regarding-large--10-multi-package-monorepos), so I've added a script.

We have a toooooon of errors, so I just fixed a few of them. Should chip away at this when people have time 🙂 

This is somewhat annoying as IDE integrations etc won't apply, but better than nothing

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added CI run

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
