### PR TITLE
chore: add more tests for `toHaveLastReturnedWith` and `lastReturnedWith` matchers

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
@@ -242,6 +242,29 @@ Received
 Number of returns: <r>3</>
 `;
 
+exports[`lastReturnedWith returnedWith incomplete recursive calls are handled properly 1`] = `
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
+
+Expected: <g>undefined</>
+Received
+       3: function call has not returned yet
+->     4: function call has not returned yet
+
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
+`;
+
+exports[`lastReturnedWith returnedWith works with more calls than the limit 1`] = `
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
+
+Expected: <g>"bar"</>
+Received
+       5: <r>"foo5"</>
+->     6: <r>"foo6"</>
+
+Number of returns: <r>6</>
+`;
+
 exports[`lastReturnedWith works only on spies or jest.fn 1`] = `
 <d>expect(</><r>received</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
@@ -2058,6 +2081,29 @@ Received
 ->     3:     <d>"foo3"</>
 
 Number of returns: <r>3</>
+`;
+
+exports[`toHaveLastReturnedWith returnedWith incomplete recursive calls are handled properly 1`] = `
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
+
+Expected: <g>undefined</>
+Received
+       3: function call has not returned yet
+->     4: function call has not returned yet
+
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
+`;
+
+exports[`toHaveLastReturnedWith returnedWith works with more calls than the limit 1`] = `
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
+
+Expected: <g>"bar"</>
+Received
+       5: <r>"foo5"</>
+->     6: <r>"foo6"</>
+
+Number of returns: <r>6</>
 `;
 
 exports[`toHaveLastReturnedWith works only on spies or jest.fn 1`] = `

--- a/packages/expect/src/__tests__/spyMatchers.test.ts
+++ b/packages/expect/src/__tests__/spyMatchers.test.ts
@@ -1023,7 +1023,12 @@ describe.each([
     ).toThrowErrorMatchingSnapshot();
   });
 
-  const basicReturnedWith = ['toHaveReturnedWith', 'toReturnWith'];
+  const basicReturnedWith = [
+    'toHaveLastReturnedWith',
+    'lastReturnedWith',
+    'toHaveReturnedWith',
+    'toReturnWith',
+  ];
   if (basicReturnedWith.indexOf(returnedWith) >= 0) {
     describe('returnedWith', () => {
       test('works with more calls than the limit', () => {


### PR DESCRIPTION
Form https://github.com/facebook/jest/pull/13383#discussion_r986890423

## Summary

Looks like `toHaveLastReturnedWith` and `lastReturnedWith` matchers were excluded in one conditional test by accident. Worth adding (;

## Test plan

Green CI.