### PR TITLE
chore: use `references` to all `__tests__/tsconfig.json` files

### DIFF
--- a/packages/babel-jest/src/__tests__/tsconfig.json
+++ b/packages/babel-jest/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/babel-plugin-jest-hoist/src/__tests__/tsconfig.json
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/diff-sequences/src/__tests__/tsconfig.json
+++ b/packages/diff-sequences/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/expect-utils/src/__tests__/tsconfig.json
+++ b/packages/expect-utils/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-circus/src/__tests__/tsconfig.json
+++ b/packages/jest-circus/src/__tests__/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"],
+  "include": ["./**/*"],
   "references": [{"path": "../../"}]
 }

--- a/packages/jest-cli/src/__tests__/tsconfig.json
+++ b/packages/jest-cli/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-cli/src/init/__tests__/tsconfig.json
+++ b/packages/jest-cli/src/init/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-config/src/__tests__/tsconfig.json
+++ b/packages/jest-config/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-console/src/__tests__/tsconfig.json
+++ b/packages/jest-console/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-core/src/lib/__tests__/tsconfig.json
+++ b/packages/jest-core/src/lib/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-core/src/plugins/__tests__/tsconfig.json
+++ b/packages/jest-core/src/plugins/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-create-cache-key-function/src/__tests__/tsconfig.json
+++ b/packages/jest-create-cache-key-function/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-diff/src/__tests__/tsconfig.json
+++ b/packages/jest-diff/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-docblock/src/__tests__/tsconfig.json
+++ b/packages/jest-docblock/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-each/src/__tests__/tsconfig.json
+++ b/packages/jest-each/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-environment-jsdom/src/__tests__/tsconfig.json
+++ b/packages/jest-environment-jsdom/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-environment-node/src/__tests__/tsconfig.json
+++ b/packages/jest-environment-node/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-fake-timers/src/__tests__/tsconfig.json
+++ b/packages/jest-fake-timers/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-get-type/src/__tests__/tsconfig.json
+++ b/packages/jest-get-type/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-globals/src/__tests__/tsconfig.json
+++ b/packages/jest-globals/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-haste-map/src/__tests__/tsconfig.json
+++ b/packages/jest-haste-map/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-haste-map/src/crawlers/__tests__/tsconfig.json
+++ b/packages/jest-haste-map/src/crawlers/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-haste-map/src/lib/__tests__/tsconfig.json
+++ b/packages/jest-haste-map/src/lib/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-jasmine2/src/__tests__/tsconfig.json
+++ b/packages/jest-jasmine2/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-leak-detector/src/__tests__/tsconfig.json
+++ b/packages/jest-leak-detector/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-matcher-utils/src/__tests__/tsconfig.json
+++ b/packages/jest-matcher-utils/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-message-util/src/__tests__/tsconfig.json
+++ b/packages/jest-message-util/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-mock/src/__tests__/tsconfig.json
+++ b/packages/jest-mock/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-regex-util/src/__tests__/tsconfig.json
+++ b/packages/jest-regex-util/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-repl/src/__tests__/tsconfig.json
+++ b/packages/jest-repl/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-reporters/src/__tests__/tsconfig.json
+++ b/packages/jest-reporters/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-resolve-dependencies/src/__tests__/tsconfig.json
+++ b/packages/jest-resolve-dependencies/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-resolve/src/__tests__/tsconfig.json
+++ b/packages/jest-resolve/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-runner/src/__tests__/tsconfig.json
+++ b/packages/jest-runner/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-runtime/src/__tests__/tsconfig.json
+++ b/packages/jest-runtime/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-snapshot/src/__tests__/tsconfig.json
+++ b/packages/jest-snapshot/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-source-map/src/__tests__/tsconfig.json
+++ b/packages/jest-source-map/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-test-result/src/__tests__/tsconfig.json
+++ b/packages/jest-test-result/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-test-sequencer/src/__tests__/tsconfig.json
+++ b/packages/jest-test-sequencer/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-transform/src/__tests__/tsconfig.json
+++ b/packages/jest-transform/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-util/src/__tests__/tsconfig.json
+++ b/packages/jest-util/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-validate/src/__tests__/tsconfig.json
+++ b/packages/jest-validate/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-watcher/src/lib/__tests__/tsconfig.json
+++ b/packages/jest-watcher/src/lib/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-worker/src/__tests__/tsconfig.json
+++ b/packages/jest-worker/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }

--- a/packages/jest-worker/src/base/__tests__/tsconfig.json
+++ b/packages/jest-worker/src/base/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/jest-worker/src/workers/__tests__/tsconfig.json
+++ b/packages/jest-worker/src/workers/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
 }

--- a/packages/pretty-format/src/__tests__/tsconfig.json
+++ b/packages/pretty-format/src/__tests__/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../../../tsconfig.test.json",
-  "compilerOptions": {
-    "rootDir": "../"
-  },
-  "include": ["../**/*"]
+  "include": ["./**/*"],
+  "references": [{"path": "../../"}]
 }


### PR DESCRIPTION
## Summary

Looks like a good idea to use `references` instead of `rootDir` in all `__tests__/tsconfig.json` files to keep them consistent. See https://github.com/facebook/jest/pull/13387#discussion_r988536925

## Test plan

Green CI.