### PR TITLE
chore(lint): use `jest/prefer-to-have-length` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -167,6 +167,8 @@ module.exports = {
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
         'jest/prefer-to-be': 'error',
+        'jest/prefer-to-contain': 'error',
+        'jest/prefer-to-have-length': 'error',
         'jest/valid-expect': 'error',
       },
     },

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -230,16 +230,16 @@ const example = jest.createMockFromModule('../example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -251,7 +251,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/e2e/__tests__/jasmineAsync.test.ts
+++ b/e2e/__tests__/jasmineAsync.test.ts
@@ -47,7 +47,7 @@ describe('async jasmine', () => {
     expect(json.numPendingTests).toBe(0);
     expect(json.testResults[0].message).toBe('');
 
-    expect((result.stderr.match(/unset flag/g) || []).length).toBe(1);
+    expect(result.stderr.match(/unset flag/g) || []).toHaveLength(1);
   });
 
   it('works with afterEach', () => {

--- a/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
+++ b/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
@@ -40,7 +40,7 @@ describe('setupFilesAfterEnv', () => {
 
     expect(result.json.numTotalTests).toBe(2);
     expect(result.json.numPassedTests).toBe(2);
-    expect(result.json.testResults.length).toBe(2);
+    expect(result.json.testResults).toHaveLength(2);
     expect(result.exitCode).toBe(0);
   });
 
@@ -61,7 +61,7 @@ describe('setupFilesAfterEnv', () => {
 
     expect(result.json.numTotalTests).toBe(1);
     expect(result.json.numPassedTests).toBe(1);
-    expect(result.json.testResults.length).toBe(1);
+    expect(result.json.testResults).toHaveLength(1);
     expect(result.exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/testInRoot.test.ts
+++ b/e2e/__tests__/testInRoot.test.ts
@@ -19,7 +19,7 @@ it('runs tests in only test.js and spec.js', () => {
     .map(name => path.basename(name))
     .sort();
 
-  expect(testNames.length).toBe(2);
+  expect(testNames).toHaveLength(2);
   expect(testNames[0]).toBe('spec.js');
   expect(testNames[1]).toBe('test.js');
 });

--- a/e2e/auto-clear-mocks/with-auto-clear/__tests__/index.js
+++ b/e2e/auto-clear-mocks/with-auto-clear/__tests__/index.js
@@ -15,14 +15,14 @@ test('first test', () => {
   importedFn();
   expect(localFn()).toBe('abcd');
 
-  expect(importedFn.mock.calls.length).toBe(1);
-  expect(localFn.mock.calls.length).toBe(1);
+  expect(importedFn).toHaveBeenCalledTimes(1);
+  expect(localFn).toHaveBeenCalledTimes(1);
 });
 
 test('second test', () => {
   importedFn();
   expect(localFn()).toBe('abcd');
 
-  expect(importedFn.mock.calls.length).toBe(1);
-  expect(localFn.mock.calls.length).toBe(1);
+  expect(importedFn).toHaveBeenCalledTimes(1);
+  expect(localFn).toHaveBeenCalledTimes(1);
 });

--- a/e2e/auto-clear-mocks/without-auto-clear/__tests__/index.js
+++ b/e2e/auto-clear-mocks/without-auto-clear/__tests__/index.js
@@ -17,16 +17,16 @@ describe('without an explicit reset', () => {
     importedFn();
     expect(localFn()).toBe('abcd');
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
     importedFn();
     expect(localFn()).toBe('abcd');
 
-    expect(importedFn.mock.calls.length).toBe(2);
-    expect(localFn.mock.calls.length).toBe(2);
+    expect(importedFn).toHaveBeenCalledTimes(2);
+    expect(localFn).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -39,15 +39,15 @@ describe('with an explicit reset', () => {
     importedFn();
     expect(localFn()).toBe('abcd');
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
     importedFn();
     expect(localFn()).toBe('abcd');
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/e2e/auto-reset-mocks/with-auto-reset/__tests__/index.js
+++ b/e2e/auto-reset-mocks/with-auto-reset/__tests__/index.js
@@ -15,14 +15,14 @@ test('first test', () => {
   importedFn();
   localFn();
 
-  expect(importedFn.mock.calls.length).toBe(1);
-  expect(localFn.mock.calls.length).toBe(1);
+  expect(importedFn).toHaveBeenCalledTimes(1);
+  expect(localFn).toHaveBeenCalledTimes(1);
 });
 
 test('second test', () => {
   importedFn();
   localFn();
 
-  expect(importedFn.mock.calls.length).toBe(1);
-  expect(localFn.mock.calls.length).toBe(1);
+  expect(importedFn).toHaveBeenCalledTimes(1);
+  expect(localFn).toHaveBeenCalledTimes(1);
 });

--- a/e2e/auto-reset-mocks/without-auto-reset/__tests__/index.js
+++ b/e2e/auto-reset-mocks/without-auto-reset/__tests__/index.js
@@ -17,16 +17,16 @@ describe('without an explicit reset', () => {
     importedFn();
     localFn();
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
     importedFn();
     localFn();
 
-    expect(importedFn.mock.calls.length).toBe(2);
-    expect(localFn.mock.calls.length).toBe(2);
+    expect(importedFn).toHaveBeenCalledTimes(2);
+    expect(localFn).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -39,15 +39,15 @@ describe('with an explicit reset', () => {
     importedFn();
     localFn();
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 
   test('second test', () => {
     importedFn();
     localFn();
 
-    expect(importedFn.mock.calls.length).toBe(1);
-    expect(localFn.mock.calls.length).toBe(1);
+    expect(importedFn).toHaveBeenCalledTimes(1);
+    expect(localFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/examples/manual-mocks/__tests__/file_summarizer.test.js
+++ b/examples/manual-mocks/__tests__/file_summarizer.test.js
@@ -20,6 +20,6 @@ describe('listFilesInDirectorySync', () => {
     const fileSummary =
       FileSummarizer.summarizeFilesInDirectorySync('/path/to');
 
-    expect(fileSummary.length).toBe(2);
+    expect(fileSummary).toHaveLength(2);
   });
 });

--- a/packages/babel-jest/src/__tests__/getCacheKey.test.ts
+++ b/packages/babel-jest/src/__tests__/getCacheKey.test.ts
@@ -44,7 +44,7 @@ describe('getCacheKey', () => {
   const oldCacheKey = getCacheKey!(sourceText, sourcePath, transformOptions);
 
   test('returns cache key hash', () => {
-    expect(oldCacheKey.length).toBe(32);
+    expect(oldCacheKey).toHaveLength(32);
   });
 
   test('if `THIS_FILE` value is changing', () => {

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -878,7 +878,7 @@ describe('testMatch', () => {
       {} as Config.Argv,
     );
 
-    expect(options.testMatch.length).toBe(0);
+    expect(options.testMatch).toHaveLength(0);
   });
 
   it('testRegex default not applied if testMatch is set', async () => {

--- a/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
+++ b/packages/jest-create-cache-key-function/src/__tests__/index.test.ts
@@ -40,7 +40,7 @@ test('creation of a cache key', () => {
     instrument: true,
   });
 
-  expect(hashA.length).toBe(32);
+  expect(hashA).toHaveLength(32);
   expect(hashA).not.toEqual(hashB);
   expect(hashA).not.toEqual(hashC);
 });

--- a/packages/jest-each/src/__tests__/array.test.ts
+++ b/packages/jest-each/src/__tests__/array.test.ts
@@ -450,7 +450,8 @@ describe('jest-each', () => {
         const testFunction = get(eachObject, keyPath);
         testFunction('expected string', function (hello, done) {
           expect(hello).toBe('hello');
-          expect(arguments).toHaveLength(1); // eslint-disable-line prefer-rest-params
+          // eslint-disable-next-line prefer-rest-params
+          expect(arguments).toHaveLength(1);
           expect(done).toBeUndefined();
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');

--- a/packages/jest-each/src/__tests__/array.test.ts
+++ b/packages/jest-each/src/__tests__/array.test.ts
@@ -450,7 +450,7 @@ describe('jest-each', () => {
         const testFunction = get(eachObject, keyPath);
         testFunction('expected string', function (hello, done) {
           expect(hello).toBe('hello');
-          expect(arguments.length).toBe(1);
+          expect(arguments).toHaveLength(1); // eslint-disable-line prefer-rest-params
           expect(done).toBeUndefined();
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');

--- a/packages/jest-each/src/__tests__/template.test.ts
+++ b/packages/jest-each/src/__tests__/template.test.ts
@@ -549,7 +549,8 @@ describe('jest-each', () => {
           expect(b).toBe(1);
           expect(expected).toBe(1);
           expect(done).toBeUndefined();
-          expect(arguments).toHaveLength(1); // eslint-disable-line prefer-rest-params
+          // eslint-disable-next-line prefer-rest-params
+          expect(arguments).toHaveLength(1);
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
       },

--- a/packages/jest-each/src/__tests__/template.test.ts
+++ b/packages/jest-each/src/__tests__/template.test.ts
@@ -549,7 +549,7 @@ describe('jest-each', () => {
           expect(b).toBe(1);
           expect(expected).toBe(1);
           expect(done).toBeUndefined();
-          expect(arguments.length).toBe(1);
+          expect(arguments).toHaveLength(1); // eslint-disable-line prefer-rest-params
         });
         get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
       },

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -722,7 +722,7 @@ describe('HasteMap', () => {
     expect(data.map.get('fbjs')).toBeUndefined();
 
     // cache file + 5 modules - the node_module
-    expect(fs.readFileSync.mock.calls.length).toBe(6);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(6);
   });
 
   it('warns on duplicate mock files', async () => {
@@ -886,7 +886,7 @@ describe('HasteMap', () => {
 
     // The first run should access the file system once for the (empty)
     // cache file and five times for the files in the system.
-    expect(fs.readFileSync.mock.calls.length).toBe(6);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(6);
 
     fs.readFileSync.mockClear();
 
@@ -902,7 +902,7 @@ describe('HasteMap', () => {
     const {__hasteMapForTest: data} = await (
       await HasteMap.create(defaultConfig)
     ).build();
-    expect(fs.readFileSync.mock.calls.length).toBe(1);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     if (require('v8').deserialize) {
       expect(fs.readFileSync).toBeCalledWith(cacheFilePath);
     } else {
@@ -936,7 +936,7 @@ describe('HasteMap', () => {
       await HasteMap.create(defaultConfig)
     ).build();
 
-    expect(fs.readFileSync.mock.calls.length).toBe(2);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
 
     if (require('v8').serialize) {
       expect(fs.readFileSync).toBeCalledWith(cacheFilePath);
@@ -1279,9 +1279,9 @@ describe('HasteMap', () => {
       })
     ).build();
 
-    expect(jestWorker.mock.calls.length).toBe(1);
+    expect(jestWorker).toHaveBeenCalledTimes(1);
 
-    expect(mockWorker.mock.calls.length).toBe(5);
+    expect(mockWorker).toHaveBeenCalledTimes(5);
 
     expect(mockWorker.mock.calls).toEqual([
       [

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -588,8 +588,8 @@ describe('moduleMocker', () => {
         const mockFunctionArity1 = moduleMocker.fn(x => x);
         const mockFunctionArity2 = moduleMocker.fn((x, y) => y);
 
-        expect(mockFunctionArity1.length).toBe(1);
-        expect(mockFunctionArity2.length).toBe(2);
+        expect(mockFunctionArity1).toHaveLength(1);
+        expect(mockFunctionArity2).toHaveLength(2);
       });
     });
 
@@ -1240,7 +1240,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).toHaveBeenCalled();
@@ -1252,7 +1252,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).not.toHaveBeenCalled();
@@ -1291,8 +1291,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(1);
       expect(methodTwoCalls).toBe(1);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
 
       moduleMocker.restoreAllMocks();
 
@@ -1302,8 +1302,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(2);
       expect(methodTwoCalls).toBe(2);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
     });
 
     it('should work with getters', () => {
@@ -1329,7 +1329,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).toHaveBeenCalled();
@@ -1341,7 +1341,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).not.toHaveBeenCalled();
@@ -1384,7 +1384,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).toHaveBeenCalled();
@@ -1396,7 +1396,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).not.toHaveBeenCalled();
@@ -1461,8 +1461,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(1);
       expect(methodTwoCalls).toBe(1);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
 
       moduleMocker.restoreAllMocks();
 
@@ -1472,8 +1472,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(2);
       expect(methodTwoCalls).toBe(2);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
     });
 
     it('should work with getters on the prototype chain', () => {
@@ -1500,7 +1500,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).toHaveBeenCalled();
@@ -1512,7 +1512,7 @@ describe('moduleMocker', () => {
       obj.method.call(thisArg, firstArg, secondArg);
       expect(isOriginalCalled).toBe(true);
       expect(originalCallThis).toBe(thisArg);
-      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments).toHaveLength(2);
       expect(originalCallArguments[0]).toBe(firstArg);
       expect(originalCallArguments[1]).toBe(secondArg);
       expect(spy).not.toHaveBeenCalled();
@@ -1567,8 +1567,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(1);
       expect(methodTwoCalls).toBe(1);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
 
       moduleMocker.restoreAllMocks();
 
@@ -1578,8 +1578,8 @@ describe('moduleMocker', () => {
       obj.methodTwo();
       expect(methodOneCalls).toBe(2);
       expect(methodTwoCalls).toBe(2);
-      expect(spy1.mock.calls.length).toBe(1);
-      expect(spy2.mock.calls.length).toBe(1);
+      expect(spy1.mock.calls).toHaveLength(1);
+      expect(spy2.mock.calls).toHaveLength(1);
     });
   });
 });

--- a/packages/jest-reporters/src/__tests__/utils.test.ts
+++ b/packages/jest-reporters/src/__tests__/utils.test.ts
@@ -46,7 +46,7 @@ describe('trimAndFormatPath()', () => {
     );
 
     expect(result).toMatchSnapshot();
-    expect(stripAnsi(result).length).toBe(20);
+    expect(stripAnsi(result)).toHaveLength(20);
   });
 
   it('trims dirname (longer line width)', () => {
@@ -62,7 +62,7 @@ describe('trimAndFormatPath()', () => {
     );
 
     expect(result).toMatchSnapshot();
-    expect(stripAnsi(result).length).toBe(25);
+    expect(stripAnsi(result)).toHaveLength(25);
   });
 
   it('trims dirname and basename', () => {
@@ -78,7 +78,7 @@ describe('trimAndFormatPath()', () => {
     );
 
     expect(result).toMatchSnapshot();
-    expect(stripAnsi(result).length).toBe(10);
+    expect(stripAnsi(result)).toHaveLength(10);
   });
 
   it('does not trim anything', () => {
@@ -95,7 +95,7 @@ describe('trimAndFormatPath()', () => {
     );
 
     expect(result).toMatchSnapshot();
-    expect(stripAnsi(result).length).toBe(totalLength);
+    expect(stripAnsi(result)).toHaveLength(totalLength);
   });
 
   test('split at the path.sep index', () => {
@@ -111,7 +111,7 @@ describe('trimAndFormatPath()', () => {
     );
 
     expect(result).toMatchSnapshot();
-    expect(stripAnsi(result).length).toBe(columns - pad);
+    expect(stripAnsi(result)).toHaveLength(columns - pad);
   });
 });
 

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -49,7 +49,7 @@ beforeEach(async () => {
 
 test('resolves no dependencies for non-existent path', () => {
   const resolved = dependencyResolver.resolve('/non/existent/path');
-  expect(resolved.length).toBe(0);
+  expect(resolved).toHaveLength(0);
 });
 
 test('resolves dependencies for existing path', () => {
@@ -86,13 +86,13 @@ test('resolves dependencies for scoped packages', () => {
 test('resolves no inverse dependencies for empty paths set', () => {
   const paths = new Set<string>();
   const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toBe(0);
+  expect(resolved).toHaveLength(0);
 });
 
 test('resolves no inverse dependencies for set of non-existent paths', () => {
   const paths = new Set(['/non/existent/path', '/another/one']);
   const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toBe(0);
+  expect(resolved).toHaveLength(0);
 });
 
 test('resolves inverse dependencies for existing path', () => {

--- a/packages/jest-snapshot/src/__tests__/plugins.test.ts
+++ b/packages/jest-snapshot/src/__tests__/plugins.test.ts
@@ -22,7 +22,7 @@ const testPath = (names: Array<string>) => {
     .forEach(serializer => addSerializer(serializer));
 
   const next = getSerializers();
-  expect(next.length).toBe(added.length + prev.length);
+  expect(next).toHaveLength(added.length + prev.length);
   expect(next).toEqual(added.concat(prev));
 };
 

--- a/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
+++ b/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
@@ -141,8 +141,8 @@ describe('BaseWorkerPool', () => {
       numWorkers: 2,
     });
 
-    expect(out.length).toBe(2);
-    expect(err.length).toBe(2);
+    expect(out).toHaveLength(2);
+    expect(err).toHaveLength(2);
 
     const stdout = jest.fn();
     const stderr = jest.fn();

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -181,16 +181,16 @@ const example = jest.genMockFromModule('./example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -202,7 +202,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -185,16 +185,16 @@ const example = jest.createMockFromModule('./example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,7 +206,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/website/versioned_docs/version-27.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.x/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -185,16 +185,16 @@ const example = jest.createMockFromModule('./example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,7 +206,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/website/versioned_docs/version-28.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-28.x/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-28.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.x/JestObjectAPI.md
@@ -185,16 +185,16 @@ const example = jest.createMockFromModule('./example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -206,7 +206,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/website/versioned_docs/version-29.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.0/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-29.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.0/JestObjectAPI.md
@@ -209,16 +209,16 @@ const example = jest.createMockFromModule('../example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -230,7 +230,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);

--- a/website/versioned_docs/version-29.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.1/Es6ClassMocks.md
@@ -349,7 +349,7 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBe(1);`
+This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toBeGreaterThan(0);`
 
 ### Mocking non-default class exports
 

--- a/website/versioned_docs/version-29.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.1/JestObjectAPI.md
@@ -230,16 +230,16 @@ const example = jest.createMockFromModule('../example');
 test('should run example code', () => {
   // creates a new mocked function with no formal arguments.
   expect(example.function.name).toBe('square');
-  expect(example.function.length).toBe(0);
+  expect(example.function).toHaveLength(0);
 
   // async functions get the same treatment as standard synchronous functions.
   expect(example.asyncFunction.name).toBe('asyncSquare');
-  expect(example.asyncFunction.length).toBe(0);
+  expect(example.asyncFunction).toHaveLength(0);
 
   // creates a new class with the same interface, member functions and properties are mocked.
   expect(example.class.constructor.name).toBe('Bar');
   expect(example.class.foo.name).toBe('foo');
-  expect(example.class.array.length).toBe(0);
+  expect(example.class.array).toHaveLength(0);
 
   // creates a deeply cloned version of the original object.
   expect(example.object).toEqual({
@@ -251,7 +251,7 @@ test('should run example code', () => {
   });
 
   // creates a new empty array, ignoring the original array.
-  expect(example.array.length).toBe(0);
+  expect(example.array).toHaveLength(0);
 
   // creates a new property with the same primitive value as the original property.
   expect(example.number).toBe(123);


### PR DESCRIPTION
## Summary

Also `jest/prefer-to-have-length` rule could be added to ESLint config. Quick search shows that currently `toHaveLength` matcher is used 81 time in 36 files (excluding `*.md`). Let’s add few more?

## Test plan

Green CI.