### PR TITLE
chore(lint): use `jest/prefer-to-be` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -166,6 +166,7 @@ module.exports = {
       rules: {
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
+        'jest/prefer-to-be': 'error',
         'jest/valid-expect': 'error',
       },
     },
@@ -189,6 +190,12 @@ module.exports = {
         'no-unused-vars': 'off',
         'prettier/prettier': 'off',
         'sort-keys': 'off',
+      },
+    },
+    {
+      files: ['**/UsingMatchers.md/**'],
+      rules: {
+        'jest/prefer-to-be': 'off',
       },
     },
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -229,17 +229,17 @@ const example = jest.createMockFromModule('../example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -251,12 +251,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -380,7 +380,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -388,7 +388,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -403,7 +403,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -411,7 +411,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -435,8 +435,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -449,8 +449,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -79,7 +79,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 
 // The first argument of the last call to the function was 'test'
 expect(someMockFunction.mock.lastCall[0]).toBe('test');

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -282,11 +282,11 @@ it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/docs/TutorialjQuery.md
+++ b/docs/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/e2e/__tests__/__snapshots__/nestedTestDefinitions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nestedTestDefinitions.test.ts.snap
@@ -32,7 +32,7 @@ exports[`print correct error message with nested test definitions outside descri
       14 |
     > 15 |   test('inner test', () => {
          |   ^
-      16 |     expect(getTruthy()).toEqual('This test should not have run');
+      16 |     expect(getTruthy()).toBe('This test should not have run');
       17 |   });
       18 | });
 

--- a/e2e/__tests__/cliHandlesExactFilenames.test.ts
+++ b/e2e/__tests__/cliHandlesExactFilenames.test.ts
@@ -47,5 +47,5 @@ test('CLI skips exact file names if no matchers matched', () => {
 
   expect(result.exitCode).toBe(1);
   expect(result.stdout).toMatch(/No tests found([\S\s]*)2 files checked./);
-  expect(result.stderr).toEqual('');
+  expect(result.stderr).toBe('');
 });

--- a/e2e/__tests__/config.test.ts
+++ b/e2e/__tests__/config.test.ts
@@ -73,5 +73,5 @@ test('negated flags override previous flags', () => {
     '--silent',
   ]);
 
-  expect(globalConfig.silent).toEqual(true);
+  expect(globalConfig.silent).toBe(true);
 });

--- a/e2e/__tests__/crawlSymlinks.test.ts
+++ b/e2e/__tests__/crawlSymlinks.test.ts
@@ -48,16 +48,16 @@ test('Node crawler picks up symlinked files when option is set as flag', () => {
     '--no-watchman',
   ]);
 
-  expect(stdout).toEqual('');
+  expect(stdout).toBe('');
   expect(stderr).toContain('Test Suites: 1 passed, 1 total');
-  expect(exitCode).toEqual(0);
+  expect(exitCode).toBe(0);
 });
 
 test('Node crawler does not pick up symlinked files by default', () => {
   const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
   expect(stdout).toContain('No tests found, exiting with code 1');
-  expect(stderr).toEqual('');
-  expect(exitCode).toEqual(1);
+  expect(stderr).toBe('');
+  expect(exitCode).toBe(1);
 });
 
 test('Should throw if watchman used with haste.enableSymlinks', () => {
@@ -71,7 +71,7 @@ test('Should throw if watchman used with haste.enableSymlinks', () => {
 
   const {exitCode, stderr, stdout} = run1;
 
-  expect(stdout).toEqual('');
+  expect(stdout).toBe('');
   expect(stderr).toMatchInlineSnapshot(`
     "Validation Error:
 
@@ -79,5 +79,5 @@ test('Should throw if watchman used with haste.enableSymlinks', () => {
 
     Either set haste.enableSymlinks to false or do not use watchman"
   `);
-  expect(exitCode).toEqual(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/doneInHooks.test.ts
+++ b/e2e/__tests__/doneInHooks.test.ts
@@ -11,5 +11,5 @@ import runJest from '../runJest';
 skipSuiteOnJasmine();
 test('`done()` works properly in hooks', () => {
   const {exitCode} = runJest('done-in-hooks');
-  expect(exitCode).toEqual(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/failureDetailsProperty.test.ts
+++ b/e2e/__tests__/failureDetailsProperty.test.ts
@@ -20,7 +20,7 @@ test('that the failureDetails property is set', () => {
   ]);
 
   // safety check: if the reporter errors it'll show up here
-  expect(stderr).toStrictEqual('');
+  expect(stderr).toBe('');
 
   const output = JSON.parse(removeStackTraces(stdout));
 

--- a/e2e/__tests__/hasteMapSha1.test.ts
+++ b/e2e/__tests__/hasteMapSha1.test.ts
@@ -66,13 +66,13 @@ test('exits the process after test are done but before timers complete', async (
 
   // Ignored files do not get the SHA-1 computed.
 
-  expect(hasteFS.getSha1(path.join(DIR, 'fileWithExtension.ignored'))).toBe(
-    null,
-  );
+  expect(
+    hasteFS.getSha1(path.join(DIR, 'fileWithExtension.ignored')),
+  ).toBeNull();
 
   expect(
     hasteFS.getSha1(
       path.join(DIR, 'node_modules/bar/fileWithExtension.ignored'),
     ),
-  ).toBe(null);
+  ).toBeNull();
 });

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -200,8 +200,8 @@ test.each([{projectPath: 'packages/somepackage'}, {projectPath: 'packages/*'}])(
     const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
     expect(stderr).toContain('PASS somepackage packages/somepackage/test.js');
     expect(stderr).toContain('Test Suites: 1 passed, 1 total');
-    expect(stdout).toEqual('');
-    expect(exitCode).toEqual(0);
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(0);
   },
 );
 
@@ -250,8 +250,8 @@ test.each([
     const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
     expect(stderr).toContain(`PASS ${displayName} ${projectPath}/test.js`);
     expect(stderr).toContain('Test Suites: 1 passed, 1 total');
-    expect(stdout).toEqual('');
-    expect(exitCode).toEqual(0);
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(0);
   },
 );
 
@@ -284,8 +284,8 @@ test('projects can be workspaces with non-JS/JSON files', () => {
   expect(stderr).toContain('PASS packages/project1/__tests__/file1.test.js');
   expect(stderr).toContain('PASS packages/project2/__tests__/file2.test.js');
   expect(stderr).toContain('Ran all test suites in 2 projects.');
-  expect(stdout).toEqual('');
-  expect(exitCode).toEqual(0);
+  expect(stdout).toBe('');
+  expect(exitCode).toBe(0);
 });
 
 test('objects in project configuration', () => {
@@ -310,8 +310,8 @@ test('objects in project configuration', () => {
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('PASS __tests__/file2.test.js');
   expect(stderr).toContain('Ran all test suites in 2 projects.');
-  expect(stdout).toEqual('');
-  expect(exitCode).toEqual(0);
+  expect(stdout).toBe('');
+  expect(exitCode).toBe(0);
 });
 
 test('allows a single project', () => {
@@ -330,8 +330,8 @@ test('allows a single project', () => {
   const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('Test Suites: 1 passed, 1 total');
-  expect(stdout).toEqual('');
-  expect(exitCode).toEqual(0);
+  expect(stdout).toBe('');
+  expect(exitCode).toBe(0);
 });
 
 test('resolves projects and their <rootDir> properly', () => {

--- a/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
+++ b/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
@@ -14,6 +14,6 @@ const dir = resolve(__dirname, '../run-programmatically-multiple-projects');
 test('run programmatically with multiple projects', () => {
   const {stderr, exitCode} = run('node run-jest.js', dir);
   const {summary} = extractSummary(stripAnsi(stderr));
-  expect(exitCode).toEqual(0);
+  expect(exitCode).toBe(0);
   expect(summary).toMatchSnapshot('summary');
 });

--- a/e2e/__tests__/snapshot.test.ts
+++ b/e2e/__tests__/snapshot.test.ts
@@ -111,7 +111,7 @@ describe('Snapshot', () => {
     const content = require(snapshotFile);
     expect(
       content['snapshot is not influenced by previous counter 1'],
-    ).not.toBeUndefined();
+    ).toBeDefined();
 
     expect(stderr).toMatch('5 snapshots written from 2 test suites');
     expect(extractSummary(stderr).summary).toMatchSnapshot();
@@ -239,7 +239,7 @@ describe('Snapshot', () => {
       const firstRun = runWithJson('snapshot', ['-w=1', '--ci=false']);
 
       const content = require(snapshotOfCopy);
-      expect(content).not.toBe(undefined);
+      expect(content).toBeDefined();
       const secondRun = runWithJson('snapshot', []);
 
       expect(firstRun.json.numTotalTests).toBe(9);
@@ -257,7 +257,7 @@ describe('Snapshot', () => {
       fs.unlinkSync(copyOfTestPath);
 
       const content = require(snapshotOfCopy);
-      expect(content).not.toBe(undefined);
+      expect(content).toBeDefined();
       const secondRun = runWithJson('snapshot', ['-w=1', '--ci=false', '-u']);
 
       expect(firstRun.json.numTotalTests).toBe(9);
@@ -317,8 +317,8 @@ describe('Snapshot', () => {
       const keyToCheck =
         'snapshot works with plain objects and the ' +
         'title has `escape` characters 2';
-      expect(beforeRemovingSnapshot[keyToCheck]).not.toBe(undefined);
-      expect(afterRemovingSnapshot[keyToCheck]).toBe(undefined);
+      expect(beforeRemovingSnapshot[keyToCheck]).toBeDefined();
+      expect(afterRemovingSnapshot[keyToCheck]).toBeUndefined();
 
       expect(extractSummary(firstRun.stderr).summary).toMatchSnapshot();
       expect(firstRun.stderr).toMatch('9 snapshots written from 3 test suites');

--- a/e2e/__tests__/testEnvironment.test.ts
+++ b/e2e/__tests__/testEnvironment.test.ts
@@ -18,7 +18,7 @@ beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
 it('respects testEnvironment docblock', () => {
-  expect(testFixturePackage.jest.testEnvironment).toEqual('node');
+  expect(testFixturePackage.jest.testEnvironment).toBe('node');
 
   const {json: result} = runWithJson('test-environment');
 

--- a/e2e/__tests__/testEnvironmentCircus.test.ts
+++ b/e2e/__tests__/testEnvironmentCircus.test.ts
@@ -12,7 +12,7 @@ skipSuiteOnJasmine();
 
 it('calls testEnvironment handleTestEvent', () => {
   const result = runJest('test-environment-circus');
-  expect(result.failed).toEqual(false);
+  expect(result.failed).toBe(false);
   expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
     Array [
       "setup",

--- a/e2e/__tests__/testEnvironmentCircusAsync.test.ts
+++ b/e2e/__tests__/testEnvironmentCircusAsync.test.ts
@@ -12,7 +12,7 @@ skipSuiteOnJasmine();
 
 it('calls asynchronous handleTestEvent in testEnvironment', () => {
   const result = runJest('test-environment-circus-async');
-  expect(result.failed).toEqual(true);
+  expect(result.failed).toBe(true);
 
   const lines = result.stdout.split('\n');
   expect(lines).toMatchInlineSnapshot(`

--- a/e2e/__tests__/testRetries.test.ts
+++ b/e2e/__tests__/testRetries.test.ts
@@ -29,14 +29,14 @@ describe('Test Retries', () => {
   it('retries failed tests', () => {
     const result = runJest('test-retries', ['e2e.test.js']);
 
-    expect(result.exitCode).toEqual(0);
+    expect(result.exitCode).toBe(0);
     expect(result.failed).toBe(false);
     expect(result.stderr).not.toContain(logErrorsBeforeRetryErrorMessage);
   });
 
   it('logs error(s) before retry', () => {
     const result = runJest('test-retries', ['logErrorsBeforeRetries.test.js']);
-    expect(result.exitCode).toEqual(0);
+    expect(result.exitCode).toBe(0);
     expect(result.failed).toBe(false);
     expect(result.stderr).toContain(logErrorsBeforeRetryErrorMessage);
     expect(extractSummary(result.stderr).rest).toMatchSnapshot();

--- a/e2e/__tests__/toMatchInlineSnapshot.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshot.test.ts
@@ -170,7 +170,7 @@ test('removes obsolete external snapshots', () => {
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(exitCode).toBe(0);
     expect(fileAfter).toMatchSnapshot('initial write');
-    expect(fs.existsSync(snapshotPath)).toEqual(true);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
   }
 
   {
@@ -180,7 +180,7 @@ test('removes obsolete external snapshots', () => {
     expect(stderr).toMatch('Snapshots:   1 obsolete, 1 written, 1 total');
     expect(exitCode).toBe(1);
     expect(fileAfter).toMatchSnapshot('inline snapshot written');
-    expect(fs.existsSync(snapshotPath)).toEqual(true);
+    expect(fs.existsSync(snapshotPath)).toBe(true);
   }
 
   {
@@ -194,7 +194,7 @@ test('removes obsolete external snapshots', () => {
     expect(stderr).toMatch('Snapshots:   1 file removed, 1 passed, 1 total');
     expect(exitCode).toBe(0);
     expect(fileAfter).toMatchSnapshot('external snapshot cleaned');
-    expect(fs.existsSync(snapshotPath)).toEqual(false);
+    expect(fs.existsSync(snapshotPath)).toBe(false);
   }
 });
 

--- a/e2e/auto-clear-mocks/with-auto-clear/__tests__/index.js
+++ b/e2e/auto-clear-mocks/with-auto-clear/__tests__/index.js
@@ -13,7 +13,7 @@ const localFn = jest.fn(() => 'abcd');
 
 test('first test', () => {
   importedFn();
-  expect(localFn()).toEqual('abcd');
+  expect(localFn()).toBe('abcd');
 
   expect(importedFn.mock.calls.length).toBe(1);
   expect(localFn.mock.calls.length).toBe(1);
@@ -21,7 +21,7 @@ test('first test', () => {
 
 test('second test', () => {
   importedFn();
-  expect(localFn()).toEqual('abcd');
+  expect(localFn()).toBe('abcd');
 
   expect(importedFn.mock.calls.length).toBe(1);
   expect(localFn.mock.calls.length).toBe(1);

--- a/e2e/auto-clear-mocks/without-auto-clear/__tests__/index.js
+++ b/e2e/auto-clear-mocks/without-auto-clear/__tests__/index.js
@@ -15,7 +15,7 @@ const localFn = jest.fn(() => 'abcd');
 describe('without an explicit reset', () => {
   test('first test', () => {
     importedFn();
-    expect(localFn()).toEqual('abcd');
+    expect(localFn()).toBe('abcd');
 
     expect(importedFn.mock.calls.length).toBe(1);
     expect(localFn.mock.calls.length).toBe(1);
@@ -23,7 +23,7 @@ describe('without an explicit reset', () => {
 
   test('second test', () => {
     importedFn();
-    expect(localFn()).toEqual('abcd');
+    expect(localFn()).toBe('abcd');
 
     expect(importedFn.mock.calls.length).toBe(2);
     expect(localFn.mock.calls.length).toBe(2);
@@ -37,7 +37,7 @@ describe('with an explicit reset', () => {
 
   test('first test', () => {
     importedFn();
-    expect(localFn()).toEqual('abcd');
+    expect(localFn()).toBe('abcd');
 
     expect(importedFn.mock.calls.length).toBe(1);
     expect(localFn.mock.calls.length).toBe(1);
@@ -45,7 +45,7 @@ describe('with an explicit reset', () => {
 
   test('second test', () => {
     importedFn();
-    expect(localFn()).toEqual('abcd');
+    expect(localFn()).toBe('abcd');
 
     expect(importedFn.mock.calls.length).toBe(1);
     expect(localFn.mock.calls.length).toBe(1);

--- a/e2e/auto-restore-mocks/with-auto-restore/__tests__/index.js
+++ b/e2e/auto-restore-mocks/with-auto-restore/__tests__/index.js
@@ -12,11 +12,11 @@ const localClass = new TestClass();
 
 test('first test', () => {
   jest.spyOn(localClass, 'test').mockImplementation(() => 'ABCD');
-  expect(localClass.test()).toEqual('ABCD');
+  expect(localClass.test()).toBe('ABCD');
   expect(localClass.test).toHaveBeenCalledTimes(1);
 });
 
 test('second test', () => {
-  expect(localClass.test()).toEqual('12345');
-  expect(localClass.test.mock).toBe(undefined);
+  expect(localClass.test()).toBe('12345');
+  expect(localClass.test.mock).toBeUndefined();
 });

--- a/e2e/auto-restore-mocks/without-auto-restore/__tests__/index.js
+++ b/e2e/auto-restore-mocks/without-auto-restore/__tests__/index.js
@@ -14,12 +14,12 @@ describe('without an explicit restore', () => {
   jest.spyOn(localClass, 'test').mockImplementation(() => 'ABCD');
 
   test('first test', () => {
-    expect(localClass.test()).toEqual('ABCD');
+    expect(localClass.test()).toBe('ABCD');
     expect(localClass.test).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
-    expect(localClass.test()).toEqual('ABCD');
+    expect(localClass.test()).toBe('ABCD');
     expect(localClass.test).toHaveBeenCalledTimes(2);
   });
 });
@@ -31,12 +31,12 @@ describe('with an explicit restore', () => {
 
   test('first test', () => {
     jest.spyOn(localClass, 'test').mockImplementation(() => 'ABCD');
-    expect(localClass.test()).toEqual('ABCD');
+    expect(localClass.test()).toBe('ABCD');
     expect(localClass.test).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
-    expect(localClass.test()).toEqual('12345');
-    expect(localClass.test.mock).toBe(undefined);
+    expect(localClass.test()).toBe('12345');
+    expect(localClass.test.mock).toBeUndefined();
   });
 });

--- a/e2e/babel-plugin-jest-hoist/__tests__/importJest.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/importJest.test.js
@@ -32,21 +32,21 @@ JestGlobals.jest.unmock('../__test_modules__/c');
 // tests
 
 test('named import', () => {
-  expect(a._isMockFunction).toBe(undefined);
+  expect(a._isMockFunction).toBeUndefined();
   expect(a()).toBe('unmocked');
 });
 
 test('aliased named import', () => {
-  expect(b._isMockFunction).toBe(undefined);
+  expect(b._isMockFunction).toBeUndefined();
   expect(b()).toBe('unmocked');
 });
 
 test('namespace import', () => {
-  expect(c._isMockFunction).toBe(undefined);
+  expect(c._isMockFunction).toBeUndefined();
   expect(c()).toBe('unmocked');
 });
 
 test('fake jest, shadowed import', () => {
   expect(d._isMockFunction).toBe(true);
-  expect(d()).toBe(undefined);
+  expect(d()).toBeUndefined();
 });

--- a/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
@@ -82,26 +82,26 @@ describe('babel-plugin-jest-hoist', () => {
   it('does not throw during transform', () => {
     const object = {};
     object.__defineGetter__('foo', () => 'bar');
-    expect(object.foo).toEqual('bar');
+    expect(object.foo).toBe('bar');
   });
 
   it('hoists react unmock call before imports', () => {
-    expect(typeof React).toEqual('object');
-    expect(React.isValidElement.mock).toBe(undefined);
+    expect(typeof React).toBe('object');
+    expect(React.isValidElement.mock).toBeUndefined();
   });
 
   it('hoists unmocked modules before imports', () => {
-    expect(Unmocked._isMockFunction).toBe(undefined);
-    expect(new Unmocked().isUnmocked).toEqual(true);
+    expect(Unmocked._isMockFunction).toBeUndefined();
+    expect(new Unmocked().isUnmocked).toBe(true);
 
-    expect(c._isMockFunction).toBe(undefined);
-    expect(c()).toEqual('unmocked');
+    expect(c._isMockFunction).toBeUndefined();
+    expect(c()).toBe('unmocked');
 
-    expect(d._isMockFunction).toBe(undefined);
-    expect(d()).toEqual('unmocked');
+    expect(d._isMockFunction).toBeUndefined();
+    expect(d()).toBe('unmocked');
 
-    expect(e._isMock).toBe(undefined);
-    expect(e()).toEqual('unmocked');
+    expect(e._isMock).toBeUndefined();
+    expect(e()).toBe('unmocked');
   });
 
   it('hoists mock call with 2 arguments', () => {
@@ -119,29 +119,29 @@ describe('babel-plugin-jest-hoist', () => {
     globalThis.CALLS = 0;
 
     require('../__test_modules__/f');
-    expect(globalThis.CALLS).toEqual(1);
+    expect(globalThis.CALLS).toBe(1);
 
     require('../__test_modules__/f');
-    expect(globalThis.CALLS).toEqual(1);
+    expect(globalThis.CALLS).toBe(1);
 
     delete globalThis.CALLS;
   });
 
   it('does not hoist dontMock calls before imports', () => {
     expect(Mocked._isMockFunction).toBe(true);
-    expect(new Mocked().isMocked).toEqual(undefined);
+    expect(new Mocked().isMocked).toBeUndefined();
 
     expect(a._isMockFunction).toBe(true);
-    expect(a()).toEqual(undefined);
+    expect(a()).toBeUndefined();
 
     expect(b._isMockFunction).toBe(true);
-    expect(b()).toEqual(undefined);
+    expect(b()).toBeUndefined();
   });
 
   it('requires modules that also call jest.mock', () => {
     require('../mockFile');
     const mock = require('../banana');
-    expect(mock).toEqual('apple');
+    expect(mock).toBe('apple');
   });
 
   it('works with virtual modules', () => {

--- a/e2e/babel-plugin-jest-hoist/__tests__/integrationAutomockOff.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/integrationAutomockOff.test.js
@@ -17,7 +17,7 @@ jest.mock('../__test_modules__/b');
 
 describe('babel-plugin-jest-hoist', () => {
   it('hoists disableAutomock call before imports', () => {
-    expect(a._isMockFunction).toBe(undefined);
+    expect(a._isMockFunction).toBeUndefined();
   });
 
   it('hoists mock call before imports', () => {

--- a/e2e/compare-dom-nodes/__tests__/failedAssertion.js
+++ b/e2e/compare-dom-nodes/__tests__/failedAssertion.js
@@ -8,5 +8,5 @@
 /* global document */
 
 test('a failed assertion comparing a DOM node does not crash Jest', () => {
-  expect(document.body).toBe(null);
+  expect(document.body).toBeNull();
 });

--- a/e2e/coverage-handlebars/__tests__/greet.js
+++ b/e2e/coverage-handlebars/__tests__/greet.js
@@ -7,7 +7,7 @@
 const greet = require('../greet.hbs');
 
 test('am', () => {
-  expect(greet({am: true, name: 'Joe'}).replace(/\r\n/g, '\n')).toEqual(
+  expect(greet({am: true, name: 'Joe'}).replace(/\r\n/g, '\n')).toBe(
     '<p>Good\n  morning\nJoe!</p>\n',
   );
 });

--- a/e2e/coverage-report/__tests__/sum.test.js
+++ b/e2e/coverage-report/__tests__/sum.test.js
@@ -16,6 +16,6 @@ if (!globalThis.setup) {
 
 describe('sum', () => {
   it('adds numbers', () => {
-    expect(sum(1, 2)).toEqual(3);
+    expect(sum(1, 2)).toBe(3);
   });
 });

--- a/e2e/coverage-report/cached-duplicates/a/__tests__/identical.test.js
+++ b/e2e/coverage-report/cached-duplicates/a/__tests__/identical.test.js
@@ -10,6 +10,6 @@ const {sum} = require('../identical');
 
 describe('sum', () => {
   it('adds numbers', () => {
-    expect(sum(1, 2)).toEqual(3);
+    expect(sum(1, 2)).toBe(3);
   });
 });

--- a/e2e/coverage-report/cached-duplicates/b/__tests__/identical.test.js
+++ b/e2e/coverage-report/cached-duplicates/b/__tests__/identical.test.js
@@ -10,6 +10,6 @@ const {sum} = require('../identical');
 
 describe('sum', () => {
   it('adds numbers', () => {
-    expect(sum(1, 2)).toEqual(3);
+    expect(sum(1, 2)).toBe(3);
   });
 });

--- a/e2e/custom-resolver/__tests__/customResolver.test.js
+++ b/e2e/custom-resolver/__tests__/customResolver.test.js
@@ -22,5 +22,5 @@ test('should work with automock', () => {
 test('should allow manual mocks to make require calls through the resolver', () => {
   jest.mock('../manualMock');
 
-  expect(require('../manualMock')).toEqual('bar');
+  expect(require('../manualMock')).toBe('bar');
 });

--- a/e2e/fake-timers/advance-timers/__tests__/advanceTimers.test.js
+++ b/e2e/fake-timers/advance-timers/__tests__/advanceTimers.test.js
@@ -14,7 +14,7 @@ test('advances timers if true is passed', done => {
 
   setTimeout(() => {
     done();
-    expect(Date.now() - start).toEqual(45);
+    expect(Date.now() - start).toBe(45);
   }, 45);
 });
 
@@ -25,19 +25,19 @@ test('advances timers if a number is passed', done => {
 
   setTimeout(() => {
     done();
-    expect(Date.now() - start).toEqual(35);
+    expect(Date.now() - start).toBe(35);
   }, 35);
 });
 
 test('works with `now` option', done => {
   jest.useFakeTimers({advanceTimers: 30, now: new Date('2015-09-25')});
 
-  expect(Date.now()).toEqual(1443139200000);
+  expect(Date.now()).toBe(1443139200000);
 
   const start = Date.now();
 
   setTimeout(() => {
     done();
-    expect(Date.now() - start).toEqual(25);
+    expect(Date.now() - start).toBe(25);
   }, 25);
 });

--- a/e2e/global-setup-custom-transform/__tests__/test.js
+++ b/e2e/global-setup-custom-transform/__tests__/test.js
@@ -21,5 +21,5 @@ test('should exist setup file', () => {
 });
 
 test('should transform imported file', () => {
-  expect(greeting).toEqual('hello, world!');
+  expect(greeting).toBe('hello, world!');
 });

--- a/e2e/jasmine-async/__tests__/promiseAfterAll.test.js
+++ b/e2e/jasmine-async/__tests__/promiseAfterAll.test.js
@@ -22,12 +22,12 @@ describe('promise afterAll', () => {
 
   // passing tests
   it('runs afterAll after all tests', () => {
-    expect(this.flag).toBe(undefined);
+    expect(this.flag).toBeUndefined();
     expect(localFlag).toBe(true);
   });
 
   it('waits for afterAll to asynchronously complete before each test', () => {
-    expect(this.flag).toBe(undefined);
+    expect(this.flag).toBeUndefined();
     expect(localFlag).toBe(true);
   });
 });

--- a/e2e/jasmine-async/__tests__/promiseAfterEach.test.js
+++ b/e2e/jasmine-async/__tests__/promiseAfterEach.test.js
@@ -22,12 +22,12 @@ describe('promise afterEach', () => {
 
   // passing tests
   it('runs afterEach after each test', () => {
-    expect(this.flag).toBe(undefined);
+    expect(this.flag).toBeUndefined();
     expect(localFlag).toBe(true);
   });
 
   it('waits for afterEach to asynchronously complete before each test', () => {
-    expect(this.flag).toBe(undefined);
+    expect(this.flag).toBeUndefined();
     expect(localFlag).toBe(false);
   });
 });

--- a/e2e/jasmine-async/__tests__/promiseIt.test.js
+++ b/e2e/jasmine-async/__tests__/promiseIt.test.js
@@ -50,13 +50,13 @@ describe('promise it', () => {
   });
 
   it('fails if failed expectation with done', done => {
-    expect(true).toEqual(false);
+    expect(true).toBe(false);
     done();
   });
 
   it('fails if failed expectation with done - async', done => {
     setTimeout(() => {
-      expect(true).toEqual(false);
+      expect(true).toBe(false);
       done();
     }, 1);
   });

--- a/e2e/json-reporter/__tests__/sum.test.js
+++ b/e2e/json-reporter/__tests__/sum.test.js
@@ -14,16 +14,16 @@ it('no ancestors', () => {
 
 describe('sum', () => {
   it('adds numbers', () => {
-    expect(sum(1, 2)).toEqual(3);
+    expect(sum(1, 2)).toBe(3);
   });
 
   describe('failing tests', () => {
     it('fails the test', () => {
-      expect(sum(1, 2)).toEqual(4);
+      expect(sum(1, 2)).toBe(4);
     });
   });
 
   it.skip('skipped test', () => {
-    expect(sum(1, 2)).toEqual(3);
+    expect(sum(1, 2)).toBe(3);
   });
 });

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -193,7 +193,7 @@ test('can mock module', async () => {
   const importedMock = await import('../mockedModule.mjs');
 
   expect(Object.keys(importedMock)).toEqual(['foo']);
-  expect(importedMock.foo).toEqual('bar');
+  expect(importedMock.foo).toBe('bar');
 });
 
 test('can mock transitive module', async () => {
@@ -202,7 +202,7 @@ test('can mock transitive module', async () => {
   const importedMock = await import('../reexport.js');
 
   expect(Object.keys(importedMock)).toEqual(['foo']);
-  expect(importedMock.foo).toEqual('bar');
+  expect(importedMock.foo).toBe('bar');
 });
 
 test('supports imports using "node:" prefix', () => {

--- a/e2e/nested-test-definitions/__tests__/nestedTestOutsideDescribe.js
+++ b/e2e/nested-test-definitions/__tests__/nestedTestOutsideDescribe.js
@@ -13,6 +13,6 @@ test('outer test', () => {
   expect(getTruthy()).toBeTruthy();
 
   test('inner test', () => {
-    expect(getTruthy()).toEqual('This test should not have run');
+    expect(getTruthy()).toBe('This test should not have run');
   });
 });

--- a/e2e/pnp/__tests__/index.js
+++ b/e2e/pnp/__tests__/index.js
@@ -10,5 +10,5 @@ const lib = require('foo');
 
 it('should work', () => {
   expect(process.versions.pnp).toBeTruthy();
-  expect(lib()).toEqual(42);
+  expect(lib()).toBe(42);
 });

--- a/e2e/presets/cjs/__tests__/index.js
+++ b/e2e/presets/cjs/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load file mapped by cjs preset', () => {
-  expect(require('./test.foo')).toEqual(42);
+  expect(require('./test.foo')).toBe(42);
 });

--- a/e2e/presets/js-type-module/__tests__/index.js
+++ b/e2e/presets/js-type-module/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load file mapped by js preset', () => {
-  expect(require('./test.foo')).toEqual(42);
+  expect(require('./test.foo')).toBe(42);
 });

--- a/e2e/presets/js/__tests__/index.js
+++ b/e2e/presets/js/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load file mapped by js preset', () => {
-  expect(require('./test.foo')).toEqual(42);
+  expect(require('./test.foo')).toBe(42);
 });

--- a/e2e/presets/json/__tests__/index.js
+++ b/e2e/presets/json/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load file mapped by json preset', () => {
-  expect(require('./test.foo')).toEqual(42);
+  expect(require('./test.foo')).toBe(42);
 });

--- a/e2e/presets/mjs/__tests__/index.js
+++ b/e2e/presets/mjs/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load file mapped by mjs preset', () => {
-  expect(require('./test.foo')).toEqual(42);
+  expect(require('./test.foo')).toBe(42);
 });

--- a/e2e/require-main-isolate-modules/__tests__/index.test.js
+++ b/e2e/require-main-isolate-modules/__tests__/index.test.js
@@ -9,5 +9,5 @@ let foo;
 jest.isolateModules(() => (foo = require('../index')));
 
 test('`require.main` on using `jest.isolateModules` should not be undefined', () => {
-  expect(foo()).toEqual(1);
+  expect(foo()).toBe(1);
 });

--- a/e2e/resolve-async/__tests__/resolveAsync.test.js
+++ b/e2e/resolve-async/__tests__/resolveAsync.test.js
@@ -8,5 +8,5 @@
 import greeting from '../some-file';
 
 test('async resolver resolves to correct file', () => {
-  expect(greeting).toEqual('Hello from mapped file!!');
+  expect(greeting).toBe('Hello from mapped file!!');
 });

--- a/e2e/resolve-conditions/__tests__/browser.test.mjs
+++ b/e2e/resolve-conditions/__tests__/browser.test.mjs
@@ -10,5 +10,5 @@
 import {fn} from 'fake-dual-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from browser');
+  expect(fn()).toBe('hello from browser');
 });

--- a/e2e/resolve-conditions/__tests__/deno.test.mjs
+++ b/e2e/resolve-conditions/__tests__/deno.test.mjs
@@ -10,5 +10,5 @@
 import {fn} from 'fake-dual-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from deno');
+  expect(fn()).toBe('hello from deno');
 });

--- a/e2e/resolve-conditions/__tests__/jsdom-custom-export-conditions.test.mjs
+++ b/e2e/resolve-conditions/__tests__/jsdom-custom-export-conditions.test.mjs
@@ -11,5 +11,5 @@
 import {fn} from 'fake-dual-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from special');
+  expect(fn()).toBe('hello from special');
 });

--- a/e2e/resolve-conditions/__tests__/node-custom-export-conditions.test.mjs
+++ b/e2e/resolve-conditions/__tests__/node-custom-export-conditions.test.mjs
@@ -11,5 +11,5 @@
 import {fn} from 'fake-dual-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from special');
+  expect(fn()).toBe('hello from special');
 });

--- a/e2e/resolve-conditions/__tests__/node.test.mjs
+++ b/e2e/resolve-conditions/__tests__/node.test.mjs
@@ -10,5 +10,5 @@
 import {fn} from 'fake-dual-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from node');
+  expect(fn()).toBe('hello from node');
 });

--- a/e2e/resolve-conditions/__tests__/resolveCjs.test.cjs
+++ b/e2e/resolve-conditions/__tests__/resolveCjs.test.cjs
@@ -8,5 +8,5 @@
 const {fn} = require('fake-dep');
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from CJS');
+  expect(fn()).toBe('hello from CJS');
 });

--- a/e2e/resolve-conditions/__tests__/resolveEsm.test.mjs
+++ b/e2e/resolve-conditions/__tests__/resolveEsm.test.mjs
@@ -8,5 +8,5 @@
 import {fn} from 'fake-dep';
 
 test('returns correct message', () => {
-  expect(fn()).toEqual('hello from ESM');
+  expect(fn()).toBe('hello from ESM');
 });

--- a/e2e/resolve-node-module/__tests__/resolve-node-module.test.js
+++ b/e2e/resolve-node-module/__tests__/resolve-node-module.test.js
@@ -14,20 +14,20 @@ jest.mock('mock-module-without-pkg');
 
 it('should resolve entry as index.js when package main is "."', () => {
   const mockModule = require('mock-module');
-  expect(mockModule).toEqual('test');
+  expect(mockModule).toBe('test');
 });
 
 it('should resolve entry as index.js when package main is "./"', () => {
   const mockModule = require('mock-module-alt');
-  expect(mockModule).toEqual('test');
+  expect(mockModule).toBe('test');
 });
 
 it('should resolve entry as index with other configured module file extension when package main is "."', () => {
   const mockJsxModule = require('mock-jsx-module');
-  expect(mockJsxModule).toEqual('test jsx');
+  expect(mockJsxModule).toBe('test jsx');
 });
 
 it('should resolve entry as index without package.json', () => {
   const mockModuleWithoutPkg = require('mock-module-without-pkg');
-  expect(mockModuleWithoutPkg).toEqual('test mock-module-without-pkg');
+  expect(mockModuleWithoutPkg).toBe('test mock-module-without-pkg');
 });

--- a/e2e/resolve-with-paths/__tests__/resolveWithPaths.test.js
+++ b/e2e/resolve-with-paths/__tests__/resolveWithPaths.test.js
@@ -8,29 +8,29 @@
 import {resolve} from 'path';
 
 test('finds a module relative to one of the given paths', () => {
-  expect(require.resolve('./mod.js', {paths: ['../dir']})).toEqual(
+  expect(require.resolve('./mod.js', {paths: ['../dir']})).toBe(
     resolve(__dirname, '..', 'dir', 'mod.js'),
   );
 });
 
 test('finds a module without a leading "./" relative to one of the given paths', () => {
-  expect(require.resolve('mod.js', {paths: ['../dir']})).toEqual(
+  expect(require.resolve('mod.js', {paths: ['../dir']})).toBe(
     resolve(__dirname, '..', 'dir', 'mod.js'),
   );
 });
 
 test('finds a node_module above one of the given paths', () => {
-  expect(require.resolve('mod', {paths: ['../dir']})).toEqual(
+  expect(require.resolve('mod', {paths: ['../dir']})).toBe(
     resolve(__dirname, '..', 'node_modules', 'mod', 'index.js'),
   );
 });
 
 test('finds a native node module when paths are given', () => {
-  expect(require.resolve('fs', {paths: ['../dir']})).toEqual('fs');
+  expect(require.resolve('fs', {paths: ['../dir']})).toBe('fs');
 });
 
 test('throws an error if the module cannot be found from given paths', () => {
-  expect(() => require.resolve('./mod.js', {paths: ['..']})).toThrowError(
+  expect(() => require.resolve('./mod.js', {paths: ['..']})).toThrow(
     "Cannot resolve module './mod.js' from paths ['..'] from ",
   );
 });

--- a/e2e/setup-files-after-env-config/__tests__/test1.test.js
+++ b/e2e/setup-files-after-env-config/__tests__/test1.test.js
@@ -8,6 +8,6 @@
 
 describe('test', () => {
   it('has predefined global variable', () => {
-    expect(globalThis.definedInSetupFile).toEqual(true);
+    expect(globalThis.definedInSetupFile).toBe(true);
   });
 });

--- a/e2e/setup-files-after-env-config/__tests__/test2.test.js
+++ b/e2e/setup-files-after-env-config/__tests__/test2.test.js
@@ -8,6 +8,6 @@
 
 describe('test', () => {
   it('has predefined global variable', () => {
-    expect(globalThis.definedInSetupFile).toEqual(true);
+    expect(globalThis.definedInSetupFile).toBe(true);
   });
 });

--- a/e2e/test-environment/__tests__/docblockPragmas.test.js
+++ b/e2e/test-environment/__tests__/docblockPragmas.test.js
@@ -9,5 +9,5 @@
  */
 
 test('docblock pragmas', () => {
-  expect(myCustomPragma).toEqual('pragma-value'); // eslint-disable-line no-undef
+  expect(myCustomPragma).toBe('pragma-value'); // eslint-disable-line no-undef
 });

--- a/e2e/test-retries/__tests__/e2e.test.js
+++ b/e2e/test-retries/__tests__/e2e.test.js
@@ -20,7 +20,7 @@ jest.retryTimes(3);
 it('retries', () => {
   const tries = parseInt(fs.readFileSync(countPath, 'utf8'), 10);
   fs.writeFileSync(countPath, `${tries + 1}`, 'utf8');
-  expect(tries).toEqual(3);
+  expect(tries).toBe(3);
 });
 
 afterAll(() => {

--- a/e2e/transform-linked-modules/__tests__/linkedModules.test.js
+++ b/e2e/transform-linked-modules/__tests__/linkedModules.test.js
@@ -7,10 +7,10 @@
 
 test('normal file', () => {
   const normal = require('../ignored/normal');
-  expect(normal).toEqual('ignored/normal');
+  expect(normal).toBe('ignored/normal');
 });
 
 test('symlink', () => {
   const symlink = require('../ignored/symlink');
-  expect(symlink).toEqual('transformed');
+  expect(symlink).toBe('transformed');
 });

--- a/e2e/transform/async-transformer/__tests__/test.js
+++ b/e2e/transform/async-transformer/__tests__/test.js
@@ -9,7 +9,7 @@ import m, {exportedSymbol} from '../module-under-test';
 import symbol from '../some-symbol';
 
 test('ESM transformer intercepts', () => {
-  expect(m).toEqual(42);
+  expect(m).toBe(42);
 });
 
 test('reexported symbol is same instance', () => {

--- a/e2e/transform/babel-jest-async/__tests__/babelJest.test.js
+++ b/e2e/transform/babel-jest-async/__tests__/babelJest.test.js
@@ -8,5 +8,5 @@
 import nullReturningFunc from '../only-file-to-transform.js';
 
 it('strips flowtypes using babel-jest', () => {
-  expect(nullReturningFunc()).toBe(null);
+  expect(nullReturningFunc()).toBeNull();
 });

--- a/e2e/transform/esm-transformer/__tests__/test.js
+++ b/e2e/transform/esm-transformer/__tests__/test.js
@@ -8,5 +8,5 @@
 const m = require('../module');
 
 test('ESM transformer intercepts', () => {
-  expect(m).toEqual(42);
+  expect(m).toBe(42);
 });

--- a/e2e/watch-plugins/cjs/__tests__/index.js
+++ b/e2e/watch-plugins/cjs/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load watch plugin cjs', () => {
-  expect(42).toEqual(42);
+  expect(42).toBe(42);
 });

--- a/e2e/watch-plugins/js-type-module/__tests__/index.js
+++ b/e2e/watch-plugins/js-type-module/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load watch plugin js type module', () => {
-  expect(42).toEqual(42);
+  expect(42).toBe(42);
 });

--- a/e2e/watch-plugins/js/__tests__/index.js
+++ b/e2e/watch-plugins/js/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load watch plugin js', () => {
-  expect(42).toEqual(42);
+  expect(42).toBe(42);
 });

--- a/e2e/watch-plugins/mjs/__tests__/index.js
+++ b/e2e/watch-plugins/mjs/__tests__/index.js
@@ -7,5 +7,5 @@
 'use strict';
 
 test('load watch plugin mjs', () => {
-  expect(42).toEqual(42);
+  expect(42).toBe(42);
 });

--- a/examples/async/__tests__/user.test.js
+++ b/examples/async/__tests__/user.test.js
@@ -9,26 +9,26 @@ import * as user from '../user';
 // Testing promise can be done using `.resolves`.
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 
 // async/await can be used.
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 
 // Testing for async errors using `.rejects`.

--- a/examples/automatic-mocks/__tests__/createMockFromModule.test.js
+++ b/examples/automatic-mocks/__tests__/createMockFromModule.test.js
@@ -12,5 +12,5 @@ test('implementation created by jest.createMockFromModule', () => {
   utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
   expect(utils.authorize.mock).toBeTruthy();
-  expect(utils.isAuthorized('not wizard')).toEqual(true);
+  expect(utils.isAuthorized('not wizard')).toBe(true);
 });

--- a/examples/enzyme/__tests__/CheckboxWithLabel-test.js
+++ b/examples/enzyme/__tests__/CheckboxWithLabel-test.js
@@ -10,9 +10,9 @@ it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });

--- a/examples/jquery/__tests__/display_user.test.js
+++ b/examples/jquery/__tests__/display_user.test.js
@@ -35,5 +35,5 @@ it('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });

--- a/examples/manual-mocks/__tests__/lodashMocking.test.js
+++ b/examples/manual-mocks/__tests__/lodashMocking.test.js
@@ -3,5 +3,5 @@
 import lodash from 'lodash';
 
 test('if lodash head is mocked', () => {
-  expect(lodash.head([2, 3])).toEqual(5);
+  expect(lodash.head([2, 3])).toBe(5);
 });

--- a/examples/module-mock/__tests__/full_mock.js
+++ b/examples/module-mock/__tests__/full_mock.js
@@ -8,7 +8,7 @@ import defaultExport, {apple, strawberry} from '../fruit';
 jest.mock('../fruit');
 
 it('does a full mock', () => {
-  expect(defaultExport()).toBe(undefined);
+  expect(defaultExport()).toBeUndefined();
   expect(apple).toBe('apple');
-  expect(strawberry()).toBe(undefined);
+  expect(strawberry()).toBeUndefined();
 });

--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -21,9 +21,9 @@ it('CheckboxWithLabel changes the text after click', () => {
   const inputNode = checkboxInputRef.current;
 
   // Verify that it's Off by default
-  expect(labelNode.textContent).toEqual('Off');
+  expect(labelNode.textContent).toBe('Off');
 
   // Simulate a click and verify that it is now On
   TestUtils.Simulate.change(inputNode);
-  expect(labelNode.textContent).toEqual('On');
+  expect(labelNode.textContent).toBe('On');
 });

--- a/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
+++ b/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
@@ -22,9 +22,9 @@ it('CheckboxWithLabel changes the text after click', () => {
   const inputNode = checkboxInputRef.current;
 
   // Verify that it's Off by default
-  expect(labelNode.textContent).toEqual('Off');
+  expect(labelNode.textContent).toBe('Off');
 
   // Simulate a click and verify that it is now On
   TestUtils.Simulate.change(inputNode);
-  expect(labelNode.textContent).toEqual('On');
+  expect(labelNode.textContent).toBe('On');
 });

--- a/examples/typescript/__tests__/calc.test.ts
+++ b/examples/typescript/__tests__/calc.test.ts
@@ -23,7 +23,7 @@ describe('calc - mocks', () => {
     const calc = makeCalc(memory);
     const result = calc('Sub', [2, 2]);
 
-    expect(result).toEqual(0);
+    expect(result).toBe(0);
     expect(mockSub).toBeCalledWith(2, 2);
   });
 
@@ -33,7 +33,7 @@ describe('calc - mocks', () => {
     const calc = makeCalc(memory);
     const result = calc('Sum', [1, 1]);
 
-    expect(result).toEqual(2);
+    expect(result).toBe(2);
     expect(mockSum).toBeCalledWith(1, 1);
   });
 
@@ -45,8 +45,8 @@ describe('calc - mocks', () => {
     const sumResult = calc('Sum', [1, 1]);
     const memoryResult = calc('MemoryAdd', []);
 
-    expect(sumResult).toEqual(2);
-    expect(memoryResult).toEqual(2);
+    expect(sumResult).toBe(2);
+    expect(memoryResult).toBe(2);
     expect(MockMemory.prototype.add).toBeCalledWith(2);
   });
 
@@ -58,8 +58,8 @@ describe('calc - mocks', () => {
     const sumResult = calc('Sum', [1, 1]);
     const memoryResult = calc('MemorySub', []);
 
-    expect(sumResult).toEqual(2);
-    expect(memoryResult).toEqual(2);
+    expect(sumResult).toBe(2);
+    expect(memoryResult).toBe(2);
     expect(MockMemory.prototype.subtract).toBeCalledWith(2);
   });
 
@@ -73,10 +73,10 @@ describe('calc - mocks', () => {
     const sumResult2 = calc('Sum', [2, 2]);
     const clearResult = calc('MemoryClear', []);
 
-    expect(sumResult).toEqual(2);
-    expect(memoryResult).toEqual(2);
-    expect(sumResult2).toEqual(4);
-    expect(clearResult).toEqual(4);
+    expect(sumResult).toBe(2);
+    expect(memoryResult).toBe(2);
+    expect(sumResult2).toBe(4);
+    expect(clearResult).toBe(4);
     expect(MockMemory.prototype.reset).toBeCalledTimes(1);
   });
 

--- a/packages/babel-jest/src/__tests__/getCacheKey.test.ts
+++ b/packages/babel-jest/src/__tests__/getCacheKey.test.ts
@@ -44,7 +44,7 @@ describe('getCacheKey', () => {
   const oldCacheKey = getCacheKey!(sourceText, sourcePath, transformOptions);
 
   test('returns cache key hash', () => {
-    expect(oldCacheKey.length).toEqual(32);
+    expect(oldCacheKey.length).toBe(32);
   });
 
   test('if `THIS_FILE` value is changing', () => {

--- a/packages/diff-sequences/src/__tests__/index.test.ts
+++ b/packages/diff-sequences/src/__tests__/index.test.ts
@@ -97,10 +97,10 @@ describe('input callback encapsulates comparison', () => {
     const b = [-0];
 
     test('are not common according to Object.is method', () => {
-      expect(countCommonObjectIs(a, b)).toEqual(0);
+      expect(countCommonObjectIs(a, b)).toBe(0);
     });
     test('are common according to === operator', () => {
-      expect(countCommonStrictEquality(a, b)).toEqual(1);
+      expect(countCommonStrictEquality(a, b)).toBe(1);
     });
   });
 
@@ -109,10 +109,10 @@ describe('input callback encapsulates comparison', () => {
     const a = [NaN];
 
     test('is common according to Object.is method', () => {
-      expect(countCommonObjectIs(a, a)).toEqual(1);
+      expect(countCommonObjectIs(a, a)).toBe(1);
     });
     test('is not common according to === operator', () => {
-      expect(countCommonStrictEquality(a, a)).toEqual(0);
+      expect(countCommonStrictEquality(a, a)).toBe(0);
     });
   });
 });
@@ -290,13 +290,13 @@ describe('no common items', () => {
     };
 
     test('of a', () => {
-      expect(countItemsNegativeZero(-0, 1)).toEqual(0);
+      expect(countItemsNegativeZero(-0, 1)).toBe(0);
     });
     test('of b', () => {
-      expect(countItemsNegativeZero(1, -0)).toEqual(0);
+      expect(countItemsNegativeZero(1, -0)).toBe(0);
     });
     test('of a and b', () => {
-      expect(countItemsNegativeZero(-0, -0)).toEqual(0);
+      expect(countItemsNegativeZero(-0, -0)).toBe(0);
     });
   });
 

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -269,7 +269,7 @@ describe('subsetEquality()', () => {
   });
 
   test('object without keys is undefined', () => {
-    expect(subsetEquality('foo', 'bar')).toBe(undefined);
+    expect(subsetEquality('foo', 'bar')).toBeUndefined();
   });
 
   test('objects to not match', () => {

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -149,7 +149,7 @@ describe('init', () => {
         const writtenPackageJson = fs.writeFileSync.mock.calls[0][1];
 
         expect(writtenPackageJson).toMatchSnapshot();
-        expect(JSON.parse(writtenPackageJson).scripts.test).toEqual('jest');
+        expect(JSON.parse(writtenPackageJson).scripts.test).toBe('jest');
       });
     });
   });

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -751,9 +751,7 @@ describe('testEnvironment', () => {
       {} as Config.Argv,
     );
 
-    expect(options.testEnvironment).toEqual(
-      'node_modules/jest-environment-jsdom',
-    );
+    expect(options.testEnvironment).toBe('node_modules/jest-environment-jsdom');
   });
 
   it('resolves to node environment by default', async () => {
@@ -790,7 +788,7 @@ describe('testEnvironment', () => {
       {} as Config.Argv,
     );
 
-    expect(options.testEnvironment).toEqual('/root/testEnvironment.js');
+    expect(options.testEnvironment).toBe('/root/testEnvironment.js');
   });
 });
 
@@ -1489,7 +1487,7 @@ describe('watchPlugins', () => {
   it('defaults to undefined', async () => {
     const {options} = await normalize({rootDir: '/root'}, {} as Config.Argv);
 
-    expect(options.watchPlugins).toEqual(undefined);
+    expect(options.watchPlugins).toBeUndefined();
   });
 
   it('resolves to watch plugins and prefers jest-watch-`name`', async () => {
@@ -2082,5 +2080,5 @@ it('parses workerIdleMemoryLimit', async () => {
     {} as Config.Argv,
   );
 
-  expect(options.workerIdleMemoryLimit).toEqual(47185920);
+  expect(options.workerIdleMemoryLimit).toBe(47185920);
 });

--- a/packages/jest-config/src/__tests__/stringToBytes.test.ts
+++ b/packages/jest-config/src/__tests__/stringToBytes.test.ts
@@ -9,15 +9,15 @@ import stringToBytes from '../stringToBytes';
 
 describe('numeric input', () => {
   test('> 1 represents bytes', () => {
-    expect(stringToBytes(50.8)).toEqual(50);
+    expect(stringToBytes(50.8)).toBe(50);
   });
 
   test('1.1 should be a 1', () => {
-    expect(stringToBytes(1.1, 54)).toEqual(1);
+    expect(stringToBytes(1.1, 54)).toBe(1);
   });
 
   test('< 1 represents a %', () => {
-    expect(stringToBytes(0.3, 51)).toEqual(15);
+    expect(stringToBytes(0.3, 51)).toBe(15);
   });
 
   test('should throw when no reference supplied', () => {
@@ -32,11 +32,11 @@ describe('numeric input', () => {
 describe('string input', () => {
   describe('numeric passthrough', () => {
     test('> 1 represents bytes', () => {
-      expect(stringToBytes('50.8')).toEqual(50);
+      expect(stringToBytes('50.8')).toBe(50);
     });
 
     test('< 1 represents a %', () => {
-      expect(stringToBytes('0.3', 51)).toEqual(15);
+      expect(stringToBytes('0.3', 51)).toBe(15);
     });
 
     test('should throw when no reference supplied', () => {
@@ -54,57 +54,57 @@ describe('string input', () => {
     });
 
     test('30%', () => {
-      expect(stringToBytes('30%', 51)).toEqual(15);
+      expect(stringToBytes('30%', 51)).toBe(15);
     });
 
     test('80%', () => {
-      expect(stringToBytes('80%', 51)).toEqual(40);
+      expect(stringToBytes('80%', 51)).toBe(40);
     });
 
     test('100%', () => {
-      expect(stringToBytes('100%', 51)).toEqual(51);
+      expect(stringToBytes('100%', 51)).toBe(51);
     });
 
     // The units caps is intentionally janky to test for forgiving string parsing.
     describe('k', () => {
       test('30k', () => {
-        expect(stringToBytes('30K')).toEqual(30000);
+        expect(stringToBytes('30K')).toBe(30000);
       });
 
       test('30KB', () => {
-        expect(stringToBytes('30kB')).toEqual(30000);
+        expect(stringToBytes('30kB')).toBe(30000);
       });
 
       test('30KiB', () => {
-        expect(stringToBytes('30kIb')).toEqual(30720);
+        expect(stringToBytes('30kIb')).toBe(30720);
       });
     });
 
     describe('m', () => {
       test('30M', () => {
-        expect(stringToBytes('30M')).toEqual(30000000);
+        expect(stringToBytes('30M')).toBe(30000000);
       });
 
       test('30MB', () => {
-        expect(stringToBytes('30MB')).toEqual(30000000);
+        expect(stringToBytes('30MB')).toBe(30000000);
       });
 
       test('30MiB', () => {
-        expect(stringToBytes('30MiB')).toEqual(31457280);
+        expect(stringToBytes('30MiB')).toBe(31457280);
       });
     });
 
     describe('g', () => {
       test('30G', () => {
-        expect(stringToBytes('30G')).toEqual(30000000000);
+        expect(stringToBytes('30G')).toBe(30000000000);
       });
 
       test('30GB', () => {
-        expect(stringToBytes('30gB')).toEqual(30000000000);
+        expect(stringToBytes('30gB')).toBe(30000000000);
       });
 
       test('30GiB', () => {
-        expect(stringToBytes('30GIB')).toEqual(32212254720);
+        expect(stringToBytes('30GIB')).toBe(32212254720);
       });
     });
 
@@ -115,13 +115,13 @@ describe('string input', () => {
 });
 
 test('nesting', () => {
-  expect(stringToBytes(stringToBytes(stringToBytes('30%', 51)))).toEqual(15);
+  expect(stringToBytes(stringToBytes(stringToBytes('30%', 51)))).toBe(15);
 });
 
 test('null', () => {
-  expect(stringToBytes(null)).toEqual(null);
+  expect(stringToBytes(null)).toBeNull();
 });
 
 test('undefined', () => {
-  expect(stringToBytes(undefined)).toEqual(undefined);
+  expect(stringToBytes(undefined)).toBeUndefined();
 });

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -96,7 +96,7 @@ describe('CustomConsole', () => {
       _console.count();
       _console.count();
 
-      expect(_stdout).toEqual('default: 1\ndefault: 2\ndefault: 3\n');
+      expect(_stdout).toBe('default: 1\ndefault: 2\ndefault: 3\n');
     });
 
     test('count using the a labeled counter', () => {
@@ -104,7 +104,7 @@ describe('CustomConsole', () => {
       _console.count('custom');
       _console.count('custom');
 
-      expect(_stdout).toEqual('custom: 1\ncustom: 2\ncustom: 3\n');
+      expect(_stdout).toBe('custom: 1\ncustom: 2\ncustom: 3\n');
     });
 
     test('countReset restarts default counter', () => {
@@ -112,7 +112,7 @@ describe('CustomConsole', () => {
       _console.count();
       _console.countReset();
       _console.count();
-      expect(_stdout).toEqual('default: 1\ndefault: 2\ndefault: 1\n');
+      expect(_stdout).toBe('default: 1\ndefault: 2\ndefault: 1\n');
     });
 
     test('countReset restarts custom counter', () => {
@@ -121,7 +121,7 @@ describe('CustomConsole', () => {
       _console.countReset('custom');
       _console.count('custom');
 
-      expect(_stdout).toEqual('custom: 1\ncustom: 2\ncustom: 1\n');
+      expect(_stdout).toBe('custom: 1\ncustom: 2\ncustom: 1\n');
     });
   });
 
@@ -132,7 +132,7 @@ describe('CustomConsole', () => {
       _console.group();
       _console.log('there');
 
-      expect(_stdout).toEqual('  hey\n    there\n');
+      expect(_stdout).toBe('  hey\n    there\n');
     });
 
     test('group with label', () => {
@@ -141,7 +141,7 @@ describe('CustomConsole', () => {
       _console.group('second');
       _console.log('there');
 
-      expect(_stdout).toEqual(`  ${chalk.bold('first')}
+      expect(_stdout).toBe(`  ${chalk.bold('first')}
   hey
     ${chalk.bold('second')}
     there
@@ -154,7 +154,7 @@ describe('CustomConsole', () => {
       _console.groupEnd();
       _console.log('there');
 
-      expect(_stdout).toEqual('  hey\nthere\n');
+      expect(_stdout).toBe('  hey\nthere\n');
     });
 
     test('groupEnd can not remove the indentation below the starting point', () => {
@@ -165,7 +165,7 @@ describe('CustomConsole', () => {
       _console.groupEnd();
       _console.log('there');
 
-      expect(_stdout).toEqual('  hey\nthere\n');
+      expect(_stdout).toBe('  hey\nthere\n');
     });
   });
 

--- a/packages/jest-console/src/__tests__/bufferedConsole.test.ts
+++ b/packages/jest-console/src/__tests__/bufferedConsole.test.ts
@@ -57,7 +57,7 @@ describe('CustomConsole', () => {
       _console.count();
       _console.count();
 
-      expect(stdout()).toEqual('default: 1\ndefault: 2\ndefault: 3');
+      expect(stdout()).toBe('default: 1\ndefault: 2\ndefault: 3');
     });
 
     test('count using the a labeled counter', () => {
@@ -65,7 +65,7 @@ describe('CustomConsole', () => {
       _console.count('custom');
       _console.count('custom');
 
-      expect(stdout()).toEqual('custom: 1\ncustom: 2\ncustom: 3');
+      expect(stdout()).toBe('custom: 1\ncustom: 2\ncustom: 3');
     });
 
     test('countReset restarts default counter', () => {
@@ -73,7 +73,7 @@ describe('CustomConsole', () => {
       _console.count();
       _console.countReset();
       _console.count();
-      expect(stdout()).toEqual('default: 1\ndefault: 2\ndefault: 1');
+      expect(stdout()).toBe('default: 1\ndefault: 2\ndefault: 1');
     });
 
     test('countReset restarts custom counter', () => {
@@ -82,7 +82,7 @@ describe('CustomConsole', () => {
       _console.countReset('custom');
       _console.count('custom');
 
-      expect(stdout()).toEqual('custom: 1\ncustom: 2\ncustom: 1');
+      expect(stdout()).toBe('custom: 1\ncustom: 2\ncustom: 1');
     });
   });
 
@@ -93,7 +93,7 @@ describe('CustomConsole', () => {
       _console.group();
       _console.log('there');
 
-      expect(stdout()).toEqual('  hey\n    there');
+      expect(stdout()).toBe('  hey\n    there');
     });
 
     test('group with label', () => {
@@ -102,7 +102,7 @@ describe('CustomConsole', () => {
       _console.group('second');
       _console.log('there');
 
-      expect(stdout()).toEqual(`  ${chalk.bold('first')}
+      expect(stdout()).toBe(`  ${chalk.bold('first')}
   hey
     ${chalk.bold('second')}
     there`);
@@ -114,7 +114,7 @@ describe('CustomConsole', () => {
       _console.groupEnd();
       _console.log('there');
 
-      expect(stdout()).toEqual('  hey\nthere');
+      expect(stdout()).toBe('  hey\nthere');
     });
 
     test('groupEnd can not remove the indentation below the starting point', () => {
@@ -125,7 +125,7 @@ describe('CustomConsole', () => {
       _console.groupEnd();
       _console.log('there');
 
-      expect(stdout()).toEqual('  hey\nthere');
+      expect(stdout()).toBe('  hey\nthere');
     });
   });
 

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -86,20 +86,20 @@ describe('SearchSource', () => {
       });
 
       const path = '/path/to/__tests__/foo/bar/baz/../../../test.js';
-      expect(searchSource.isTestFilePath(path)).toEqual(true);
+      expect(searchSource.isTestFilePath(path)).toBe(true);
     });
 
     it('supports unix separators', () => {
       if (process.platform !== 'win32') {
         const path = '/path/to/__tests__/test.js';
-        expect(searchSource.isTestFilePath(path)).toEqual(true);
+        expect(searchSource.isTestFilePath(path)).toBe(true);
       }
     });
 
     it('supports win32 separators', () => {
       if (process.platform === 'win32') {
         const path = '\\path\\to\\__tests__\\test.js';
-        expect(searchSource.isTestFilePath(path)).toEqual(true);
+        expect(searchSource.isTestFilePath(path)).toBe(true);
       }
     });
   });

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -279,7 +279,7 @@ describe('scheduleTests should always dispatch runStart and runComplete events',
       setState: jest.fn(),
     });
 
-    expect(result.numTotalTestSuites).toEqual(1);
+    expect(result.numTotalTestSuites).toBe(1);
 
     expect(mockReporter.onRunStart).toBeCalledTimes(1);
     expect(mockReporter.onRunComplete).toBeCalledTimes(1);

--- a/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
+++ b/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
@@ -40,7 +40,7 @@ test('creation of a cache key', () => {
     instrument: true,
   });
 
-  expect(hashA.length).toEqual(32);
+  expect(hashA.length).toBe(32);
   expect(hashA).not.toEqual(hashB);
   expect(hashA).not.toEqual(hashC);
 });

--- a/packages/jest-docblock/src/__tests__/index.test.ts
+++ b/packages/jest-docblock/src/__tests__/index.test.ts
@@ -174,7 +174,7 @@ describe('docblock', () => {
   it('preserves leading whitespace in multiline comments from docblock', () => {
     const code = `/**${EOL} *  hello${EOL} *   world${EOL} */`;
 
-    expect(docblock.parseWithComments(code).comments).toEqual(
+    expect(docblock.parseWithComments(code).comments).toBe(
       ` hello${EOL}  world`,
     );
   });
@@ -182,7 +182,7 @@ describe('docblock', () => {
   it('removes leading newlines in multiline comments from docblock', () => {
     const code = `/**${EOL} * @snailcode${EOL} *${EOL} *  hello world${EOL} */`;
 
-    expect(docblock.parseWithComments(code).comments).toEqual(' hello world');
+    expect(docblock.parseWithComments(code).comments).toBe(' hello world');
   });
 
   it('extracts comments from beginning and end of docblock', () => {
@@ -243,7 +243,7 @@ describe('docblock', () => {
 
   it('strips the docblock out of a file that contains a top docblock', () => {
     const code = '/**\n * foo\n * bar\n*/\nthe rest';
-    expect(docblock.strip(code)).toEqual('\nthe rest');
+    expect(docblock.strip(code)).toBe('\nthe rest');
   });
 
   it('returns a file unchanged if there is no top docblock to strip', () => {
@@ -253,12 +253,12 @@ describe('docblock', () => {
 
   it('prints docblocks with no pragmas as empty string', () => {
     const pragmas = {};
-    expect(docblock.print({pragmas})).toEqual('');
+    expect(docblock.print({pragmas})).toBe('');
   });
 
   it('prints docblocks with one pragma on one line', () => {
     const pragmas = {flow: ''};
-    expect(docblock.print({pragmas})).toEqual('/** @flow */');
+    expect(docblock.print({pragmas})).toBe('/** @flow */');
   });
 
   it('prints docblocks with multiple pragmas on multiple lines', () => {
@@ -266,7 +266,7 @@ describe('docblock', () => {
       flow: '',
       format: '',
     };
-    expect(docblock.print({pragmas})).toEqual(
+    expect(docblock.print({pragmas})).toBe(
       `/**${EOL} * @flow${EOL} * @format${EOL} */`,
     );
   });
@@ -276,7 +276,7 @@ describe('docblock', () => {
       x: ['a', 'b'],
       y: 'c',
     };
-    expect(docblock.print({pragmas})).toEqual(
+    expect(docblock.print({pragmas})).toBe(
       `/**${EOL} * @x a${EOL} * @x b${EOL} * @y c${EOL} */`,
     );
   });
@@ -285,7 +285,7 @@ describe('docblock', () => {
       flow: 'foo',
       team: 'x/y/z',
     };
-    expect(docblock.print({pragmas})).toEqual(
+    expect(docblock.print({pragmas})).toBe(
       `/**${EOL} * @flow foo${EOL} * @team x/y/z${EOL} */`,
     );
   });
@@ -293,7 +293,7 @@ describe('docblock', () => {
   it('prints docblocks with comments', () => {
     const pragmas = {flow: 'foo'};
     const comments = 'hello';
-    expect(docblock.print({comments, pragmas})).toEqual(
+    expect(docblock.print({comments, pragmas})).toBe(
       `/**${EOL} * hello${EOL} *${EOL} * @flow foo${EOL} */`,
     );
   });
@@ -302,7 +302,7 @@ describe('docblock', () => {
     const pragmas = {};
     const comments =
       'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.';
-    expect(docblock.print({comments, pragmas})).toEqual(
+    expect(docblock.print({comments, pragmas})).toBe(
       `/**${EOL} * ${comments}${EOL} */`,
     );
   });
@@ -310,7 +310,7 @@ describe('docblock', () => {
   it('prints docblocks with multiline comments', () => {
     const pragmas = {};
     const comments = `hello${EOL}world`;
-    expect(docblock.print({comments, pragmas})).toEqual(
+    expect(docblock.print({comments, pragmas})).toBe(
       `/**${EOL} * hello${EOL} * world${EOL} */`,
     );
   });
@@ -328,7 +328,7 @@ describe('docblock', () => {
     const {comments, pragmas} = docblock.parseWithComments(before);
     pragmas.format = '';
     const after = docblock.print({comments, pragmas});
-    expect(after).toEqual(
+    expect(after).toBe(
       `/**${EOL} * Legalese${EOL} *${EOL} * @flow${EOL} * @format${EOL} */`,
     );
   });
@@ -337,13 +337,13 @@ describe('docblock', () => {
     const pragmas = {};
     const comments = 'hello\r\nworld';
     const formatted = docblock.print({comments, pragmas});
-    expect(formatted).toEqual('/**\r\n * hello\r\n * world\r\n */');
+    expect(formatted).toBe('/**\r\n * hello\r\n * world\r\n */');
   });
 
   it('prints docblocks using LF if comments contains LF', () => {
     const pragmas = {};
     const comments = 'hello\nworld';
     const formatted = docblock.print({comments, pragmas});
-    expect(formatted).toEqual('/**\n * hello\n * world\n */');
+    expect(formatted).toBe('/**\n * hello\n * world\n */');
   });
 });

--- a/packages/jest-each/src/__tests__/array.test.ts
+++ b/packages/jest-each/src/__tests__/array.test.ts
@@ -451,7 +451,7 @@ describe('jest-each', () => {
         testFunction('expected string', function (hello, done) {
           expect(hello).toBe('hello');
           expect(arguments.length).toBe(1);
-          expect(done).toBe(undefined);
+          expect(done).toBeUndefined();
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
       },

--- a/packages/jest-each/src/__tests__/template.test.ts
+++ b/packages/jest-each/src/__tests__/template.test.ts
@@ -548,7 +548,7 @@ describe('jest-each', () => {
           expect(a).toBe(0);
           expect(b).toBe(1);
           expect(expected).toBe(1);
-          expect(done).toBe(undefined);
+          expect(done).toBeUndefined();
           expect(arguments.length).toBe(1);
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -53,7 +53,7 @@ describe('JSDomEnvironment', () => {
       {console, docblockPragmas: {}, testPath: __filename},
     );
 
-    expect(env.dom.window.navigator.userAgent).toEqual('foo');
+    expect(env.dom.window.navigator.userAgent).toBe('foo');
   });
 
   it('should respect url option', () => {
@@ -65,7 +65,7 @@ describe('JSDomEnvironment', () => {
       {console, docblockPragmas: {}, testPath: __filename},
     );
 
-    expect(env.dom.window.location.href).toEqual('http://localhost/');
+    expect(env.dom.window.location.href).toBe('http://localhost/');
 
     const envWithUrl = new JSDomEnvironment(
       {
@@ -79,7 +79,7 @@ describe('JSDomEnvironment', () => {
       {console, docblockPragmas: {}, testPath: __filename},
     );
 
-    expect(envWithUrl.dom.window.location.href).toEqual('https://jestjs.io/');
+    expect(envWithUrl.dom.window.location.href).toBe('https://jestjs.io/');
   });
 
   /**

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -26,7 +26,7 @@ describe('NodeEnvironment', () => {
       projectConfig: makeProjectConfig(),
     });
 
-    expect(env1.global.process.on).not.toBe(null);
+    expect(env1.global.process.on).not.toBeNull();
   });
 
   it('exposes global.global', () => {
@@ -50,7 +50,7 @@ describe('NodeEnvironment', () => {
     const timer2 = env1.global.setInterval(() => {}, 0);
 
     [timer1, timer2].forEach(timer => {
-      expect(timer.id).not.toBeUndefined();
+      expect(timer.id).toBeDefined();
       expect(typeof timer.ref).toBe('function');
       expect(typeof timer.unref).toBe('function');
     });

--- a/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts
+++ b/packages/jest-fake-timers/src/__tests__/legacyFakeTimers.test.ts
@@ -40,7 +40,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.setTimeout).not.toBe(undefined);
+      expect(global.setTimeout).toBeDefined();
     });
 
     it('accepts to promisify setTimeout mock', async () => {
@@ -66,7 +66,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.clearTimeout).not.toBe(undefined);
+      expect(global.clearTimeout).toBeDefined();
     });
 
     it('installs setInterval mock', () => {
@@ -78,7 +78,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.setInterval).not.toBe(undefined);
+      expect(global.setInterval).toBeDefined();
     });
 
     it('installs clearInterval mock', () => {
@@ -90,7 +90,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.clearInterval).not.toBe(undefined);
+      expect(global.clearInterval).toBeDefined();
     });
 
     it('mocks process.nextTick if it exists on global', () => {
@@ -155,7 +155,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.requestAnimationFrame).toBe(undefined);
+      expect(global.requestAnimationFrame).toBeUndefined();
     });
 
     it('mocks requestAnimationFrame if available on global', () => {
@@ -171,7 +171,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.requestAnimationFrame).not.toBe(undefined);
+      expect(global.requestAnimationFrame).toBeDefined();
       expect(global.requestAnimationFrame).not.toBe(origRequestAnimationFrame);
     });
 
@@ -186,7 +186,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.cancelAnimationFrame).toBe(undefined);
+      expect(global.cancelAnimationFrame).toBeUndefined();
     });
 
     it('mocks cancelAnimationFrame if available on global', () => {
@@ -202,7 +202,7 @@ describe('FakeTimers', () => {
         timerConfig,
       });
       timers.useFakeTimers();
-      expect(global.cancelAnimationFrame).not.toBe(undefined);
+      expect(global.cancelAnimationFrame).toBeDefined();
       expect(global.cancelAnimationFrame).not.toBe(origCancelAnimationFrame);
     });
   });
@@ -1535,15 +1535,15 @@ describe('FakeTimers', () => {
       fakedGlobal.setTimeout(() => {}, 0);
       fakedGlobal.setTimeout(() => {}, 10);
 
-      expect(timers.getTimerCount()).toEqual(3);
+      expect(timers.getTimerCount()).toBe(3);
 
       timers.advanceTimersByTime(5);
 
-      expect(timers.getTimerCount()).toEqual(1);
+      expect(timers.getTimerCount()).toBe(1);
 
       timers.advanceTimersByTime(5);
 
-      expect(timers.getTimerCount()).toEqual(0);
+      expect(timers.getTimerCount()).toBe(0);
     });
 
     it('includes immediates and ticks', () => {
@@ -1553,27 +1553,27 @@ describe('FakeTimers', () => {
       fakedGlobal.setImmediate(() => {});
       process.nextTick(() => {});
 
-      expect(timers.getTimerCount()).toEqual(3);
+      expect(timers.getTimerCount()).toBe(3);
     });
 
     it('not includes cancelled immediates', () => {
       timers.useFakeTimers();
 
       fakedGlobal.setImmediate(() => {});
-      expect(timers.getTimerCount()).toEqual(1);
+      expect(timers.getTimerCount()).toBe(1);
       timers.clearAllTimers();
 
-      expect(timers.getTimerCount()).toEqual(0);
+      expect(timers.getTimerCount()).toBe(0);
     });
 
     it('includes animation frames', () => {
       timers.useFakeTimers();
 
       fakedGlobal.requestAnimationFrame(() => {});
-      expect(timers.getTimerCount()).toEqual(1);
+      expect(timers.getTimerCount()).toBe(1);
       timers.clearAllTimers();
 
-      expect(timers.getTimerCount()).toEqual(0);
+      expect(timers.getTimerCount()).toBe(0);
     });
   });
 
@@ -1601,19 +1601,19 @@ describe('FakeTimers', () => {
       fakedGlobal.setTimeout(() => {}, 2);
       fakedGlobal.setTimeout(() => {}, 100);
 
-      expect(timers.now()).toEqual(0);
+      expect(timers.now()).toBe(0);
 
       // This should run the 2ms timer, and then advance _now by 3ms
       timers.advanceTimersByTime(5);
-      expect(timers.now()).toEqual(5);
+      expect(timers.now()).toBe(5);
 
       // Advance _now even though there are no timers to run
       timers.advanceTimersByTime(5);
-      expect(timers.now()).toEqual(10);
+      expect(timers.now()).toBe(10);
 
       // Run up to the 100ms timer
       timers.runAllTimers();
-      expect(timers.now()).toEqual(100);
+      expect(timers.now()).toBe(100);
 
       // Verify that runOnlyPendingTimers advances now only up to the first
       // recursive timer
@@ -1621,11 +1621,11 @@ describe('FakeTimers', () => {
         fakedGlobal.setTimeout(infinitelyRecursingCallback, 20);
       }, 10);
       timers.runOnlyPendingTimers();
-      expect(timers.now()).toEqual(110);
+      expect(timers.now()).toBe(110);
 
       // For legacy timers, reset() sets the clock to 0
       timers.reset();
-      expect(timers.now()).toEqual(0);
+      expect(timers.now()).toBe(0);
     });
 
     it('returns the real time if useFakeTimers is not called', () => {

--- a/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts
+++ b/packages/jest-fake-timers/src/__tests__/modernFakeTimers.test.ts
@@ -20,7 +20,7 @@ describe('FakeTimers', () => {
       } as unknown as typeof globalThis;
       const timers = new FakeTimers({config: makeProjectConfig(), global});
       timers.useFakeTimers();
-      expect(global.setTimeout).not.toBe(undefined);
+      expect(global.setTimeout).toBeDefined();
     });
 
     it('installs clearTimeout mock', () => {
@@ -32,7 +32,7 @@ describe('FakeTimers', () => {
       } as unknown as typeof globalThis;
       const timers = new FakeTimers({config: makeProjectConfig(), global});
       timers.useFakeTimers();
-      expect(global.clearTimeout).not.toBe(undefined);
+      expect(global.clearTimeout).toBeDefined();
     });
 
     it('installs setInterval mock', () => {
@@ -44,7 +44,7 @@ describe('FakeTimers', () => {
       } as unknown as typeof globalThis;
       const timers = new FakeTimers({config: makeProjectConfig(), global});
       timers.useFakeTimers();
-      expect(global.setInterval).not.toBe(undefined);
+      expect(global.setInterval).toBeDefined();
     });
 
     it('installs clearInterval mock', () => {
@@ -56,7 +56,7 @@ describe('FakeTimers', () => {
       } as unknown as typeof globalThis;
       const timers = new FakeTimers({config: makeProjectConfig(), global});
       timers.useFakeTimers();
-      expect(global.clearInterval).not.toBe(undefined);
+      expect(global.clearInterval).toBeDefined();
     });
 
     it('mocks process.nextTick if it exists on global', () => {
@@ -932,15 +932,15 @@ describe('FakeTimers', () => {
       fakedGlobal.setTimeout(() => {}, 0);
       fakedGlobal.setTimeout(() => {}, 10);
 
-      expect(timers.getTimerCount()).toEqual(3);
+      expect(timers.getTimerCount()).toBe(3);
 
       timers.advanceTimersByTime(5);
 
-      expect(timers.getTimerCount()).toEqual(1);
+      expect(timers.getTimerCount()).toBe(1);
 
       timers.advanceTimersByTime(5);
 
-      expect(timers.getTimerCount()).toEqual(0);
+      expect(timers.getTimerCount()).toBe(0);
     });
 
     it('includes immediates and ticks', () => {
@@ -948,15 +948,15 @@ describe('FakeTimers', () => {
       fakedGlobal.setImmediate(() => {});
       process.nextTick(() => {});
 
-      expect(timers.getTimerCount()).toEqual(3);
+      expect(timers.getTimerCount()).toBe(3);
     });
 
     it('not includes cancelled immediates', () => {
       fakedGlobal.setImmediate(() => {});
-      expect(timers.getTimerCount()).toEqual(1);
+      expect(timers.getTimerCount()).toBe(1);
       timers.clearAllTimers();
 
-      expect(timers.getTimerCount()).toEqual(0);
+      expect(timers.getTimerCount()).toBe(0);
     });
   });
 
@@ -983,19 +983,19 @@ describe('FakeTimers', () => {
       fakedGlobal.setTimeout(() => {}, 2);
       fakedGlobal.setTimeout(() => {}, 100);
 
-      expect(timers.now()).toEqual(0);
+      expect(timers.now()).toBe(0);
 
       // This should run the 2ms timer, and then advance _now by 3ms
       timers.advanceTimersByTime(5);
-      expect(timers.now()).toEqual(5);
+      expect(timers.now()).toBe(5);
 
       // Advance _now even though there are no timers to run
       timers.advanceTimersByTime(5);
-      expect(timers.now()).toEqual(10);
+      expect(timers.now()).toBe(10);
 
       // Run up to the 100ms timer
       timers.runAllTimers();
-      expect(timers.now()).toEqual(100);
+      expect(timers.now()).toBe(100);
 
       // Verify that runOnlyPendingTimers advances now only up to the first
       // recursive timer
@@ -1003,11 +1003,11 @@ describe('FakeTimers', () => {
         fakedGlobal.setTimeout(infinitelyRecursingCallback, 20);
       }, 10);
       timers.runOnlyPendingTimers();
-      expect(timers.now()).toEqual(110);
+      expect(timers.now()).toBe(110);
 
       // For modern timers, reset() explicitly preserves the clock time
       timers.reset();
-      expect(timers.now()).toEqual(110);
+      expect(timers.now()).toBe(110);
     });
 
     it('returns the real time if useFakeTimers is not called', () => {

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -719,7 +719,7 @@ describe('HasteMap', () => {
       data.files.get(path.join('fruits', 'node_modules', 'fbjs', 'fbjs.js')),
     ).toEqual(['', 32, 42, 0, [], null]);
 
-    expect(data.map.get('fbjs')).not.toBeDefined();
+    expect(data.map.get('fbjs')).toBeUndefined();
 
     // cache file + 5 modules - the node_module
     expect(fs.readFileSync.mock.calls.length).toBe(6);
@@ -780,7 +780,7 @@ describe('HasteMap', () => {
 
     // Duplicate modules are removed so that it doesn't cause
     // non-determinism later on.
-    expect(data.map.get('Strawberry')[H.GENERIC_PLATFORM]).not.toBeDefined();
+    expect(data.map.get('Strawberry')[H.GENERIC_PLATFORM]).toBeUndefined();
 
     expect(console.warn.mock.calls[0][0].replace(/\\/g, '/')).toMatchSnapshot();
   });
@@ -1234,7 +1234,7 @@ describe('HasteMap', () => {
 
     const config = {...defaultConfig, ignorePattern: /Kiwi|Pear/};
     const {moduleMap} = await (await HasteMap.create(config)).build();
-    expect(moduleMap.getModule('Pear')).toBe(null);
+    expect(moduleMap.getModule('Pear')).toBeNull();
   });
 
   it('ignores files that do not exist', async () => {
@@ -1261,9 +1261,9 @@ describe('HasteMap', () => {
     expect(data.files.size).toBe(5);
 
     // Ensure this file is not part of the file list.
-    expect(data.files.get(path.join('fruits', 'invalid', 'file.js'))).toBe(
-      undefined,
-    );
+    expect(
+      data.files.get(path.join('fruits', 'invalid', 'file.js')),
+    ).toBeUndefined();
   });
 
   it('distributes work across workers', async () => {

--- a/packages/jest-haste-map/src/__tests__/worker.test.js
+++ b/packages/jest-haste-map/src/__tests__/worker.test.js
@@ -142,7 +142,7 @@ describe('worker', () => {
       error = err;
     }
 
-    expect(error.message).toEqual("Cannot read path '/kiwi.js'.");
+    expect(error.message).toBe("Cannot read path '/kiwi.js'.");
   });
 
   it('simply computes SHA-1s when requested (works well with binary data)', async () => {

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -173,7 +173,7 @@ describe('node crawler', () => {
       ')',
     ]);
 
-    expect(hasteMap.files).not.toBe(null);
+    expect(hasteMap.files).not.toBeNull();
 
     expect(hasteMap.files).toEqual(
       createMap({

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -143,12 +143,12 @@ describe('watchman watch', () => {
     expect(client.on).toBeCalledWith('error', expect.any(Function));
 
     // Call 0 and 1 are for ['watch-project']
-    expect(calls[0][0][0]).toEqual('watch-project');
-    expect(calls[1][0][0]).toEqual('watch-project');
+    expect(calls[0][0][0]).toBe('watch-project');
+    expect(calls[1][0][0]).toBe('watch-project');
 
     // Call 2 is the query
     const query = calls[2][0];
-    expect(query[0]).toEqual('query');
+    expect(query[0]).toBe('query');
 
     expect(query[2].expression).toEqual([
       'allof',
@@ -172,7 +172,7 @@ describe('watchman watch', () => {
       }),
     );
 
-    expect(changedFiles).toEqual(undefined);
+    expect(changedFiles).toBeUndefined();
 
     expect(hasteMap.files).toEqual(mockFiles);
 
@@ -326,7 +326,7 @@ describe('watchman watch', () => {
       }),
     );
 
-    expect(changedFiles).toEqual(undefined);
+    expect(changedFiles).toBeUndefined();
 
     // strawberry and melon removed from the file list.
     expect(hasteMap.files).toEqual(
@@ -420,7 +420,7 @@ describe('watchman watch', () => {
       }),
     );
 
-    expect(changedFiles).toEqual(undefined);
+    expect(changedFiles).toBeUndefined();
 
     expect(hasteMap.files).toEqual(
       createMap({
@@ -485,13 +485,13 @@ describe('watchman watch', () => {
     expect(client.on).toBeCalledWith('error', expect.any(Function));
 
     // First 3 calls are for ['watch-project']
-    expect(calls[0][0][0]).toEqual('watch-project');
-    expect(calls[1][0][0]).toEqual('watch-project');
-    expect(calls[2][0][0]).toEqual('watch-project');
+    expect(calls[0][0][0]).toBe('watch-project');
+    expect(calls[1][0][0]).toBe('watch-project');
+    expect(calls[2][0][0]).toBe('watch-project');
 
     // Call 4 is the query
     const query = calls[3][0];
-    expect(query[0]).toEqual('query');
+    expect(query[0]).toBe('query');
 
     expect(query[2].expression).toEqual([
       'allof',

--- a/packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js
@@ -14,7 +14,7 @@ describe('getPlatformExtension', () => {
     expect(getPlatformExtension('/b/c/a.ios.js')).toBe('ios');
     expect(getPlatformExtension('/b/c.android/a.ios.js')).toBe('ios');
     expect(getPlatformExtension('/b/c/a@1.5x.ios.png')).toBe('ios');
-    expect(getPlatformExtension('/b/c/a@1.5x.lol.png')).toBe(null);
-    expect(getPlatformExtension('/b/c/a.lol.png')).toBe(null);
+    expect(getPlatformExtension('/b/c/a@1.5x.lol.png')).toBeNull();
+    expect(getPlatformExtension('/b/c/a.lol.png')).toBeNull();
   });
 });

--- a/packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js
@@ -12,13 +12,13 @@ describe('normalizePathSep', () => {
     jest.resetModules();
     jest.mock('path', () => jest.requireActual('path').posix);
     const normalizePathSep = require('../normalizePathSep').default;
-    expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo/bar/baz.js');
+    expect(normalizePathSep('foo/bar/baz.js')).toBe('foo/bar/baz.js');
   });
 
   it('replace slashes on windows', () => {
     jest.resetModules();
     jest.mock('path', () => jest.requireActual('path').win32);
     const normalizePathSep = require('../normalizePathSep').default;
-    expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo\\bar\\baz.js');
+    expect(normalizePathSep('foo/bar/baz.js')).toBe('foo\\bar\\baz.js');
   });
 });

--- a/packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/expectationResultFactory.test.ts
@@ -26,7 +26,7 @@ describe('expectationResultFactory', () => {
       passed: false,
     };
     const result = expectationResultFactory(options);
-    expect(result.message).toEqual('thrown: undefined');
+    expect(result.message).toBe('thrown: undefined');
   });
 
   it('returns the result if failed (with `message`).', () => {
@@ -52,7 +52,7 @@ describe('expectationResultFactory', () => {
       passed: false,
     };
     const result = expectationResultFactory(options);
-    expect(result.message).toEqual('Error: Expected `Pass`, received `Fail`.');
+    expect(result.message).toBe('Error: Expected `Pass`, received `Fail`.');
   });
 
   it('returns the error name if the error message is empty', () => {
@@ -64,7 +64,7 @@ describe('expectationResultFactory', () => {
       passed: false,
     };
     const result = expectationResultFactory(options);
-    expect(result.message).toEqual('Error');
+    expect(result.message).toBe('Error');
   });
 
   it('returns the result if failed (with `error` as a string).', () => {
@@ -76,7 +76,7 @@ describe('expectationResultFactory', () => {
       passed: false,
     };
     const result = expectationResultFactory(options);
-    expect(result.message).toEqual('Expected `Pass`, received `Fail`.');
+    expect(result.message).toBe('Expected `Pass`, received `Fail`.');
   });
 
   it('returns the result if failed (with `error.stack` not as a string).', () => {

--- a/packages/jest-leak-detector/src/__tests__/index.test.ts
+++ b/packages/jest-leak-detector/src/__tests__/index.test.ts
@@ -32,7 +32,7 @@ it('does not show the GC if hidden', async () => {
   // @ts-expect-error: purposefully removed
   globalThis.gc = undefined;
   await detector.isLeaking();
-  expect(globalThis.gc).not.toBeDefined();
+  expect(globalThis.gc).toBeUndefined();
 });
 
 it('does not hide the GC if visible', async () => {

--- a/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
@@ -11,8 +11,8 @@ import deepCyclicCopyReplaceable from '../deepCyclicCopyReplaceable';
 test('returns the same value for primitive or function values', () => {
   const fn = () => {};
 
-  expect(deepCyclicCopyReplaceable(undefined)).toBe(undefined);
-  expect(deepCyclicCopyReplaceable(null)).toBe(null);
+  expect(deepCyclicCopyReplaceable(undefined)).toBeUndefined();
+  expect(deepCyclicCopyReplaceable(null)).toBeNull();
   expect(deepCyclicCopyReplaceable(true)).toBe(true);
   expect(deepCyclicCopyReplaceable(42)).toBe(42);
   expect(Number.isNaN(deepCyclicCopyReplaceable(NaN))).toBe(true);

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -246,22 +246,22 @@ describe('diff', () => {
   });
 
   test('two booleans', () => {
-    expect(diff(false, true)).toBe(null);
+    expect(diff(false, true)).toBeNull();
   });
 
   test('two numbers', () => {
-    expect(diff(1, 2)).toBe(null);
+    expect(diff(1, 2)).toBeNull();
   });
 
   test('two bigints', () => {
-    expect(diff(BigInt(1), BigInt(2))).toBe(null);
+    expect(diff(BigInt(1), BigInt(2))).toBeNull();
   });
 });
 
 describe('pluralize()', () => {
-  test('one', () => expect(pluralize('apple', 1)).toEqual('one apple'));
-  test('two', () => expect(pluralize('apple', 2)).toEqual('two apples'));
-  test('20', () => expect(pluralize('apple', 20)).toEqual('20 apples'));
+  test('one', () => expect(pluralize('apple', 1)).toBe('one apple'));
+  test('two', () => expect(pluralize('apple', 2)).toBe('two apples'));
+  test('20', () => expect(pluralize('apple', 20)).toBe('20 apples'));
 });
 
 describe('getLabelPrinter', () => {

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -46,9 +46,9 @@ describe('moduleMocker', () => {
     it('mocks constant values', () => {
       const metadata = moduleMocker.getMetadata(Symbol.for('bowties.are.cool'));
       expect(metadata.value).toEqual(Symbol.for('bowties.are.cool'));
-      expect(moduleMocker.getMetadata('banana').value).toEqual('banana');
-      expect(moduleMocker.getMetadata(27).value).toEqual(27);
-      expect(moduleMocker.getMetadata(false).value).toEqual(false);
+      expect(moduleMocker.getMetadata('banana').value).toBe('banana');
+      expect(moduleMocker.getMetadata(27).value).toBe(27);
+      expect(moduleMocker.getMetadata(false).value).toBe(false);
       expect(moduleMocker.getMetadata(Infinity).value).toEqual(Infinity);
     });
 
@@ -57,21 +57,21 @@ describe('moduleMocker', () => {
       const metadata = moduleMocker.getMetadata(array);
       expect(metadata.value).toBeUndefined();
       expect(metadata.members).toBeUndefined();
-      expect(metadata.type).toEqual('array');
+      expect(metadata.type).toBe('array');
     });
 
     it('does not retrieve metadata for undefined', () => {
       const metadata = moduleMocker.getMetadata(undefined);
       expect(metadata.value).toBeUndefined();
       expect(metadata.members).toBeUndefined();
-      expect(metadata.type).toEqual('undefined');
+      expect(metadata.type).toBe('undefined');
     });
 
     it('does not retrieve metadata for null', () => {
       const metadata = moduleMocker.getMetadata(null);
       expect(metadata.value).toBeNull();
       expect(metadata.members).toBeUndefined();
-      expect(metadata.type).toEqual('null');
+      expect(metadata.type).toBe('null');
     });
 
     it('retrieves metadata for ES6 classes', () => {
@@ -80,22 +80,22 @@ describe('moduleMocker', () => {
       }
       const fooInstance = new ClassFooMock();
       const metadata = moduleMocker.getMetadata(fooInstance);
-      expect(metadata.type).toEqual('object');
-      expect(metadata.members.constructor.name).toEqual('ClassFooMock');
+      expect(metadata.type).toBe('object');
+      expect(metadata.members.constructor.name).toBe('ClassFooMock');
     });
 
     it('retrieves synchronous function metadata', () => {
       function functionFooMock() {}
       const metadata = moduleMocker.getMetadata(functionFooMock);
-      expect(metadata.type).toEqual('function');
-      expect(metadata.name).toEqual('functionFooMock');
+      expect(metadata.type).toBe('function');
+      expect(metadata.name).toBe('functionFooMock');
     });
 
     it('retrieves asynchronous function metadata', () => {
       async function asyncFunctionFooMock() {}
       const metadata = moduleMocker.getMetadata(asyncFunctionFooMock);
-      expect(metadata.type).toEqual('function');
-      expect(metadata.name).toEqual('asyncFunctionFooMock');
+      expect(metadata.type).toBe('function');
+      expect(metadata.name).toBe('asyncFunctionFooMock');
     });
 
     it("retrieves metadata for object literals and it's members", () => {
@@ -103,20 +103,20 @@ describe('moduleMocker', () => {
         bar: 'two',
         foo: 1,
       });
-      expect(metadata.type).toEqual('object');
-      expect(metadata.members.bar.value).toEqual('two');
-      expect(metadata.members.bar.type).toEqual('constant');
-      expect(metadata.members.foo.value).toEqual(1);
-      expect(metadata.members.foo.type).toEqual('constant');
+      expect(metadata.type).toBe('object');
+      expect(metadata.members.bar.value).toBe('two');
+      expect(metadata.members.bar.type).toBe('constant');
+      expect(metadata.members.foo.value).toBe(1);
+      expect(metadata.members.foo.type).toBe('constant');
     });
 
     it('retrieves Date object metadata', () => {
       const metadata = moduleMocker.getMetadata(Date);
-      expect(metadata.type).toEqual('function');
-      expect(metadata.name).toEqual('Date');
-      expect(metadata.members.now.name).toEqual('now');
-      expect(metadata.members.parse.name).toEqual('parse');
-      expect(metadata.members.UTC.name).toEqual('UTC');
+      expect(metadata.type).toBe('function');
+      expect(metadata.name).toBe('Date');
+      expect(metadata.members.now.name).toBe('now');
+      expect(metadata.members.parse.name).toBe('parse');
+      expect(metadata.members.UTC.name).toBe('UTC');
     });
   });
 
@@ -456,15 +456,15 @@ describe('moduleMocker', () => {
 
         // null context
         fn.apply(null, []); // eslint-disable-line no-useless-call
-        expect(fn.mock.contexts[3]).toBe(null);
+        expect(fn.mock.contexts[3]).toBeNull();
         fn.call(null); // eslint-disable-line no-useless-call
-        expect(fn.mock.contexts[4]).toBe(null);
+        expect(fn.mock.contexts[4]).toBeNull();
         fn.bind(null)();
-        expect(fn.mock.contexts[5]).toBe(null);
+        expect(fn.mock.contexts[5]).toBeNull();
 
         // Unspecified context is `undefined` in strict mode (like in this test) and `window` otherwise.
         fn();
-        expect(fn.mock.contexts[6]).toBe(undefined);
+        expect(fn.mock.contexts[6]).toBeUndefined();
       });
 
       it('supports clearing mock calls', () => {
@@ -485,7 +485,7 @@ describe('moduleMocker', () => {
         expect(fn.mock.calls).toEqual([['a', 'b', 'c']]);
         expect(fn.mock.contexts).toEqual([undefined]);
 
-        expect(fn()).toEqual('abcd');
+        expect(fn()).toBe('abcd');
       });
 
       it('supports clearing mocks', () => {
@@ -516,8 +516,8 @@ describe('moduleMocker', () => {
         moduleMocker.clearAllMocks();
         expect(fn1.mock.calls).toEqual([]);
         expect(fn2.mock.calls).toEqual([]);
-        expect(fn1()).toEqual('abcd');
-        expect(fn2()).toEqual('abcde');
+        expect(fn1()).toBe('abcd');
+        expect(fn2()).toBe('abcde');
       });
 
       it('supports resetting mock return values', () => {
@@ -525,12 +525,12 @@ describe('moduleMocker', () => {
         fn.mockReturnValue('abcd');
 
         const before = fn();
-        expect(before).toEqual('abcd');
+        expect(before).toBe('abcd');
 
         fn.mockReset();
 
         const after = fn();
-        expect(after).not.toEqual('abcd');
+        expect(after).not.toBe('abcd');
       });
 
       it('supports resetting single use mock return values', () => {
@@ -540,7 +540,7 @@ describe('moduleMocker', () => {
         fn.mockReset();
 
         const after = fn();
-        expect(after).not.toEqual('abcd');
+        expect(after).not.toBe('abcd');
       });
 
       it('supports resetting mock implementations', () => {
@@ -548,12 +548,12 @@ describe('moduleMocker', () => {
         fn.mockImplementation(() => 'abcd');
 
         const before = fn();
-        expect(before).toEqual('abcd');
+        expect(before).toBe('abcd');
 
         fn.mockReset();
 
         const after = fn();
-        expect(after).not.toEqual('abcd');
+        expect(after).not.toBe('abcd');
       });
 
       it('supports resetting single use mock implementations', () => {
@@ -563,7 +563,7 @@ describe('moduleMocker', () => {
         fn.mockReset();
 
         const after = fn();
-        expect(after).not.toEqual('abcd');
+        expect(after).not.toBe('abcd');
       });
 
       it('supports resetting all mocks', () => {
@@ -580,8 +580,8 @@ describe('moduleMocker', () => {
         moduleMocker.resetAllMocks();
         expect(fn1.mock.calls).toEqual([]);
         expect(fn2.mock.calls).toEqual([]);
-        expect(fn1()).not.toEqual('abcd');
-        expect(fn2()).not.toEqual('abcd');
+        expect(fn1()).not.toBe('abcd');
+        expect(fn2()).not.toBe('abcd');
       });
 
       it('maintains function arity', () => {
@@ -600,8 +600,8 @@ describe('moduleMocker', () => {
       moduleMocker.spyOn(child, 'func').mockReturnValue('efgh');
 
       expect(Object.prototype.hasOwnProperty.call(child, 'func')).toBe(true);
-      expect(child.func()).toEqual('efgh');
-      expect(parent.func()).toEqual('abcd');
+      expect(child.func()).toBe('efgh');
+      expect(parent.func()).toBe('abcd');
     });
 
     it('should delete previously inexistent methods when restoring', () => {
@@ -611,12 +611,12 @@ describe('moduleMocker', () => {
       moduleMocker.spyOn(child, 'func').mockReturnValue('efgh');
 
       moduleMocker.restoreAllMocks();
-      expect(child.func()).toEqual('abcd');
+      expect(child.func()).toBe('abcd');
 
       moduleMocker.spyOn(parent, 'func').mockReturnValue('jklm');
 
       expect(Object.prototype.hasOwnProperty.call(child, 'func')).toBe(false);
-      expect(child.func()).toEqual('jklm');
+      expect(child.func()).toBe('jklm');
     });
 
     it('supports mock value returning undefined', () => {
@@ -626,7 +626,7 @@ describe('moduleMocker', () => {
 
       moduleMocker.spyOn(obj, 'func').mockReturnValue(undefined);
 
-      expect(obj.func()).not.toEqual('some text');
+      expect(obj.func()).not.toBe('some text');
     });
 
     it('supports mock value once returning undefined', () => {
@@ -636,14 +636,14 @@ describe('moduleMocker', () => {
 
       moduleMocker.spyOn(obj, 'func').mockReturnValueOnce(undefined);
 
-      expect(obj.func()).not.toEqual('some text');
+      expect(obj.func()).not.toBe('some text');
     });
 
     it('mockReturnValueOnce mocks value just once', () => {
       const fake = jest.fn(a => a + 2);
       fake.mockReturnValueOnce(42);
-      expect(fake(2)).toEqual(42);
-      expect(fake(2)).toEqual(4);
+      expect(fake(2)).toBe(42);
+      expect(fake(2)).toBe(4);
     });
 
     it('supports mocking resolvable async functions', () => {
@@ -985,7 +985,7 @@ describe('moduleMocker', () => {
         fn('a', 'b', 'c');
         expect(fn.mock.invocationCallOrder).toEqual([2]);
 
-        expect(fn()).toEqual('abcd');
+        expect(fn()).toBe('abcd');
       });
 
       it('supports clearing all mocks invocationCallOrder', () => {
@@ -1004,8 +1004,8 @@ describe('moduleMocker', () => {
         moduleMocker.clearAllMocks();
         expect(fn1.mock.invocationCallOrder).toEqual([]);
         expect(fn2.mock.invocationCallOrder).toEqual([]);
-        expect(fn1()).toEqual('abcd');
-        expect(fn2()).toEqual('abcde');
+        expect(fn1()).toBe('abcd');
+        expect(fn2()).toBe('abcde');
       });
 
       it('handles a property called `prototype`', () => {

--- a/packages/jest-reporters/src/__tests__/CoverageWorker.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageWorker.test.js
@@ -45,7 +45,7 @@ test('resolves to the result of generateEmptyCoverage upon success', async () =>
     undefined,
   );
 
-  expect(result).toEqual(42);
+  expect(result).toBe(42);
 });
 
 test('throws errors on invalid JavaScript', async () => {

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -49,7 +49,7 @@ beforeEach(async () => {
 
 test('resolves no dependencies for non-existent path', () => {
   const resolved = dependencyResolver.resolve('/non/existent/path');
-  expect(resolved.length).toEqual(0);
+  expect(resolved.length).toBe(0);
 });
 
 test('resolves dependencies for existing path', () => {
@@ -86,13 +86,13 @@ test('resolves dependencies for scoped packages', () => {
 test('resolves no inverse dependencies for empty paths set', () => {
   const paths = new Set<string>();
   const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toEqual(0);
+  expect(resolved.length).toBe(0);
 });
 
 test('resolves no inverse dependencies for set of non-existent paths', () => {
   const paths = new Set(['/non/existent/path', '/another/one']);
   const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toEqual(0);
+  expect(resolved.length).toBe(0);
 });
 
 test('resolves inverse dependencies for existing path', () => {

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -53,21 +53,21 @@ describe('isCoreModule', () => {
       hasCoreModules: false,
     } as ResolverConfig);
     const isCore = resolver.isCoreModule('assert');
-    expect(isCore).toEqual(false);
+    expect(isCore).toBe(false);
   });
 
   it('returns true if `hasCoreModules` is true and `moduleName` is a core module.', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('assert');
-    expect(isCore).toEqual(true);
+    expect(isCore).toBe(true);
   });
 
   it('returns false if `hasCoreModules` is true and `moduleName` is not a core module.', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('not-a-core-module');
-    expect(isCore).toEqual(false);
+    expect(isCore).toBe(false);
   });
 
   it('returns false if `hasCoreModules` is true and `moduleNameMapper` alias a module same name with core module', () => {
@@ -81,21 +81,21 @@ describe('isCoreModule', () => {
       ],
     } as ResolverConfig);
     const isCore = resolver.isCoreModule('constants');
-    expect(isCore).toEqual(false);
+    expect(isCore).toBe(false);
   });
 
   it('returns true if using `node:` URLs and `moduleName` is a core module.', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('node:assert');
-    expect(isCore).toEqual(true);
+    expect(isCore).toBe(true);
   });
 
   it('returns false if using `node:` URLs and `moduleName` is not a core module.', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('node:not-a-core-module');
-    expect(isCore).toEqual(false);
+    expect(isCore).toBe(false);
   });
 });
 
@@ -301,7 +301,7 @@ describe('findNodeModule', () => {
         conditions: [],
       });
 
-      expect(result).toEqual(null);
+      expect(result).toBeNull();
     });
 
     test('fails if own pkg.json with no exports', () => {
@@ -313,7 +313,7 @@ describe('findNodeModule', () => {
         conditions: [],
       });
 
-      expect(result).toEqual(null);
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_create_mock_from_module.test.js
@@ -36,7 +36,7 @@ describe('Runtime', () => {
       const mock = module.jest.createMockFromModule('ModuleWithSideEffects');
 
       // Make sure we get a mock.
-      expect(mock.fn()).toBe(undefined);
+      expect(mock.fn()).toBeUndefined();
       expect(module.getModuleStateValue()).toBe(origModuleStateValue);
     });
 

--- a/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
+++ b/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
@@ -31,7 +31,7 @@ describe('Runtime', () => {
       const mock = root.jest.fn(string => `${string} implementation`);
       expect(mock._isMockFunction).toBe(true);
       const value = mock('mock');
-      expect(value).toEqual('mock implementation');
+      expect(value).toBe('mock implementation');
       expect(mock).toBeCalled();
     });
   });

--- a/packages/jest-runtime/src/__tests__/runtime_module_directories.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_module_directories.test.js
@@ -37,7 +37,7 @@ describe('Runtime', () => {
       moduleDirectories,
     });
     const exports = runtime.requireModule(runtime.__mockRootPath, 'my-module');
-    expect(exports.isNodeModule).toEqual(true);
+    expect(exports.isNodeModule).toBe(true);
   });
 
   it('finds closest module from moduleDirectories', async () => {
@@ -46,9 +46,7 @@ describe('Runtime', () => {
       path.join(rootDir, 'subdir2', 'my_module.js'),
       'module_dir_module',
     );
-    expect(exports.modulePath).toEqual(
-      'subdir2/module_dir/module_dir_module.js',
-    );
+    expect(exports.modulePath).toBe('subdir2/module_dir/module_dir_module.js');
   });
 
   it('only checks the configured directories', async () => {

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -83,7 +83,7 @@ describe('Runtime requireModule', () => {
       runtime.__mockRootPath,
       'inner_parent_module',
     );
-    expect(exports.outputString).toEqual('This should happen');
+    expect(exports.outputString).toBe('This should happen');
   });
 
   it('resolve module.parent.filename correctly', async () => {
@@ -93,7 +93,7 @@ describe('Runtime requireModule', () => {
       'inner_parent_module',
     );
 
-    expect(slash(exports.parentFileName.replace(__dirname, ''))).toEqual(
+    expect(slash(exports.parentFileName.replace(__dirname, ''))).toBe(
       '/test_root/inner_parent_module.js',
     );
   });
@@ -106,9 +106,9 @@ describe('Runtime requireModule', () => {
     );
 
     // `exports.loaded` is set while the module is loaded, so should be `false`
-    expect(exports.loaded).toEqual(false);
+    expect(exports.loaded).toBe(false);
     // After the module is loaded we can query `module.loaded` again, at which point it should be `true`
-    expect(exports.isLoaded()).toEqual(true);
+    expect(exports.isLoaded()).toBe(true);
   });
 
   it('provides `module.filename` to modules', async () => {

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
@@ -153,7 +153,7 @@ it('automocking is disabled by default', async () => {
     runtime.__mockRootPath,
     'RegularModule',
   );
-  expect(exports.setModuleStateValue._isMockFunction).toBe(undefined);
+  expect(exports.setModuleStateValue._isMockFunction).toBeUndefined();
 });
 
 it('unmocks modules in config.unmockedModulePathPatterns for tests with automock enabled when automock is false', async () => {

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js
@@ -29,8 +29,8 @@ describe('transitive dependencies', () => {
   const expectUnmocked = nodeModule => {
     const moduleData = nodeModule();
     expect(moduleData.isUnmocked()).toBe(true);
-    expect(moduleData.transitiveNPM3Dep).toEqual('npm3-transitive-dep');
-    expect(moduleData.internalImplementation()).toEqual('internal-module-code');
+    expect(moduleData.transitiveNPM3Dep).toBe('npm3-transitive-dep');
+    expect(moduleData.internalImplementation()).toBe('internal-module-code');
   };
 
   it('mocks a manually mocked and mapped module', async () => {
@@ -73,7 +73,7 @@ describe('transitive dependencies', () => {
       runtime.__mockRootPath,
       'npm3-transitive-dep',
     );
-    expect(transitiveDep()).toEqual(undefined);
+    expect(transitiveDep()).toBeUndefined();
   });
 
   it('unmocks transitive dependencies in node_modules when using unmock', async () => {
@@ -98,7 +98,7 @@ describe('transitive dependencies', () => {
       runtime.__mockRootPath,
       'npm3-transitive-dep',
     );
-    expect(transitiveDep()).toEqual(undefined);
+    expect(transitiveDep()).toBeUndefined();
   });
 
   it('unmocks transitive dependencies in node_modules by default when using both patterns and unmock', async () => {
@@ -124,7 +124,7 @@ describe('transitive dependencies', () => {
       runtime.__mockRootPath,
       'npm3-transitive-dep',
     );
-    expect(transitiveDep()).toEqual(undefined);
+    expect(transitiveDep()).toBeUndefined();
   });
 
   it('mocks deep dependencies when using unmock', async () => {

--- a/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
+++ b/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
@@ -130,7 +130,7 @@ describe('dedentLines null', () => {
     ['object value multi-line', {key: 'multi\nline\nvalue'}],
     ['object key and value multi-line', {'multi\nline': '\nleading nl'}],
   ])('%s', (name, val) => {
-    expect(dedentLines(formatLines2(val))).toEqual(null);
+    expect(dedentLines(formatLines2(val))).toBeNull();
   });
 
   test('markup prop multi-line', () => {
@@ -145,7 +145,7 @@ describe('dedentLines null', () => {
     };
     const indented = formatLines2(val);
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 
   test('markup prop component with multi-line text', () => {
@@ -178,7 +178,7 @@ describe('dedentLines null', () => {
     };
     const indented = formatLines2(val);
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 
   test('markup text multi-line', () => {
@@ -205,7 +205,7 @@ describe('dedentLines null', () => {
     };
     const indented = formatLines2(val);
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 
   test('markup text multiple lines', () => {
@@ -232,18 +232,18 @@ describe('dedentLines null', () => {
     };
     const indented = formatLines2(val);
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 
   test('markup unclosed self-closing start tag', () => {
     const indented = ['<img', '  alt="Jest logo"', '  src="jest.svg"'];
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 
   test('markup unclosed because no end tag', () => {
     const indented = ['<p>', '  Delightful JavaScript testing'];
 
-    expect(dedentLines(indented)).toEqual(null);
+    expect(dedentLines(indented)).toBeNull();
   });
 });

--- a/packages/jest-util/src/__tests__/createProcessObject.test.ts
+++ b/packages/jest-util/src/__tests__/createProcessObject.test.ts
@@ -59,13 +59,13 @@ it('checks that process.env works as expected on Linux platforms', () => {
   expect(fake.PROP_UNDEFINED).toBe('undefined');
 
   // Mac and Linux are case sensitive.
-  expect(fake.PROP_string).toBe(undefined);
+  expect(fake.PROP_string).toBeUndefined();
 
   // Added properties to the fake object are not added to the real one.
   fake.PROP_ADDED = 'new!';
 
   expect(fake.PROP_ADDED).toBe('new!');
-  expect(process.env.PROP_ADDED).toBe(undefined);
+  expect(process.env.PROP_ADDED).toBeUndefined();
 
   // You can delete properties, but they are case sensitive!
   fake.prop = 'foo';
@@ -77,7 +77,7 @@ it('checks that process.env works as expected on Linux platforms', () => {
   delete fake.PROP;
 
   expect(fake.prop).toBe('foo');
-  expect(fake.PROP).toBe(undefined);
+  expect(fake.PROP).toBeUndefined();
 });
 
 it('checks that process.env works as expected in Windows platforms', () => {

--- a/packages/jest-util/src/__tests__/deepCyclicCopy.test.ts
+++ b/packages/jest-util/src/__tests__/deepCyclicCopy.test.ts
@@ -11,8 +11,8 @@ import deepCyclicCopy from '../deepCyclicCopy';
 it('returns the same value for primitive or function values', () => {
   const fn = () => {};
 
-  expect(deepCyclicCopy(undefined)).toBe(undefined);
-  expect(deepCyclicCopy(null)).toBe(null);
+  expect(deepCyclicCopy(undefined)).toBeUndefined();
+  expect(deepCyclicCopy(null)).toBeNull();
   expect(deepCyclicCopy(true)).toBe(true);
   expect(deepCyclicCopy(42)).toBe(42);
   expect(Number.isNaN(deepCyclicCopy(NaN))).toBe(true);

--- a/packages/jest-worker/src/__tests__/Farm.test.js
+++ b/packages/jest-worker/src/__tests__/Farm.test.js
@@ -186,7 +186,7 @@ describe('Farm', () => {
     workerReply(0, null, 34);
     const result = await promise;
 
-    expect(result).toEqual(34);
+    expect(result).toBe(34);
   });
 
   it('throws if the call failed', async () => {
@@ -203,7 +203,7 @@ describe('Farm', () => {
       error = err;
     }
 
-    expect(error).not.toBe(null);
+    expect(error).not.toBeNull();
     expect(error).toBeInstanceOf(TypeError);
   });
 

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -165,7 +165,7 @@ it('calls doWork', async () => {
 
   const promise = farm.foo('car', 'plane');
 
-  expect(await promise).toEqual(42);
+  expect(await promise).toBe(42);
 });
 
 it('calls getStderr and getStdout from worker', async () => {
@@ -174,6 +174,6 @@ it('calls getStderr and getStdout from worker', async () => {
     numWorkers: 1,
   });
 
-  expect(farm.getStderr()('err')).toEqual('err');
-  expect(farm.getStdout()('out')).toEqual('out');
+  expect(farm.getStderr()('err')).toBe('err');
+  expect(farm.getStdout()('out')).toBe('out');
 });

--- a/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
+++ b/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
@@ -112,9 +112,9 @@ describe('BaseWorkerPool', () => {
     });
 
     expect(Worker).toHaveBeenCalledTimes(3);
-    expect(Worker.mock.calls[0][0].workerId).toEqual(0);
-    expect(Worker.mock.calls[1][0].workerId).toEqual(1);
-    expect(Worker.mock.calls[2][0].workerId).toEqual(2);
+    expect(Worker.mock.calls[0][0].workerId).toBe(0);
+    expect(Worker.mock.calls[1][0].workerId).toBe(1);
+    expect(Worker.mock.calls[2][0].workerId).toBe(2);
   });
 
   it('aggregates all stdouts and stderrs from all workers', () => {

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -97,7 +97,7 @@ it('passes workerId to the child process and assign it to 1-indexed env.JEST_WOR
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.fork.mock.calls[0][2].env.JEST_WORKER_ID).toEqual('3');
+  expect(childProcess.fork.mock.calls[0][2].env.JEST_WORKER_ID).toBe('3');
 });
 
 it('initializes the child process with the given workerPath', () => {
@@ -141,7 +141,7 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   expect(onProcessEnd).toHaveBeenCalledTimes(1);
   expect(onProcessEnd.mock.calls[0][0]).toBeInstanceOf(Error);
   expect(onProcessEnd.mock.calls[0][0].type).toBe('WorkerError');
-  expect(onProcessEnd.mock.calls[0][1]).toBe(null);
+  expect(onProcessEnd.mock.calls[0][1]).toBeNull();
 });
 
 it('provides stdout and stderr from the child processes', async () => {
@@ -161,8 +161,8 @@ it('provides stdout and stderr from the child processes', async () => {
   forkInterface.stderr.end('Workers!', 'utf8');
   forkInterface.emit('exit', 0);
 
-  await expect(getStream(stdout)).resolves.toEqual('Hello World!');
-  await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');
+  await expect(getStream(stdout)).resolves.toBe('Hello World!');
+  await expect(getStream(stderr)).resolves.toBe('Jest Workers!');
 });
 
 it('sends the task to the child process', () => {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -125,7 +125,7 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   expect(onProcessEnd).toHaveBeenCalledTimes(1);
   expect(onProcessEnd.mock.calls[0][0]).toBeInstanceOf(Error);
   expect(onProcessEnd.mock.calls[0][0].type).toBe('WorkerError');
-  expect(onProcessEnd.mock.calls[0][1]).toBe(null);
+  expect(onProcessEnd.mock.calls[0][1]).toBeNull();
 });
 
 it('provides stdout and stderr from the threads', async () => {
@@ -145,8 +145,8 @@ it('provides stdout and stderr from the threads', async () => {
   worker._worker.stderr.end('Workers!', 'utf8');
   worker._worker.emit('exit', 0);
 
-  await expect(getStream(stdout)).resolves.toEqual('Hello World!');
-  await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');
+  await expect(getStream(stdout)).resolves.toBe('Hello World!');
+  await expect(getStream(stderr)).resolves.toBe('Jest Workers!');
 });
 
 it('sends the task to the thread', () => {

--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.js
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.js
@@ -376,7 +376,7 @@ describe.each([
       // Give it some time to restart some workers
       await new Promise(resolve => setTimeout(resolve, 4000));
 
-      expect(startedWorkers).toEqual(6);
+      expect(startedWorkers).toBe(6);
 
       expect(worker.isWorkerRunning()).toBeTruthy();
       expect(worker.state).toEqual(WorkerStates.OK);

--- a/packages/jest-worker/src/workers/__tests__/processChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/processChild.test.js
@@ -140,7 +140,7 @@ it('lazily requires the file', () => {
   ]);
 
   expect(mockCount).toBe(1);
-  expect(initializeParm).toBe(undefined);
+  expect(initializeParm).toBeUndefined();
 });
 
 it('should return memory usage', () => {
@@ -248,9 +248,7 @@ it('returns results immediately when function is synchronous', () => {
 
   expect(process.send.mock.calls[4][0][0]).toBe(PARENT_MESSAGE_CLIENT_ERROR);
   expect(process.send.mock.calls[4][0][1]).toBe('Error');
-  expect(process.send.mock.calls[4][0][2]).toEqual(
-    '"null" or "undefined" thrown',
-  );
+  expect(process.send.mock.calls[4][0][2]).toBe('"null" or "undefined" thrown');
 
   expect(process.send).toHaveBeenCalledTimes(5);
 });

--- a/packages/jest-worker/src/workers/__tests__/threadChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/threadChild.test.js
@@ -160,7 +160,7 @@ it('lazily requires the file', () => {
   ]);
 
   expect(mockCount).toBe(1);
-  expect(initializeParm).toBe(undefined);
+  expect(initializeParm).toBeUndefined();
 });
 
 it('calls initialize with the correct arguments', () => {
@@ -260,7 +260,7 @@ it('returns results immediately when function is synchronous', () => {
     PARENT_MESSAGE_CLIENT_ERROR,
   );
   expect(thread.postMessage.mock.calls[4][0][1]).toBe('Error');
-  expect(thread.postMessage.mock.calls[4][0][2]).toEqual(
+  expect(thread.postMessage.mock.calls[4][0][2]).toBe(
     '"null" or "undefined" thrown',
   );
 

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 ].forEach(type => {
   test(`supports any(${fnNameFor(type)})`, () => {
     const result = prettyFormat(expect.any(type), options);
-    expect(result).toEqual(`Any<${fnNameFor(type)}>`);
+    expect(result).toBe(`Any<${fnNameFor(type)}>`);
   });
 
   test(`supports nested any(${fnNameFor(type)})`, () => {
@@ -49,7 +49,7 @@ beforeEach(() => {
       },
       options,
     );
-    expect(result).toEqual(
+    expect(result).toBe(
       `Object {\n  "test": Object {\n    "nested": Any<${fnNameFor(
         type,
       )}>,\n  },\n}`,
@@ -59,12 +59,12 @@ beforeEach(() => {
 
 test('anything()', () => {
   const result = prettyFormat(expect.anything(), options);
-  expect(result).toEqual('Anything');
+  expect(result).toBe('Anything');
 });
 
 test('arrayContaining()', () => {
   const result = prettyFormat(expect.arrayContaining([1, 2]), options);
-  expect(result).toEqual(`ArrayContaining [
+  expect(result).toBe(`ArrayContaining [
   1,
   2,
 ]`);
@@ -72,7 +72,7 @@ test('arrayContaining()', () => {
 
 test('arrayNotContaining()', () => {
   const result = prettyFormat(expect.not.arrayContaining([1, 2]), options);
-  expect(result).toEqual(`ArrayNotContaining [
+  expect(result).toBe(`ArrayNotContaining [
   1,
   2,
 ]`);
@@ -80,7 +80,7 @@ test('arrayNotContaining()', () => {
 
 test('objectContaining()', () => {
   const result = prettyFormat(expect.objectContaining({a: 'test'}), options);
-  expect(result).toEqual(`ObjectContaining {
+  expect(result).toBe(`ObjectContaining {
   "a": "test",
 }`);
 });
@@ -90,75 +90,75 @@ test('objectNotContaining()', () => {
     expect.not.objectContaining({a: 'test'}),
     options,
   );
-  expect(result).toEqual(`ObjectNotContaining {
+  expect(result).toBe(`ObjectNotContaining {
   "a": "test",
 }`);
 });
 
 test('stringContaining(string)', () => {
   const result = prettyFormat(expect.stringContaining('jest'), options);
-  expect(result).toEqual('StringContaining "jest"');
+  expect(result).toBe('StringContaining "jest"');
 });
 
 test('not.stringContaining(string)', () => {
   const result = prettyFormat(expect.not.stringContaining('jest'), options);
-  expect(result).toEqual('StringNotContaining "jest"');
+  expect(result).toBe('StringNotContaining "jest"');
 });
 
 test('stringMatching(string)', () => {
   const result = prettyFormat(expect.stringMatching('jest'), options);
-  expect(result).toEqual('StringMatching /jest/');
+  expect(result).toBe('StringMatching /jest/');
 });
 
 test('stringMatching(regexp)', () => {
   const result = prettyFormat(expect.stringMatching(/(jest|niema).*/), options);
-  expect(result).toEqual('StringMatching /(jest|niema).*/');
+  expect(result).toBe('StringMatching /(jest|niema).*/');
 });
 
 test('stringMatching(regexp) {escapeRegex: false}', () => {
   const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
-  expect(result).toEqual('StringMatching /regexp\\d/gi');
+  expect(result).toBe('StringMatching /regexp\\d/gi');
 });
 
 test('stringMatching(regexp) {escapeRegex: true}', () => {
   options.escapeRegex = true;
   const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
-  expect(result).toEqual('StringMatching /regexp\\\\d/gi');
+  expect(result).toBe('StringMatching /regexp\\\\d/gi');
 });
 
 test('stringNotMatching(string)', () => {
   const result = prettyFormat(expect.not.stringMatching('jest'), options);
-  expect(result).toEqual('StringNotMatching /jest/');
+  expect(result).toBe('StringNotMatching /jest/');
 });
 
 test('closeTo(number, precision)', () => {
   const result = prettyFormat(expect.closeTo(1.2345, 4), options);
-  expect(result).toEqual('NumberCloseTo 1.2345 (4 digits)');
+  expect(result).toBe('NumberCloseTo 1.2345 (4 digits)');
 });
 
 test('notCloseTo(number, precision)', () => {
   const result = prettyFormat(expect.not.closeTo(1.2345, 1), options);
-  expect(result).toEqual('NumberNotCloseTo 1.2345 (1 digit)');
+  expect(result).toBe('NumberNotCloseTo 1.2345 (1 digit)');
 });
 
 test('closeTo(number)', () => {
   const result = prettyFormat(expect.closeTo(1.2345), options);
-  expect(result).toEqual('NumberCloseTo 1.2345 (2 digits)');
+  expect(result).toBe('NumberCloseTo 1.2345 (2 digits)');
 });
 
 test('closeTo(Infinity)', () => {
   const result = prettyFormat(expect.closeTo(-Infinity), options);
-  expect(result).toEqual('NumberCloseTo -Infinity (2 digits)');
+  expect(result).toBe('NumberCloseTo -Infinity (2 digits)');
 });
 
 test('closeTo(scientific number)', () => {
   const result = prettyFormat(expect.closeTo(1.56e-3, 4), options);
-  expect(result).toEqual('NumberCloseTo 0.00156 (4 digits)');
+  expect(result).toBe('NumberCloseTo 0.00156 (4 digits)');
 });
 
 test('closeTo(very small scientific number)', () => {
   const result = prettyFormat(expect.closeTo(1.56e-10, 4), options);
-  expect(result).toEqual('NumberCloseTo 1.56e-10 (4 digits)');
+  expect(result).toBe('NumberCloseTo 1.56e-10 (4 digits)');
 });
 
 test('correctly handles inability to pretty-print matcher', () => {
@@ -183,7 +183,7 @@ test('supports multiple nested asymmetric matchers', () => {
     },
     options,
   );
-  expect(result).toEqual(`Object {
+  expect(result).toBe(`Object {
   "test": Object {
     "nested": ObjectContaining {
       "a": ArrayContaining [
@@ -278,7 +278,7 @@ describe('maxDepth option', () => {
       ],
     };
     const result = prettyFormat(val, options);
-    expect(result).toEqual(`Object {
+    expect(result).toBe(`Object {
   "nested": Array [
     [ArrayContaining],
     [ObjectContaining],
@@ -313,7 +313,7 @@ describe('maxDepth option', () => {
       }),
     ];
     const result = prettyFormat(val, options);
-    expect(result).toEqual(`Array [
+    expect(result).toBe(`Array [
   ArrayContaining [
     "printed",
     [Object],
@@ -343,7 +343,7 @@ test('min option', () => {
     },
     options,
   );
-  expect(result).toEqual(
+  expect(result).toBe(
     '{"test": {"nested": ObjectContaining {"a": ArrayContaining [1], "b": Anything, "c": Any<String>, "d": StringContaining "jest", "e": StringMatching /jest/, "f": ObjectContaining {"test": "case"}}}}',
   );
 });

--- a/packages/pretty-format/src/__tests__/DOMElement.test.ts
+++ b/packages/pretty-format/src/__tests__/DOMElement.test.ts
@@ -21,7 +21,7 @@ setPrettyPrint([DOMElement]);
 describe('pretty-format', () => {
   // Test is not related to plugin but is related to jsdom testing environment.
   it('prints global window as constructor name alone', () => {
-    expect(prettyFormat(window)).toEqual('[Window]');
+    expect(prettyFormat(window)).toBe('[Window]');
   });
 });
 

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -23,90 +23,90 @@ function MyObject(value: unknown) {
 describe('prettyFormat()', () => {
   it('prints empty arguments', () => {
     const val = returnArguments();
-    expect(prettyFormat(val)).toEqual('Arguments []');
+    expect(prettyFormat(val)).toBe('Arguments []');
   });
 
   it('prints arguments', () => {
     const val = returnArguments(1, 2, 3);
-    expect(prettyFormat(val)).toEqual('Arguments [\n  1,\n  2,\n  3,\n]');
+    expect(prettyFormat(val)).toBe('Arguments [\n  1,\n  2,\n  3,\n]');
   });
 
   it('prints an empty array', () => {
     const val: Array<never> = [];
-    expect(prettyFormat(val)).toEqual('Array []');
+    expect(prettyFormat(val)).toBe('Array []');
   });
 
   it('prints an array with items', () => {
     const val = [1, 2, 3];
-    expect(prettyFormat(val)).toEqual('Array [\n  1,\n  2,\n  3,\n]');
+    expect(prettyFormat(val)).toBe('Array [\n  1,\n  2,\n  3,\n]');
   });
 
   it('prints a sparse array with only holes', () => {
     // eslint-disable-next-line no-sparse-arrays
     const val = [, , ,];
-    expect(prettyFormat(val)).toEqual('Array [\n  ,\n  ,\n  ,\n]');
+    expect(prettyFormat(val)).toBe('Array [\n  ,\n  ,\n  ,\n]');
   });
 
   it('prints a sparse array with items', () => {
     // eslint-disable-next-line no-sparse-arrays
     const val = [1, , , 4];
-    expect(prettyFormat(val)).toEqual('Array [\n  1,\n  ,\n  ,\n  4,\n]');
+    expect(prettyFormat(val)).toBe('Array [\n  1,\n  ,\n  ,\n  4,\n]');
   });
 
   it('prints a sparse array with value surrounded by holes', () => {
     // eslint-disable-next-line no-sparse-arrays
     const val = [, 5, ,];
-    expect(prettyFormat(val)).toEqual('Array [\n  ,\n  5,\n  ,\n]');
+    expect(prettyFormat(val)).toBe('Array [\n  ,\n  5,\n  ,\n]');
   });
 
   it('prints a sparse array also containing undefined values', () => {
     // eslint-disable-next-line no-sparse-arrays
     const val = [1, , undefined, undefined, , 4];
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Array [\n  1,\n  ,\n  undefined,\n  undefined,\n  ,\n  4,\n]',
     );
   });
 
   it('prints a empty typed array', () => {
     const val = new Uint32Array(0);
-    expect(prettyFormat(val)).toEqual('Uint32Array []');
+    expect(prettyFormat(val)).toBe('Uint32Array []');
   });
 
   it('prints a typed array with items', () => {
     const val = new Uint32Array(3);
-    expect(prettyFormat(val)).toEqual('Uint32Array [\n  0,\n  0,\n  0,\n]');
+    expect(prettyFormat(val)).toBe('Uint32Array [\n  0,\n  0,\n  0,\n]');
   });
 
   it('prints an array buffer', () => {
     const val = new ArrayBuffer(3);
-    expect(prettyFormat(val)).toEqual('ArrayBuffer []');
+    expect(prettyFormat(val)).toBe('ArrayBuffer []');
   });
 
   it('prints a nested array', () => {
     const val = [[1, 2, 3]];
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Array [\n  Array [\n    1,\n    2,\n    3,\n  ],\n]',
     );
   });
 
   it('prints true', () => {
     const val = true;
-    expect(prettyFormat(val)).toEqual('true');
+    expect(prettyFormat(val)).toBe('true');
   });
 
   it('prints false', () => {
     const val = false;
-    expect(prettyFormat(val)).toEqual('false');
+    expect(prettyFormat(val)).toBe('false');
   });
 
   it('prints an error', () => {
     const val = new Error();
-    expect(prettyFormat(val)).toEqual('[Error]');
+    expect(prettyFormat(val)).toBe('[Error]');
   });
 
   it('prints a typed error with a message', () => {
     const val = new TypeError('message');
-    expect(prettyFormat(val)).toEqual('[TypeError: message]');
+    expect(prettyFormat(val)).toBe('[TypeError: message]');
   });
 
   it('prints a function constructor', () => {
@@ -114,7 +114,7 @@ describe('prettyFormat()', () => {
     const val = new Function();
     /* eslint-enable no-new-func */
     // In Node >=8.1.4: val.name === 'anonymous'
-    expect(prettyFormat(val)).toEqual('[Function anonymous]');
+    expect(prettyFormat(val)).toBe('[Function anonymous]');
   });
 
   it('prints an anonymous callback function', () => {
@@ -124,7 +124,7 @@ describe('prettyFormat()', () => {
     }
     f(() => {});
     // In Node >=8.1.4: val.name === ''
-    expect(prettyFormat(val)).toEqual('[Function anonymous]');
+    expect(prettyFormat(val)).toBe('[Function anonymous]');
   });
 
   it('prints an anonymous assigned function', () => {
@@ -138,7 +138,7 @@ describe('prettyFormat()', () => {
 
   it('prints a named function', () => {
     const val = function named() {};
-    expect(prettyFormat(val)).toEqual('[Function named]');
+    expect(prettyFormat(val)).toBe('[Function named]');
   });
 
   it('prints a named generator function', () => {
@@ -147,7 +147,7 @@ describe('prettyFormat()', () => {
       yield 2;
       yield 3;
     };
-    expect(prettyFormat(val)).toEqual('[Function generate]');
+    expect(prettyFormat(val)).toBe('[Function generate]');
   });
 
   it('can customize function names', () => {
@@ -156,29 +156,29 @@ describe('prettyFormat()', () => {
       prettyFormat(val, {
         printFunctionName: false,
       }),
-    ).toEqual('[Function]');
+    ).toBe('[Function]');
   });
 
   it('prints Infinity', () => {
     const val = Infinity;
-    expect(prettyFormat(val)).toEqual('Infinity');
+    expect(prettyFormat(val)).toBe('Infinity');
   });
 
   it('prints -Infinity', () => {
     const val = -Infinity;
-    expect(prettyFormat(val)).toEqual('-Infinity');
+    expect(prettyFormat(val)).toBe('-Infinity');
   });
 
   it('prints an empty map', () => {
     const val = new Map();
-    expect(prettyFormat(val)).toEqual('Map {}');
+    expect(prettyFormat(val)).toBe('Map {}');
   });
 
   it('prints a map with values', () => {
     const val = new Map();
     val.set('prop1', 'value1');
     val.set('prop2', 'value2');
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Map {\n  "prop1" => "value1",\n  "prop2" => "value2",\n}',
     );
   });
@@ -224,72 +224,72 @@ describe('prettyFormat()', () => {
 
   it('prints NaN', () => {
     const val = NaN;
-    expect(prettyFormat(val)).toEqual('NaN');
+    expect(prettyFormat(val)).toBe('NaN');
   });
 
   it('prints null', () => {
     const val = null;
-    expect(prettyFormat(val)).toEqual('null');
+    expect(prettyFormat(val)).toBe('null');
   });
 
   it('prints a positive number', () => {
     const val = 123;
-    expect(prettyFormat(val)).toEqual('123');
+    expect(prettyFormat(val)).toBe('123');
   });
 
   it('prints a negative number', () => {
     const val = -123;
-    expect(prettyFormat(val)).toEqual('-123');
+    expect(prettyFormat(val)).toBe('-123');
   });
 
   it('prints zero', () => {
     const val = 0;
-    expect(prettyFormat(val)).toEqual('0');
+    expect(prettyFormat(val)).toBe('0');
   });
 
   it('prints negative zero', () => {
     const val = -0;
-    expect(prettyFormat(val)).toEqual('-0');
+    expect(prettyFormat(val)).toBe('-0');
   });
 
   it('prints a positive bigint', () => {
     const val = BigInt(123);
-    expect(prettyFormat(val)).toEqual('123n');
+    expect(prettyFormat(val)).toBe('123n');
   });
 
   it('prints a negative bigint', () => {
     const val = BigInt(-123);
-    expect(prettyFormat(val)).toEqual('-123n');
+    expect(prettyFormat(val)).toBe('-123n');
   });
 
   it('prints zero bigint', () => {
     const val = BigInt(0);
-    expect(prettyFormat(val)).toEqual('0n');
+    expect(prettyFormat(val)).toBe('0n');
   });
 
   it('prints negative zero bigint', () => {
     const val = BigInt(-0);
-    expect(prettyFormat(val)).toEqual('0n');
+    expect(prettyFormat(val)).toBe('0n');
   });
 
   it('prints a date', () => {
     const val = new Date(10e11);
-    expect(prettyFormat(val)).toEqual('2001-09-09T01:46:40.000Z');
+    expect(prettyFormat(val)).toBe('2001-09-09T01:46:40.000Z');
   });
 
   it('prints an invalid date', () => {
     const val = new Date(Infinity);
-    expect(prettyFormat(val)).toEqual('Date { NaN }');
+    expect(prettyFormat(val)).toBe('Date { NaN }');
   });
 
   it('prints an empty object', () => {
     const val = {};
-    expect(prettyFormat(val)).toEqual('Object {}');
+    expect(prettyFormat(val)).toBe('Object {}');
   });
 
   it('prints an object with properties', () => {
     const val = {prop1: 'value1', prop2: 'value2'};
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Object {\n  "prop1": "value1",\n  "prop2": "value2",\n}',
     );
   });
@@ -299,7 +299,7 @@ describe('prettyFormat()', () => {
     val[Symbol('symbol1')] = 'value2';
     val[Symbol('symbol2')] = 'value3';
     val.prop = 'value1';
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Object {\n  "prop": "value1",\n  Symbol(symbol1): "value2",\n  Symbol(symbol2): "value3",\n}',
     );
   });
@@ -313,7 +313,7 @@ describe('prettyFormat()', () => {
       enumerable: false,
       value: false,
     });
-    expect(prettyFormat(val)).toEqual('Object {\n  "enumerable": true,\n}');
+    expect(prettyFormat(val)).toBe('Object {\n  "enumerable": true,\n}');
   });
 
   it('prints an object without non-enumerable properties which have symbol key', () => {
@@ -325,20 +325,20 @@ describe('prettyFormat()', () => {
       enumerable: false,
       value: false,
     });
-    expect(prettyFormat(val)).toEqual('Object {\n  "enumerable": true,\n}');
+    expect(prettyFormat(val)).toBe('Object {\n  "enumerable": true,\n}');
   });
 
   it('prints an object with sorted properties', () => {
     // eslint-disable-next-line sort-keys
     const val = {b: 1, a: 2};
-    expect(prettyFormat(val)).toEqual('Object {\n  "a": 2,\n  "b": 1,\n}');
+    expect(prettyFormat(val)).toBe('Object {\n  "a": 2,\n  "b": 1,\n}');
   });
 
   it('prints an object with keys in their original order with the appropriate comparing function', () => {
     // eslint-disable-next-line sort-keys
     const val = {b: 1, a: 2};
     const compareKeys = () => 0;
-    expect(prettyFormat(val, {compareKeys})).toEqual(
+    expect(prettyFormat(val, {compareKeys})).toBe(
       'Object {\n  "b": 1,\n  "a": 2,\n}',
     );
   });
@@ -346,7 +346,7 @@ describe('prettyFormat()', () => {
   it('prints an object with keys in their original order with compareKeys set to null', () => {
     // eslint-disable-next-line sort-keys
     const val = {b: 1, a: 2};
-    expect(prettyFormat(val, {compareKeys: null})).toEqual(
+    expect(prettyFormat(val, {compareKeys: null})).toBe(
       'Object {\n  "b": 1,\n  "a": 2,\n}',
     );
   });
@@ -354,73 +354,73 @@ describe('prettyFormat()', () => {
   it('prints an object with keys sorted in reverse order', () => {
     const val = {a: 1, b: 2};
     const compareKeys = (a: string, b: string) => (a > b ? -1 : 1);
-    expect(prettyFormat(val, {compareKeys})).toEqual(
+    expect(prettyFormat(val, {compareKeys})).toBe(
       'Object {\n  "b": 2,\n  "a": 1,\n}',
     );
   });
 
   it('prints regular expressions from constructors', () => {
     const val = new RegExp('regexp');
-    expect(prettyFormat(val)).toEqual('/regexp/');
+    expect(prettyFormat(val)).toBe('/regexp/');
   });
 
   it('prints regular expressions from literals', () => {
     const val = /regexp/gi;
-    expect(prettyFormat(val)).toEqual('/regexp/gi');
+    expect(prettyFormat(val)).toBe('/regexp/gi');
   });
 
   it('prints regular expressions {escapeRegex: false}', () => {
     const val = /regexp\d/gi;
-    expect(prettyFormat(val)).toEqual('/regexp\\d/gi');
+    expect(prettyFormat(val)).toBe('/regexp\\d/gi');
   });
 
   it('prints regular expressions {escapeRegex: true}', () => {
     const val = /regexp\d/gi;
-    expect(prettyFormat(val, {escapeRegex: true})).toEqual('/regexp\\\\d/gi');
+    expect(prettyFormat(val, {escapeRegex: true})).toBe('/regexp\\\\d/gi');
   });
 
   it('escapes regular expressions nested inside object', () => {
     const obj = {test: /regexp\d/gi};
-    expect(prettyFormat(obj, {escapeRegex: true})).toEqual(
+    expect(prettyFormat(obj, {escapeRegex: true})).toBe(
       'Object {\n  "test": /regexp\\\\d/gi,\n}',
     );
   });
 
   it('prints an empty set', () => {
     const val = new Set();
-    expect(prettyFormat(val)).toEqual('Set {}');
+    expect(prettyFormat(val)).toBe('Set {}');
   });
 
   it('prints a set with values', () => {
     const val = new Set();
     val.add('value1');
     val.add('value2');
-    expect(prettyFormat(val)).toEqual('Set {\n  "value1",\n  "value2",\n}');
+    expect(prettyFormat(val)).toBe('Set {\n  "value1",\n  "value2",\n}');
   });
 
   it('prints a string', () => {
     const val = 'string';
-    expect(prettyFormat(val)).toEqual('"string"');
+    expect(prettyFormat(val)).toBe('"string"');
   });
 
   it('prints and escape a string', () => {
     const val = '"\'\\';
-    expect(prettyFormat(val)).toEqual('"\\"\'\\\\"');
+    expect(prettyFormat(val)).toBe('"\\"\'\\\\"');
   });
 
   it("doesn't escape string with {escapeString: false}", () => {
     const val = '"\'\\n';
-    expect(prettyFormat(val, {escapeString: false})).toEqual('""\'\\n"');
+    expect(prettyFormat(val, {escapeString: false})).toBe('""\'\\n"');
   });
 
   it('prints a string with escapes', () => {
-    expect(prettyFormat('"-"')).toEqual('"\\"-\\""');
-    expect(prettyFormat('\\ \\\\')).toEqual('"\\\\ \\\\\\\\"');
+    expect(prettyFormat('"-"')).toBe('"\\"-\\""');
+    expect(prettyFormat('\\ \\\\')).toBe('"\\\\ \\\\\\\\"');
   });
 
   it('prints a multiline string', () => {
     const val = ['line 1', 'line 2', 'line 3'].join('\n');
-    expect(prettyFormat(val)).toEqual(`"${val}"`);
+    expect(prettyFormat(val)).toBe(`"${val}"`);
   });
 
   it('prints a multiline string as value of object property', () => {
@@ -459,27 +459,27 @@ describe('prettyFormat()', () => {
 
   it('prints a symbol', () => {
     const val = Symbol('symbol');
-    expect(prettyFormat(val)).toEqual('Symbol(symbol)');
+    expect(prettyFormat(val)).toBe('Symbol(symbol)');
   });
 
   it('prints undefined', () => {
     const val = undefined;
-    expect(prettyFormat(val)).toEqual('undefined');
+    expect(prettyFormat(val)).toBe('undefined');
   });
 
   it('prints a WeakMap', () => {
     const val = new WeakMap();
-    expect(prettyFormat(val)).toEqual('WeakMap {}');
+    expect(prettyFormat(val)).toBe('WeakMap {}');
   });
 
   it('prints a WeakSet', () => {
     const val = new WeakSet();
-    expect(prettyFormat(val)).toEqual('WeakSet {}');
+    expect(prettyFormat(val)).toBe('WeakSet {}');
   });
 
   it('prints deeply nested objects', () => {
     const val = {prop: {prop: {prop: 'value'}}};
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Object {\n  "prop": Object {\n    "prop": Object {\n      "prop": "value",\n    },\n  },\n}',
     );
   });
@@ -487,13 +487,13 @@ describe('prettyFormat()', () => {
   it('prints circular references', () => {
     const val: any = {};
     val.prop = val;
-    expect(prettyFormat(val)).toEqual('Object {\n  "prop": [Circular],\n}');
+    expect(prettyFormat(val)).toBe('Object {\n  "prop": [Circular],\n}');
   });
 
   it('prints parallel references', () => {
     const inner = {};
     const val = {prop1: inner, prop2: inner};
-    expect(prettyFormat(val)).toEqual(
+    expect(prettyFormat(val)).toBe(
       'Object {\n  "prop1": Object {},\n  "prop2": Object {},\n}',
     );
   });
@@ -685,7 +685,7 @@ describe('prettyFormat()', () => {
           },
         ],
       }),
-    ).toEqual('class Foo');
+    ).toBe('class Foo');
   });
 
   it('supports plugins that return empty string', () => {
@@ -704,7 +704,7 @@ describe('prettyFormat()', () => {
         },
       ],
     };
-    expect(prettyFormat(val, options)).toEqual('');
+    expect(prettyFormat(val, options)).toBe('');
   });
 
   it('throws if plugin does not return a string', () => {
@@ -804,7 +804,7 @@ describe('prettyFormat()', () => {
           },
         ],
       }),
-    ).toEqual('1 - 2 - 3 - 4');
+    ).toBe('1 - 2 - 3 - 4');
   });
 
   it('should call plugins on nested basic values', () => {
@@ -822,11 +822,11 @@ describe('prettyFormat()', () => {
           },
         ],
       }),
-    ).toEqual('Object {\n  [called]: [called],\n}');
+    ).toBe('Object {\n  [called]: [called],\n}');
   });
 
   it('prints objects with no constructor', () => {
-    expect(prettyFormat(Object.create(null))).toEqual('Object {}');
+    expect(prettyFormat(Object.create(null))).toBe('Object {}');
   });
 
   it('prints identity-obj-proxy with string constructor', () => {
@@ -846,7 +846,7 @@ describe('prettyFormat()', () => {
         toJSON: () => ({value: false}),
         value: true,
       }),
-    ).toEqual('Object {\n  "value": false,\n}');
+    ).toBe('Object {\n  "value": false,\n}');
   });
 
   it('calls toJSON and prints an internal representation.', () => {
@@ -855,7 +855,7 @@ describe('prettyFormat()', () => {
         toJSON: () => '[Internal Object]',
         value: true,
       }),
-    ).toEqual('"[Internal Object]"');
+    ).toBe('"[Internal Object]"');
   });
 
   it('calls toJSON only on functions', () => {
@@ -864,7 +864,7 @@ describe('prettyFormat()', () => {
         toJSON: false,
         value: true,
       }),
-    ).toEqual('Object {\n  "toJSON": false,\n  "value": true,\n}');
+    ).toBe('Object {\n  "toJSON": false,\n  "value": true,\n}');
   });
 
   it('does not call toJSON recursively', () => {
@@ -873,13 +873,13 @@ describe('prettyFormat()', () => {
         toJSON: () => ({toJSON: () => ({value: true})}),
         value: false,
       }),
-    ).toEqual('Object {\n  "toJSON": [Function toJSON],\n}');
+    ).toBe('Object {\n  "toJSON": [Function toJSON],\n}');
   });
 
   it('calls toJSON on Sets', () => {
     const set = new Set([1]);
     (set as any).toJSON = () => 'map';
-    expect(prettyFormat(set)).toEqual('"map"');
+    expect(prettyFormat(set)).toBe('"map"');
   });
 
   it('disables toJSON calls through options', () => {
@@ -891,7 +891,7 @@ describe('prettyFormat()', () => {
       prettyFormat(set, {
         callToJSON: false,
       }),
-    ).toEqual(
+    ).toBe(
       `Set {\n  Object {\n    "apple": "banana",\n    "toJSON": [Function ${name}],\n  },\n}`,
     );
     expect((set as any).toJSON).not.toBeCalled();
@@ -911,7 +911,7 @@ describe('prettyFormat()', () => {
         prettyFormat(val, {
           min: true,
         }),
-      ).toEqual(
+      ).toBe(
         `{${[
           '"boolean": [false, true]',
           '"null": null',
@@ -943,7 +943,7 @@ describe('prettyFormat()', () => {
         prettyFormat(val, {
           min: true,
         }),
-      ).toEqual(
+      ).toBe(
         `{${[
           '"arguments empty": []',
           '"arguments non-empty": ["arg"]',

--- a/packages/pretty-format/src/__tests__/react.test.tsx
+++ b/packages/pretty-format/src/__tests__/react.test.tsx
@@ -277,7 +277,7 @@ test('supports a single element with custom React elements with a child', () => 
 });
 
 test('supports undefined element type', () => {
-  expect(formatElement({$$typeof: elementSymbol, props: {}})).toEqual(
+  expect(formatElement({$$typeof: elementSymbol, props: {}})).toBe(
     '<UNDEFINED />',
   );
 });
@@ -285,7 +285,7 @@ test('supports undefined element type', () => {
 test('supports a fragment with no children', () => {
   expect(
     formatElement({$$typeof: elementSymbol, props: {}, type: fragmentSymbol}),
-  ).toEqual('<React.Fragment />');
+  ).toBe('<React.Fragment />');
 });
 
 test('supports a fragment with string child', () => {
@@ -295,7 +295,7 @@ test('supports a fragment with string child', () => {
       props: {children: 'test'},
       type: fragmentSymbol,
     }),
-  ).toEqual('<React.Fragment>\n  test\n</React.Fragment>');
+  ).toBe('<React.Fragment>\n  test\n</React.Fragment>');
 });
 
 test('supports a fragment with element child', () => {
@@ -305,7 +305,7 @@ test('supports a fragment with element child', () => {
       props: {children: React.createElement('div', null, 'test')},
       type: fragmentSymbol,
     }),
-  ).toEqual('<React.Fragment>\n  <div>\n    test\n  </div>\n</React.Fragment>');
+  ).toBe('<React.Fragment>\n  <div>\n    test\n  </div>\n</React.Fragment>');
 });
 
 test('supports suspense', () => {
@@ -317,7 +317,7 @@ test('supports suspense', () => {
       },
       type: suspenseSymbol,
     }),
-  ).toEqual('<React.Suspense>\n  <div>\n    test\n  </div>\n</React.Suspense>');
+  ).toBe('<React.Suspense>\n  <div>\n    test\n  </div>\n</React.Suspense>');
 });
 
 test('supports a single element with React elements with a child', () => {
@@ -399,7 +399,7 @@ describe('test object for subset match', () => {
       children: ['undefined props'],
       type: 'span',
     };
-    expect(formatTestObject(val)).toEqual('<span>\n  undefined props\n</span>');
+    expect(formatTestObject(val)).toBe('<span>\n  undefined props\n</span>');
   });
   test('undefined children', () => {
     const val = {
@@ -409,7 +409,7 @@ describe('test object for subset match', () => {
       },
       type: 'span',
     };
-    expect(formatTestObject(val)).toEqual(
+    expect(formatTestObject(val)).toBe(
       '<span\n  className="undefined children"\n/>',
     );
   });
@@ -712,7 +712,7 @@ test('supports forwardRef with a child', () => {
 
   expect(
     formatElement(React.createElement(React.forwardRef(Cat), null, 'mouse')),
-  ).toEqual('<ForwardRef(Cat)>\n  mouse\n</ForwardRef(Cat)>');
+  ).toBe('<ForwardRef(Cat)>\n  mouse\n</ForwardRef(Cat)>');
 });
 
 describe('React.memo', () => {
@@ -724,7 +724,7 @@ describe('React.memo', () => {
 
       expect(
         formatElement(React.createElement(React.memo(Dog), null, 'cat')),
-      ).toEqual('<Memo(Dog)>\n  cat\n</Memo(Dog)>');
+      ).toBe('<Memo(Dog)>\n  cat\n</Memo(Dog)>');
     });
   });
 
@@ -734,7 +734,7 @@ describe('React.memo', () => {
       Foo.displayName = 'DisplayNameBeforeMemoizing(Foo)';
       const MemoFoo = React.memo(Foo);
 
-      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
+      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toBe(
         '<Memo(DisplayNameBeforeMemoizing(Foo))>\n  cat\n</Memo(DisplayNameBeforeMemoizing(Foo))>',
       );
     });
@@ -745,7 +745,7 @@ describe('React.memo', () => {
       const MemoFoo = React.memo(Foo);
       MemoFoo.displayName = 'DisplayNameForMemoized(Foo)';
 
-      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
+      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toBe(
         '<Memo(DisplayNameForMemoized(Foo))>\n  cat\n</Memo(DisplayNameForMemoized(Foo))>',
       );
     });
@@ -759,7 +759,7 @@ test('supports context Provider with a child', () => {
     formatElement(
       React.createElement(Provider, {value: 'test-value'}, 'child'),
     ),
-  ).toEqual(
+  ).toBe(
     '<Context.Provider\n  value="test-value"\n>\n  child\n</Context.Provider>',
   );
 });
@@ -773,7 +773,7 @@ test('supports context Consumer with a child', () => {
         React.createElement('div', null, 'child'),
       ),
     ),
-  ).toEqual('<Context.Consumer>\n  [Function anonymous]\n</Context.Consumer>');
+  ).toBe('<Context.Consumer>\n  [Function anonymous]\n</Context.Consumer>');
 });
 
 test('ReactElement removes undefined props', () => {

--- a/website/blog/2016-03-11-javascript-unit-testing-performance.md
+++ b/website/blog/2016-03-11-javascript-unit-testing-performance.md
@@ -45,7 +45,7 @@ If you have written tests using Jasmine before, they probably look like this:
 const sum = require('sum');
 describe('sum', () => {
   it('works', () => {
-    expect(sum(5, 4)).toEqual(9);
+    expect(sum(5, 4)).toBe(9);
   });
 });
 ```
@@ -61,11 +61,11 @@ describe('sum', () => {
     sum = require('sum');
   });
   it('works', () => {
-    expect(sum(5, 4)).toEqual(9);
+    expect(sum(5, 4)).toBe(9);
   });
   it('works too', () => {
     // This copy of sum is not the same as in the previous call to `it`.
-    expect(sum(2, 3)).toEqual(5);
+    expect(sum(2, 3)).toBe(5);
   });
 });
 ```
@@ -75,7 +75,7 @@ We built a babel transform called [inline-requires](https://github.com/facebook/
 ```js
 describe('sum', () => {
   it('works', () => {
-    expect(require('sum')(5, 4)).toEqual(9);
+    expect(require('sum')(5, 4)).toBe(9);
   });
 });
 ```

--- a/website/blog/2016-04-12-jest-11.md
+++ b/website/blog/2016-04-12-jest-11.md
@@ -53,7 +53,7 @@ We have made numerous improvements and bug fixes to Jest's automocking feature, 
 
 We have also added two new APIs to simplify manual mocks. `jest.mock` specifies a manual mock factory for a specific test:
 
-```
+```js
 // Implement a mock for a hypothetical "sum" module.
 jest.mock('sum', () => {
   return (a, b) => a + b;
@@ -65,11 +65,11 @@ sum(1, 4); // 5
 
 And `jest.fn` was added to make it easier to create mock functions:
 
-```
+```js
 // Create a mock function
 const mockFn = jest.fn(() => 42);
 mockFn(); // 42
-expect(mockFn.calls.length).toEqual(1);
+expect(mockFn.calls.length).toBe(1);
 ```
 
 #### Performance

--- a/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
+++ b/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
@@ -44,7 +44,7 @@ We made a number of additions and improvements to the testing APIs which will he
 
 Here is an example of all how all the new APIs together will make testing more delightful:
 
-```
+```js
 /**
  * @jest-environment node
  */

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -117,7 +117,7 @@ utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.genMockFromModule', () => {
   expect(utils.authorize.mock).toBeTruthy();
-  expect(utils.isAuthorized('not wizard')).toEqual(true);
+  expect(utils.isAuthorized('not wizard')).toBe(true);
 });
 ```
 
@@ -180,17 +180,17 @@ const example = jest.genMockFromModule('./example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -202,12 +202,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -302,7 +302,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -310,7 +310,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -334,8 +334,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -348,8 +348,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-25.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-25.x/MockFunctionAPI.md
@@ -437,7 +437,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // However, it will not allow access to `.mock` in TypeScript as it
   // is returning `SoundPlayer`. Instead, you can check the calls to a
   // method like this fully typed:
-  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toEqual(
+  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toBe(
     coolSoundFileName,
   );
   // Equivalent to above check:

--- a/website/versioned_docs/version-25.x/MockFunctions.md
+++ b/website/versioned_docs/version-25.x/MockFunctions.md
@@ -74,7 +74,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 ```
 
 ## Mock Return Values

--- a/website/versioned_docs/version-25.x/SetupAndTeardown.md
+++ b/website/versioned_docs/version-25.x/SetupAndTeardown.md
@@ -141,7 +141,7 @@ describe('outer', () => {
     console.log('describe inner 1');
     test('test 1', () => {
       console.log('test for describe inner 1');
-      expect(true).toEqual(true);
+      expect(true).toBe(true);
     });
   });
 
@@ -149,14 +149,14 @@ describe('outer', () => {
 
   test('test 1', () => {
     console.log('test for describe outer');
-    expect(true).toEqual(true);
+    expect(true).toBe(true);
   });
 
   describe('describe inner 2', () => {
     console.log('describe inner 2');
     test('test for describe inner 2', () => {
       console.log('test for describe inner 2');
-      expect(false).toEqual(false);
+      expect(false).toBe(false);
     });
   });
 

--- a/website/versioned_docs/version-25.x/TutorialAsync.md
+++ b/website/versioned_docs/version-25.x/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-25.x/TutorialReact.md
+++ b/website/versioned_docs/version-25.x/TutorialReact.md
@@ -268,11 +268,11 @@ test('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-25.x/TutorialjQuery.md
+++ b/website/versioned_docs/version-25.x/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -121,7 +121,7 @@ utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.createMockFromModule', () => {
   expect(utils.authorize.mock).toBeTruthy();
-  expect(utils.isAuthorized('not wizard')).toEqual(true);
+  expect(utils.isAuthorized('not wizard')).toBe(true);
 });
 ```
 
@@ -184,17 +184,17 @@ const example = jest.createMockFromModule('./example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,12 +206,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -306,7 +306,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -314,7 +314,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -338,8 +338,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -352,8 +352,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-26.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-26.x/MockFunctionAPI.md
@@ -437,7 +437,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // However, it will not allow access to `.mock` in TypeScript as it
   // is returning `SoundPlayer`. Instead, you can check the calls to a
   // method like this fully typed:
-  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toEqual(
+  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toBe(
     coolSoundFileName,
   );
   // Equivalent to above check:

--- a/website/versioned_docs/version-26.x/MockFunctions.md
+++ b/website/versioned_docs/version-26.x/MockFunctions.md
@@ -74,7 +74,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 ```
 
 ## Mock Return Values

--- a/website/versioned_docs/version-26.x/SetupAndTeardown.md
+++ b/website/versioned_docs/version-26.x/SetupAndTeardown.md
@@ -141,7 +141,7 @@ describe('outer', () => {
     console.log('describe inner 1');
     test('test 1', () => {
       console.log('test for describe inner 1');
-      expect(true).toEqual(true);
+      expect(true).toBe(true);
     });
   });
 
@@ -149,14 +149,14 @@ describe('outer', () => {
 
   test('test 1', () => {
     console.log('test for describe outer');
-    expect(true).toEqual(true);
+    expect(true).toBe(true);
   });
 
   describe('describe inner 2', () => {
     console.log('describe inner 2');
     test('test for describe inner 2', () => {
       console.log('test for describe inner 2');
-      expect(false).toEqual(false);
+      expect(false).toBe(false);
     });
   });
 

--- a/website/versioned_docs/version-26.x/TutorialAsync.md
+++ b/website/versioned_docs/version-26.x/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-26.x/TutorialReact.md
+++ b/website/versioned_docs/version-26.x/TutorialReact.md
@@ -268,11 +268,11 @@ test('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-26.x/TutorialjQuery.md
+++ b/website/versioned_docs/version-26.x/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/website/versioned_docs/version-27.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.x/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -121,7 +121,7 @@ utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.createMockFromModule', () => {
   expect(utils.authorize.mock).toBeTruthy();
-  expect(utils.isAuthorized('not wizard')).toEqual(true);
+  expect(utils.isAuthorized('not wizard')).toBe(true);
 });
 ```
 
@@ -184,17 +184,17 @@ const example = jest.createMockFromModule('./example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,12 +206,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -306,7 +306,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -314,7 +314,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -338,8 +338,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -352,8 +352,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-27.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-27.x/MockFunctionAPI.md
@@ -447,7 +447,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // However, it will not allow access to `.mock` in TypeScript as it
   // is returning `SoundPlayer`. Instead, you can check the calls to a
   // method like this fully typed:
-  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toEqual(
+  expect(SoundPlayerMock.prototype.playSoundFile.mock.calls[0][0]).toBe(
     coolSoundFileName,
   );
   // Equivalent to above check:

--- a/website/versioned_docs/version-27.x/MockFunctions.md
+++ b/website/versioned_docs/version-27.x/MockFunctions.md
@@ -74,7 +74,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 
 // The first argument of the last call to the function was 'test'
 expect(someMockFunction.mock.lastCall[0]).toBe('test');

--- a/website/versioned_docs/version-27.x/TutorialAsync.md
+++ b/website/versioned_docs/version-27.x/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-27.x/TutorialReact.md
+++ b/website/versioned_docs/version-27.x/TutorialReact.md
@@ -268,11 +268,11 @@ test('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-27.x/TutorialjQuery.md
+++ b/website/versioned_docs/version-27.x/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/website/versioned_docs/version-28.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-28.x/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-28.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.x/JestObjectAPI.md
@@ -121,7 +121,7 @@ utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.createMockFromModule', () => {
   expect(utils.authorize.mock).toBeTruthy();
-  expect(utils.isAuthorized('not wizard')).toEqual(true);
+  expect(utils.isAuthorized('not wizard')).toBe(true);
 });
 ```
 
@@ -184,17 +184,17 @@ const example = jest.createMockFromModule('./example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,12 +206,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -306,7 +306,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -314,7 +314,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -338,8 +338,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -352,8 +352,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-28.x/MockFunctions.md
+++ b/website/versioned_docs/version-28.x/MockFunctions.md
@@ -79,7 +79,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 
 // The first argument of the last call to the function was 'test'
 expect(someMockFunction.mock.lastCall[0]).toBe('test');

--- a/website/versioned_docs/version-28.x/TutorialAsync.md
+++ b/website/versioned_docs/version-28.x/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-28.x/TutorialReact.md
+++ b/website/versioned_docs/version-28.x/TutorialReact.md
@@ -282,11 +282,11 @@ it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-28.x/TutorialjQuery.md
+++ b/website/versioned_docs/version-28.x/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/website/versioned_docs/version-29.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.0/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-29.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.0/JestObjectAPI.md
@@ -208,17 +208,17 @@ const example = jest.createMockFromModule('../example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -230,12 +230,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -348,7 +348,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -356,7 +356,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -380,8 +380,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -394,8 +394,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-29.0/MockFunctions.md
+++ b/website/versioned_docs/version-29.0/MockFunctions.md
@@ -79,7 +79,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 
 // The first argument of the last call to the function was 'test'
 expect(someMockFunction.mock.lastCall[0]).toBe('test');

--- a/website/versioned_docs/version-29.0/TutorialAsync.md
+++ b/website/versioned_docs/version-29.0/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-29.0/TutorialReact.md
+++ b/website/versioned_docs/version-29.0/TutorialReact.md
@@ -282,11 +282,11 @@ it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-29.0/TutorialjQuery.md
+++ b/website/versioned_docs/version-29.0/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 

--- a/website/versioned_docs/version-29.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.1/Es6ClassMocks.md
@@ -81,7 +81,7 @@ it('We can check if the consumer called a method on the class instance', () => {
   // mock.instances is available with automatic mocks:
   const mockSoundPlayerInstance = SoundPlayer.mock.instances[0];
   const mockPlaySoundFile = mockSoundPlayerInstance.playSoundFile;
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
   // Equivalent to above check:
   expect(mockPlaySoundFile).toHaveBeenCalledWith(coolSoundFileName);
   expect(mockPlaySoundFile).toHaveBeenCalledTimes(1);
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
 
 ### Mocking non-default class exports
 
@@ -444,6 +444,6 @@ it('We can check if the consumer called a method on the class instance', () => {
   const soundPlayerConsumer = new SoundPlayerConsumer();
   const coolSoundFileName = 'song.mp3';
   soundPlayerConsumer.playSomethingCool();
-  expect(mockPlaySoundFile.mock.calls[0][0]).toEqual(coolSoundFileName);
+  expect(mockPlaySoundFile.mock.calls[0][0]).toBe(coolSoundFileName);
 });
 ```

--- a/website/versioned_docs/version-29.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.1/JestObjectAPI.md
@@ -229,17 +229,17 @@ const example = jest.createMockFromModule('../example');
 
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
-  expect(example.function.name).toEqual('square');
-  expect(example.function.length).toEqual(0);
+  expect(example.function.name).toBe('square');
+  expect(example.function.length).toBe(0);
 
   // async functions get the same treatment as standard synchronous functions.
-  expect(example.asyncFunction.name).toEqual('asyncSquare');
-  expect(example.asyncFunction.length).toEqual(0);
+  expect(example.asyncFunction.name).toBe('asyncSquare');
+  expect(example.asyncFunction.length).toBe(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
-  expect(example.class.constructor.name).toEqual('Bar');
-  expect(example.class.foo.name).toEqual('foo');
-  expect(example.class.array.length).toEqual(0);
+  expect(example.class.constructor.name).toBe('Bar');
+  expect(example.class.foo.name).toBe('foo');
+  expect(example.class.array.length).toBe(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -251,12 +251,12 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toEqual(0);
+  expect(example.array.length).toBe(0);
 
   // creates a new property with the same primitive value as the original property.
-  expect(example.number).toEqual(123);
-  expect(example.string).toEqual('baz');
-  expect(example.boolean).toEqual(true);
+  expect(example.number).toBe(123);
+  expect(example.string).toBe('baz');
+  expect(example.boolean).toBe(true);
   expect(example.symbol).toEqual(Symbol.for('a.b.c'));
 });
 ```
@@ -380,7 +380,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -388,7 +388,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -403,7 +403,7 @@ test('moduleName 1', () => {
     return jest.fn(() => 1);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(1);
+  expect(moduleName()).toBe(1);
 });
 
 test('moduleName 2', () => {
@@ -411,7 +411,7 @@ test('moduleName 2', () => {
     return jest.fn(() => 2);
   });
   const moduleName = require('../moduleName');
-  expect(moduleName()).toEqual(2);
+  expect(moduleName()).toBe(2);
 });
 ```
 
@@ -435,8 +435,8 @@ test('moduleName 1', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default1');
-    expect(moduleName.foo).toEqual('foo1');
+    expect(moduleName.default).toBe('default1');
+    expect(moduleName.foo).toBe('foo1');
   });
 });
 
@@ -449,8 +449,8 @@ test('moduleName 2', () => {
     };
   });
   return import('../moduleName').then(moduleName => {
-    expect(moduleName.default).toEqual('default2');
-    expect(moduleName.foo).toEqual('foo2');
+    expect(moduleName.default).toBe('default2');
+    expect(moduleName.foo).toBe('foo2');
   });
 });
 ```

--- a/website/versioned_docs/version-29.1/MockFunctions.md
+++ b/website/versioned_docs/version-29.1/MockFunctions.md
@@ -79,7 +79,7 @@ expect(someMockFunction.mock.instances.length).toBe(2);
 
 // The object returned by the first instantiation of this function
 // had a `name` property whose value was set to 'test'
-expect(someMockFunction.mock.instances[0].name).toEqual('test');
+expect(someMockFunction.mock.instances[0].name).toBe('test');
 
 // The first argument of the last call to the function was 'test'
 expect(someMockFunction.mock.lastCall[0]).toBe('test');

--- a/website/versioned_docs/version-29.1/TutorialAsync.md
+++ b/website/versioned_docs/version-29.1/TutorialAsync.md
@@ -68,7 +68,7 @@ import * as user from '../user';
 // The assertion for a promise must be returned.
 it('works with promises', () => {
   expect.assertions(1);
-  return user.getUserName(4).then(data => expect(data).toEqual('Mark'));
+  return user.getUserName(4).then(data => expect(data).toBe('Mark'));
 });
 ```
 
@@ -81,7 +81,7 @@ There is a less verbose way using `resolves` to unwrap the value of a fulfilled 
 ```js
 it('works with resolves', () => {
   expect.assertions(1);
-  return expect(user.getUserName(5)).resolves.toEqual('Paul');
+  return expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 
@@ -94,13 +94,13 @@ Writing tests using the `async`/`await` syntax is also possible. Here is how you
 it('works with async/await', async () => {
   expect.assertions(1);
   const data = await user.getUserName(4);
-  expect(data).toEqual('Mark');
+  expect(data).toBe('Mark');
 });
 
 // async/await can also be used with `.resolves`.
 it('works with async/await and resolves', async () => {
   expect.assertions(1);
-  await expect(user.getUserName(5)).resolves.toEqual('Paul');
+  await expect(user.getUserName(5)).resolves.toBe('Paul');
 });
 ```
 

--- a/website/versioned_docs/version-29.1/TutorialReact.md
+++ b/website/versioned_docs/version-29.1/TutorialReact.md
@@ -282,11 +282,11 @@ it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
   const checkbox = shallow(<CheckboxWithLabel labelOn="On" labelOff="Off" />);
 
-  expect(checkbox.text()).toEqual('Off');
+  expect(checkbox.text()).toBe('Off');
 
   checkbox.find('input').simulate('change');
 
-  expect(checkbox.text()).toEqual('On');
+  expect(checkbox.text()).toBe('On');
 });
 ```
 

--- a/website/versioned_docs/version-29.1/TutorialjQuery.md
+++ b/website/versioned_docs/version-29.1/TutorialjQuery.md
@@ -55,7 +55,7 @@ test('displays a user after a click', () => {
   // Assert that the fetchCurrentUser function was called, and that the
   // #username span's inner text was updated as we'd expect it to.
   expect(fetchCurrentUser).toBeCalled();
-  expect($('#username').text()).toEqual('Johnny Cash - Logged In');
+  expect($('#username').text()).toBe('Johnny Cash - Logged In');
 });
 ```
 


### PR DESCRIPTION
## Summary

Let’s add `jest/prefer-to-be` rule to ESLint config?

The diff is huge. It might feel like changing `toEqual('thing')` to `toBe('thing')` is not worth it, but next to these some `not.toBe(undefined)` are caught as well. Also more consistent usage in documentation might be helpful to understand difference between `toBe` and `toEqual`.

## Test plan

Green CI.