### PR TITLE
chore(lint): ensure no mock APIs are used in the e2e tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -172,6 +172,23 @@ module.exports = {
       },
     },
 
+    {
+      files: ['e2e/__tests__/*'],
+      rules: {
+        'jest/no-restricted-jest-methods': [
+          'error',
+          {
+            fn: 'Please use fixtures instead of mocks in end-to-end tests.',
+            mock: 'Please use fixtures instead of mocks in end-to-end tests.',
+            doMock: 'Please use fixtures instead of mocks in end-to-end tests.',
+            setMock:
+              'Please use fixtures instead of mocks in end-to-end tests.',
+            spyOn: 'Please use fixtures instead of mocks in end-to-end tests.',
+          },
+        ],
+      },
+    },
+
     // to make it more suitable for running on code examples in docs/ folder
     {
       files: ['**/*.md/**'],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -178,12 +178,14 @@ module.exports = {
         'jest/no-restricted-jest-methods': [
           'error',
           {
-            fn: 'Please use fixtures instead of mocks in end-to-end tests.',
-            mock: 'Please use fixtures instead of mocks in end-to-end tests.',
-            doMock: 'Please use fixtures instead of mocks in end-to-end tests.',
+            fn: 'Please use fixtures instead of mocks in the end-to-end tests.',
+            mock: 'Please use fixtures instead of mocks in the end-to-end tests.',
+            doMock:
+              'Please use fixtures instead of mocks in the end-to-end tests.',
             setMock:
-              'Please use fixtures instead of mocks in end-to-end tests.',
-            spyOn: 'Please use fixtures instead of mocks in end-to-end tests.',
+              'Please use fixtures instead of mocks in the end-to-end tests.',
+            spyOn:
+              'Please use fixtures instead of mocks in the end-to-end tests.',
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^3.2.5",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.6.0",
-    "eslint-plugin-jest": "^26.1.0",
+    "eslint-plugin-jest": "^27.1.0",
     "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-markdown": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,7 +2784,7 @@ __metadata:
     eslint-import-resolver-typescript: ^3.2.5
     eslint-plugin-eslint-comments: ^3.1.2
     eslint-plugin-import: ^2.6.0
-    eslint-plugin-jest: ^26.1.0
+    eslint-plugin-jest: ^27.1.0
     eslint-plugin-jsdoc: ^39.3.6
     eslint-plugin-local: ^1.0.0
     eslint-plugin-markdown: ^3.0.0
@@ -9105,20 +9105,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:^26.1.0":
-  version: 26.9.0
-  resolution: "eslint-plugin-jest@npm:26.9.0"
+"eslint-plugin-jest@npm:^27.1.0":
+  version: 27.1.0
+  resolution: "eslint-plugin-jest@npm:27.1.0"
   dependencies:
     "@typescript-eslint/utils": ^5.10.0
   peerDependencies:
     "@typescript-eslint/eslint-plugin": ^5.0.0
-    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     "@typescript-eslint/eslint-plugin":
       optional: true
     jest:
       optional: true
-  checksum: 6d5fd5c95368f1ca2640389aeb7ce703d6202493c3ec6bdedb4eaca37233710508b0c75829e727765a16fd27029a466d34202bc7f2811c752038ccbbce224400
+  checksum: 288f8fb585a18b759b4782d97368da9974df42691332e2221bac508b3de8a253da489d165593f5ed588e625177462750acfe085d818f0e786fb520c907a9e360
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `eslint-plugin-jest` and uses `jest/no-restricted-jest-methods` rule to ensure no mock APIs are used in the end-to-end tests.

@G-Rath thanks once again for implementing the rule so quick!

## Test plan

Green CI.