### PR TITLE
chore: lint files in `website/blog` directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,7 +5,6 @@ bin/
 packages/*/build/**
 packages/*/dist/**
 website/.docusaurus
-website/blog
 website/build
 website/node_modules
 website/i18n/*.js

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -180,7 +180,6 @@ module.exports = {
         '@typescript-eslint/no-empty-function': 'off',
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/no-empty-interface': 'off',
-        'arrow-body-style': 'off',
         'consistent-return': 'off',
         'import/export': 'off',
         'import/no-extraneous-dependencies': 'off',
@@ -189,7 +188,6 @@ module.exports = {
         'no-console': 'off',
         'no-undef': 'off',
         'no-unused-vars': 'off',
-        'prettier/prettier': 'off',
         'sort-keys': 'off',
       },
     },
@@ -197,6 +195,14 @@ module.exports = {
       files: ['**/UsingMatchers.md/**'],
       rules: {
         'jest/prefer-to-be': 'off',
+      },
+    },
+    {
+      files: [
+        '**/2017-05-06-jest-20-delightful-testing-multi-project-runner.md/**',
+      ],
+      rules: {
+        'jest/valid-expect': 'off',
       },
     },
 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -198,7 +198,7 @@ module.exports = {
         'jest/prefer-to-be': 'off',
       },
     },
-    // demonstration of 'jest/valid-expect' rule usage
+    // demonstration of 'jest/valid-expect' rule
     {
       files: [
         '**/2017-05-06-jest-20-delightful-testing-multi-project-runner.md/**',
@@ -207,7 +207,7 @@ module.exports = {
         'jest/valid-expect': 'off',
       },
     },
-    // `toHaveLength` matcher was added in Jest 17
+    // Jest 11 did not had `toHaveLength` matcher
     {
       files: ['**/2016-04-12-jest-11.md/**'],
       rules: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -191,18 +191,27 @@ module.exports = {
         'sort-keys': 'off',
       },
     },
+    // demonstration of matchers usage
     {
       files: ['**/UsingMatchers.md/**'],
       rules: {
         'jest/prefer-to-be': 'off',
       },
     },
+    // demonstration of 'jest/valid-expect' rule usage
     {
       files: [
         '**/2017-05-06-jest-20-delightful-testing-multi-project-runner.md/**',
       ],
       rules: {
         'jest/valid-expect': 'off',
+      },
+    },
+    // `toHaveLength` matcher was added in Jest 17
+    {
+      files: ['**/2016-04-12-jest-11.md/**'],
+      rules: {
+        'jest/prefer-to-have-length': 'off',
       },
     },
 

--- a/website/blog/2016-04-12-jest-11.md
+++ b/website/blog/2016-04-12-jest-11.md
@@ -69,7 +69,7 @@ And `jest.fn` was added to make it easier to create mock functions:
 // Create a mock function
 const mockFn = jest.fn(() => 42);
 mockFn(); // 42
-expect(mockFn.calls).toHaveLength(1);
+expect(mockFn.calls.length).toBe(1);
 ```
 
 #### Performance

--- a/website/blog/2016-04-12-jest-11.md
+++ b/website/blog/2016-04-12-jest-11.md
@@ -69,7 +69,7 @@ And `jest.fn` was added to make it easier to create mock functions:
 // Create a mock function
 const mockFn = jest.fn(() => 42);
 mockFn(); // 42
-expect(mockFn.calls.length).toBe(1);
+expect(mockFn.calls).toHaveLength(1);
 ```
 
 #### Performance

--- a/website/blog/2017-12-18-jest-22.md
+++ b/website/blog/2017-12-18-jest-22.md
@@ -102,12 +102,6 @@ exports[`my mocking test 1`] = `
       },
     ],
   ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
 }
 `;
 ```

--- a/website/blog/2017-12-18-jest-22.md
+++ b/website/blog/2017-12-18-jest-22.md
@@ -25,7 +25,7 @@ To get a better understanding of custom runners and Jest as a platform, make sur
 
 In order to more easily identify which assertion is failing your test, we've added a code frame showing the context where the assertion is in order to focus on your own code. See the following example test:
 
-```
+```js
 test('some test', () => {
   function someFunctionWhichShouldThrow() {
     if (false) {
@@ -35,7 +35,7 @@ test('some test', () => {
     return 'success!';
   }
 
-  expect(someFunctionWhichShouldThrow).toThrowError();
+  expect(someFunctionWhichShouldThrow).toThrow();
 });
 ```
 
@@ -51,7 +51,7 @@ In Jest 22, we have added a codeframe, giving more context to the failing assert
 
 You can now use `toThrow` and `toThrowErrorMatchingSnapshot` on promise rejections in the same way you can on synchronous errors.
 
-```
+```js
 async function throwingFunction() {
   throw new Error('This failed');
 }
@@ -81,17 +81,18 @@ Jest uses Babel under the hood to power code coverage and advanced mocking featu
 
 There has been a couple of changes to mock functions in Jest 22, making them even easier to use. Firstly, we added a [`mockName`](/docs/mock-function-api#mockfnmocknamevalue) property allowing you to name your mocks, which is useful in assertion failures. We have also made the Jest mock function serializable in `pretty-format`, meaning that you can snapshot test mocks. In Jest 21, `expect(jest.fn()).toMatchSnapshot()` would serialize to `[Function]`, in Jest 22, you might get something like this:
 
-```
+```js
 test('my mocking test', () => {
   const mock = jest.fn().mockName('myMock');
 
-  mock('hello', { foo: 'bar' });
+  mock('hello', {foo: 'bar'});
 
   expect(mock).toMatchSnapshot();
 });
 
 // Serializes to:
 
+exports[`my mocking test 1`] = `
 [MockFunction myMock] {
   "calls": Array [
     Array [
@@ -101,7 +102,14 @@ test('my mocking test', () => {
       },
     ],
   ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
 }
+`;
 ```
 
 ## Highlights from Jest 21


### PR DESCRIPTION
## Summary

For some reason currently ESLint is told to ignore file in `website/blog` directory. Hm.. Let’s lint those too? Why not? ;D

## Test plan

Green CI.