### PR TITLE
feat: expose internal matchers on extended matchers context

### DIFF
--- a/packages/expect/src/__tests__/extend.test.ts
+++ b/packages/expect/src/__tests__/extend.test.ts
@@ -10,6 +10,7 @@ import {equals, iterableEquality, subsetEquality} from '@jest/expect-utils';
 import {alignedAnsiStyleSerializer} from '@jest/test-utils';
 import * as matcherUtils from 'jest-matcher-utils';
 import jestExpect from '../';
+import matchers from '../matchers';
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
@@ -228,4 +229,19 @@ it('throws descriptive errors for invalid matchers', () => {
   ).toThrow(
     'expect.extend: `default` is not a valid matcher. Must be a function, is "string"',
   );
+});
+
+it('exposes matchers in context', () => {
+  jestExpect.extend({
+    _shouldNotError(_actual: unknown, _expected: unknown) {
+      const pass = this.equals(this.matchers, matchers);
+      const message = pass
+        ? () => 'expected this.matchers to be defined in an extend call'
+        : () => 'expected this.matchers not to be defined in an extend call';
+
+      return {message, pass};
+    },
+  });
+
+  jestExpect()._shouldNotError();
 });

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -40,6 +40,7 @@ import toThrowMatchers, {
 } from './toThrowMatchers';
 import type {
   AsyncExpectationResult,
+  CustomMatcherContext,
   Expect,
   ExpectationResult,
   MatcherContext,
@@ -359,7 +360,15 @@ const makeThrowingMatcher = (
             // in the stack trace, so that it can correctly get the custom matcher
             // function call.
             (function __EXTERNAL_MATCHER_TRAP__() {
-              return matcher.call(matcherContext, actual, ...args);
+              return matcher.call<
+                CustomMatcherContext,
+                [unknown, ...Array<unknown>],
+                ExpectationResult
+              >(
+                {...matcherContext, matchers: Object.freeze(matchers)},
+                actual,
+                ...args,
+              );
             })();
 
       if (isPromise(potentialResult)) {

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -7,13 +7,8 @@
  */
 
 import {getType} from 'jest-get-type';
-import {AsymmetricMatcher} from './asymmetricMatchers';
-import type {
-  Expect,
-  MatcherState,
-  MatchersObject,
-  SyncExpectationResult,
-} from './types';
+import {customMatcher} from './asymmetricMatchers';
+import type {Expect, MatcherState, MatchersObject} from './types';
 
 // Global matchers object holds the list of available matchers and
 // the state, that can hold matcher specific values that change over time.
@@ -72,49 +67,18 @@ export const setMatchers = (
 
     if (!isInternal) {
       // expect is defined
-
-      class CustomMatcher extends AsymmetricMatcher<
-        [unknown, ...Array<unknown>]
-      > {
-        constructor(inverse = false, ...sample: [unknown, ...Array<unknown>]) {
-          super(sample, inverse);
-        }
-
-        asymmetricMatch(other: unknown) {
-          const {pass} = matcher.call(
-            this.getMatcherContext(),
-            other,
-            ...this.sample,
-          ) as SyncExpectationResult;
-
-          return this.inverse ? !pass : pass;
-        }
-
-        toString() {
-          return `${this.inverse ? 'not.' : ''}${key}`;
-        }
-
-        override getExpectedType() {
-          return 'any';
-        }
-
-        override toAsymmetricMatcher() {
-          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
-        }
-      }
-
       Object.defineProperty(expect, key, {
         configurable: true,
         enumerable: true,
         value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(false, ...sample),
+          customMatcher(key, matcher, false, sample),
         writable: true,
       });
       Object.defineProperty(expect.not, key, {
         configurable: true,
         enumerable: true,
         value: (...sample: [unknown, ...Array<unknown>]) =>
-          new CustomMatcher(true, ...sample),
+          customMatcher(key, matcher, true, sample),
         writable: true,
       });
     }

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -38,8 +38,8 @@ export type RawMatcherFn<Context extends MatcherContext = MatcherContext> = {
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
-export type MatchersObject = {
-  [name: string]: RawMatcherFn;
+export type MatchersObject<Context extends MatcherContext = MatcherContext> = {
+  [name: string]: RawMatcherFn<Context>;
 };
 
 export type ThrowingMatcherFn = (actual: any) => void;
@@ -71,6 +71,10 @@ export interface MatcherState {
 
 export type MatcherContext = MatcherUtils & Readonly<MatcherState>;
 
+export type CustomMatcherContext = MatcherContext & {
+  matchers: Readonly<MatchersObject>;
+};
+
 export type AsymmetricMatcher = {
   asymmetricMatch(other: unknown): boolean;
   toString(): string;
@@ -86,7 +90,7 @@ export type ExpectedAssertionsErrors = Array<{
 
 export interface BaseExpect {
   assertions(numberOfAssertions: number): void;
-  extend(matchers: MatchersObject): void;
+  extend(matchers: MatchersObject<CustomMatcherContext>): void;
   extractExpectedAssertionsErrors(): ExpectedAssertionsErrors;
   getState(): MatcherState;
   hasAssertions(): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

Address https://github.com/facebook/jest/issues/10590

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The idea is to have access to the internal matchers Jest has when creating custom matchers. The internal matchers are only exposed to those functions created from expect.extend() function.

Also, I moved the CustomMatcher class definition to the asymmetricMatchers file. Since that class is only being used when defining the custom matcher as asymmetric in the expect object, I guess it makes more sense to have it over there.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tests have been added to ensure internal matchers are exposed in the custom matcher context