### PR TITLE
jest-worker: Move @types/node to devDependencies

### DIFF
--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -17,12 +17,12 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@types/node": "*",
     "jest-util": "workspace:^",
     "merge-stream": "^2.0.0",
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
+    "@types/node": "*",
     "@tsd/typescript": "~4.8.2",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",


### PR DESCRIPTION
## Summary

Currently, when you `npm require` jest-worker, it has `@types/node` as a sub-requirement.  It should be a dev requirement as `@types/node` is in no way required for _using_ jest-worker, just development of jest-worker.

This is a bigger problem because TypeScript projects which include jest-worker are forced into targeting node instead of a browser. This is a because `@types/node` for instance redefines `setTimeout` among other things.

I had previously opened this as #12544 - it got closed for being stale. I am reopening as I am once again actively butting heads with the issue.

## Test plan

Not really "testable" perse.