### PR TITLE
chore: fix error message in native module test

### DIFF
--- a/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
@@ -93,7 +93,7 @@ describe('Runtime', () => {
         error = e;
       } finally {
         expect(error.message).toMatch(
-          /NativeModule.node: file too short|not a valid Win\d+ application/,
+          /NativeModule.node: file too short|NativeModule.node, 0x0001|not a valid Win\d+ application/,
         );
       }
     });


### PR DESCRIPTION
## Summary

It does not reproduce in CI. For some time already I always see this error each time running the tests of Jest repo locally:

<img width="1151" alt="Screenshot 2022-10-03 at 18 08 43" src="https://user-images.githubusercontent.com/72159681/193611914-69760816-0349-42a5-80a9-6bdd8e3aac46.png">

Am I the only one? Issues with my setup (macOS 12.6, Apple M1 Pro, Node: 18.10.0)? Or let’s just fix it?

## Test plan

Green CI.