### PR TITLE
fix(@jest/types): infer `each` types correctly when the table is a tuple or array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - `[babel-plugin-jest-hoist]` Ignore `TSTypeQuery` when checking for hoisted references ([#13367](https://github.com/facebook/jest/pull/13367))
+- `[@jest/types]` Infer type of `each` table correctly when the table is a tuple or array ([#13381](https://github.com/facebook/jest/pull/13381))
 
 ### Chore & Maintenance
 

--- a/packages/jest-circus/src/__tests__/hooksError.test.ts
+++ b/packages/jest-circus/src/__tests__/hooksError.test.ts
@@ -5,31 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {Circus} from '@jest/types';
 import circus from '../';
 
-describe.each([
-  'beforeEach',
-  'beforeAll',
-  'afterEach',
-  'afterAll',
-] as Array<Circus.HookType>)('%s hooks error throwing', fn => {
-  test.each([
-    ['String'],
-    [1],
-    [[]],
-    [{}],
-    [Symbol('hello')],
-    [true],
-    [null],
-    [undefined],
-  ])(
-    `${fn} throws an error when %p is provided as a first argument to it`,
-    el => {
-      expect(() => {
-        // @ts-expect-error: Testing runtime errors here
-        circus[fn](el);
-      }).toThrow('Invalid first argument. It must be a callback function.');
-    },
-  );
-});
+describe.each(['beforeEach', 'beforeAll', 'afterEach', 'afterAll'] as const)(
+  '%s hooks error throwing',
+  fn => {
+    test.each([
+      ['String'],
+      [1],
+      [[]],
+      [{}],
+      [Symbol('hello')],
+      [true],
+      [null],
+      [undefined],
+    ])(
+      `${fn} throws an error when %p is provided as a first argument to it`,
+      el => {
+        expect(() => {
+          // @ts-expect-error: Testing runtime errors here
+          circus[fn](el);
+        }).toThrow('Invalid first argument. It must be a callback function.');
+      },
+    );
+  },
+);

--- a/packages/jest-jasmine2/src/__tests__/hooksError.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/hooksError.test.ts
@@ -5,30 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type SharedHookType = 'afterAll' | 'beforeAll';
-export type HookType = SharedHookType | 'afterEach' | 'beforeEach';
-
-describe.each([
-  'beforeEach',
-  'beforeAll',
-  'afterEach',
-  'afterAll',
-] as Array<HookType>)('%s hooks error throwing', fn => {
-  test.each([
-    ['String'],
-    [1],
-    [[]],
-    [{}],
-    [Symbol('hello')],
-    [true],
-    [null],
-    [undefined],
-  ])(
-    `${fn} throws an error when %p is provided as a first argument to it`,
-    el => {
-      expect(() => {
-        globalThis[fn](el);
-      }).toThrow('Invalid first argument. It must be a callback function.');
-    },
-  );
-});
+describe.each(['beforeEach', 'beforeAll', 'afterEach', 'afterAll'] as const)(
+  '%s hooks error throwing',
+  fn => {
+    test.each([
+      ['String'],
+      [1],
+      [[]],
+      [{}],
+      [Symbol('hello')],
+      [true],
+      [null],
+      [undefined],
+    ])(
+      `${fn} throws an error when %p is provided as a first argument to it`,
+      el => {
+        expect(() => {
+          // @ts-expect-error: Testing runtime errors
+          globalThis[fn](el);
+        }).toThrow('Invalid first argument. It must be a callback function.');
+      },
+    );
+  },
+);

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -6,7 +6,6 @@
  */
 
 import {expectError, expectType} from 'tsd-lite';
-import {number} from 'yargs';
 import {describe, test} from '@jest/globals';
 
 const list = [1, 2, 3];

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -6,10 +6,11 @@
  */
 
 import {expectError, expectType} from 'tsd-lite';
+import {number} from 'yargs';
 import {describe, test} from '@jest/globals';
 
 const list = [1, 2, 3];
-const tupleList: [number, number, string] = [1, 2, 'three'];
+const tupleList = ['one', 'two', 'three'] as const;
 const table = [
   [1, 2, 'three'],
   [3, 4, 'seven'],
@@ -28,57 +29,41 @@ const objectTable = [
 // test.each
 
 expectType<void>(
-  test.each(list)('some test', (a, b, expected) => {
+  test.each(list)('some test', a => {
     expectType<number>(a);
-    expectType<number>(b);
-    expectType<number>(expected);
   }),
 );
 expectType<void>(
-  test.each(list)(
-    'some test',
-    (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<number>(expected);
-    },
-    1000,
-  ),
+  test.each(list)('some test', a => {
+    expectType<number>(a);
+  }),
 );
 
 expectType<void>(
-  test.each(tupleList)('some test', (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  test.each(tupleList)('some test', b => {
+    expectType<'one' | 'two' | 'three'>(b);
   }),
 );
 expectType<void>(
   test.each(tupleList)(
     'some test',
-    (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    b => {
+      expectType<'one' | 'two' | 'three'>(b);
     },
     1000,
   ),
 );
 
 expectType<void>(
-  test.each([3, 4, 'seven'])('some test', (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  test.each([3, 4, 'seven'])('some test', c => {
+    expectType<string | number>(c);
   }),
 );
 expectType<void>(
   test.each([3, 4, 'seven'])(
     'some test',
-    (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    c => {
+      expectType<string | number>(c);
     },
     1000,
   ),
@@ -261,57 +246,45 @@ expectType<typeof test.each>(test.skip.each);
 // test.concurrent.each
 
 expectType<void>(
-  test.concurrent.each(list)('some test', async (a, b, expected) => {
+  test.concurrent.each(list)('some test', async a => {
     expectType<number>(a);
-    expectType<number>(b);
-    expectType<number>(expected);
   }),
 );
 expectType<void>(
   test.concurrent.each(list)(
     'some test',
-    async (a, b, expected) => {
+    async a => {
       expectType<number>(a);
-      expectType<number>(b);
-      expectType<number>(expected);
     },
     1000,
   ),
 );
 
 expectType<void>(
-  test.concurrent.each(tupleList)('some test', async (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  test.concurrent.each(tupleList)('some test', async b => {
+    expectType<'one' | 'two' | 'three'>(b);
   }),
 );
 expectType<void>(
   test.concurrent.each(tupleList)(
     'some test',
-    async (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    async b => {
+      expectType<'one' | 'two' | 'three'>(b);
     },
     1000,
   ),
 );
 
 expectType<void>(
-  test.concurrent.each([3, 4, 'seven'])('some test', async (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  test.concurrent.each([3, 4, 'seven'])('some test', async c => {
+    expectType<string | number>(c);
   }),
 );
 expectType<void>(
   test.concurrent.each([3, 4, 'seven'])(
     'some test',
-    async (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    async c => {
+      expectType<string | number>(c);
     },
     1000,
   ),
@@ -448,57 +421,45 @@ expectType<typeof test.concurrent.each>(test.concurrent.skip.each);
 // describe.each
 
 expectType<void>(
-  describe.each(list)('describe each', (a, b, expected) => {
+  describe.each(list)('describe each', a => {
     expectType<number>(a);
-    expectType<number>(b);
-    expectType<number>(expected);
   }),
 );
 expectType<void>(
   describe.each(list)(
     'describe each',
-    (a, b, expected) => {
+    a => {
       expectType<number>(a);
-      expectType<number>(b);
-      expectType<number>(expected);
     },
     1000,
   ),
 );
 
 expectType<void>(
-  describe.each(tupleList)('describe each', (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  describe.each(tupleList)('describe each', b => {
+    expectType<'one' | 'two' | 'three'>(b);
   }),
 );
 expectType<void>(
   describe.each(tupleList)(
     'describe each',
-    (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    b => {
+      expectType<'one' | 'two' | 'three'>(b);
     },
     1000,
   ),
 );
 
 expectType<void>(
-  describe.each([3, 4, 'seven'])('describe each', (a, b, expected) => {
-    expectType<number>(a);
-    expectType<number>(b);
-    expectType<string>(expected);
+  describe.each([3, 4, 'seven'])('describe each', c => {
+    expectType<string | number>(c);
   }),
 );
 expectType<void>(
   describe.each([3, 4, 'seven'])(
     'describe each',
-    (a, b, expected) => {
-      expectType<number>(a);
-      expectType<number>(b);
-      expectType<string>(expected);
+    c => {
+      expectType<string | number>(c);
     },
     1000,
   ),

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -56,42 +56,42 @@ export type EachTestFn<EachCallback extends TestCallback> = (
 ) => ReturnType<EachCallback>;
 
 interface Each<EachFn extends TestFn | BlockFn> {
+  // when the table is an array of object literals
   <T extends Record<string, unknown>>(table: ReadonlyArray<T>): (
     name: string | NameLike,
     fn: (arg: T) => ReturnType<EachFn>,
     timeout?: number,
   ) => void;
 
+  // when the table is an array of tuples
   <T extends readonly [unknown, ...Array<unknown>]>(table: ReadonlyArray<T>): (
     name: string | NameLike,
     fn: (...args: T) => ReturnType<EachFn>,
     timeout?: number,
   ) => void;
 
-  <T extends readonly [unknown, ...Array<unknown>]>(table: T): (
-    name: string | NameLike,
-    fn: (...args: T) => ReturnType<EachFn>,
-    timeout?: number,
-  ) => void;
-
+  // when the table is an array of arrays
   <T extends ReadonlyArray<unknown>>(table: ReadonlyArray<T>): (
     name: string | NameLike,
     fn: (...args: T) => ReturnType<EachFn>,
     timeout?: number,
   ) => void;
 
-  <T extends ReadonlyArray<unknown>>(table: T): (
+  // when the table is a tuple or array
+  <T>(table: ReadonlyArray<T>): (
     name: string | NameLike,
-    fn: (...args: T) => ReturnType<EachFn>,
+    fn: (arg: T) => ReturnType<EachFn>,
     timeout?: number,
   ) => void;
 
+  // when the table is a template literal
   <T = unknown>(strings: TemplateStringsArray, ...expressions: Array<T>): (
     name: string | NameLike,
     fn: (arg: Record<string, T>) => ReturnType<EachFn>,
     timeout?: number,
   ) => void;
 
+  // when the table is a template literal with a type argument
   <T extends Record<string, unknown>>(
     strings: TemplateStringsArray,
     ...expressions: Array<unknown>


### PR DESCRIPTION
From https://github.com/facebook/jest/pull/13360#discussion_r985275338

## Summary

The type of `each` table wasn’t inferred correctly in cases if the table was passed as a tuple or array. This PR fixes the bug.

## Test plan

Type tests adjusted.