### PR TITLE
chore: add typechecks for tests of `jest-cli`, `jest-config` and `@jest/console` packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "test": "yarn lint && yarn jest",
     "typecheck": "yarn typecheck:examples && yarn typecheck:tests",
     "typecheck:examples": "tsc -p examples/angular --noEmit && tsc -p examples/expect-extend --noEmit && tsc -p examples/typescript --noEmit",
-    "typecheck:tests": "tsc -b packages/{babel-jest,babel-plugin-jest-hoist,diff-sequences,expect,expect-utils,jest-circus,jest-cli}/src/{__tests__,init/__tests__}",
+    "typecheck:tests": "tsc -b packages/{babel-jest,babel-plugin-jest-hoist,diff-sequences,expect,expect-utils,jest-circus,jest-cli,jest-config,jest-console}/src/{__tests__,init/__tests__}",
     "verify-old-ts": "node ./scripts/verifyOldTs.mjs",
     "verify-pnp": "node ./scripts/verifyPnP.mjs",
     "watch": "yarn build:js && node ./scripts/watch.mjs",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "test": "yarn lint && yarn jest",
     "typecheck": "yarn typecheck:examples && yarn typecheck:tests",
     "typecheck:examples": "tsc -p examples/angular --noEmit && tsc -p examples/expect-extend --noEmit && tsc -p examples/typescript --noEmit",
-    "typecheck:tests": "tsc -b packages/{babel-jest,babel-plugin-jest-hoist,diff-sequences,expect,expect-utils,jest-circus}/src/__tests__",
+    "typecheck:tests": "tsc -b packages/{babel-jest,babel-plugin-jest-hoist,diff-sequences,expect,expect-utils,jest-circus,jest-cli}/src/{__tests__,init/__tests__}",
     "verify-old-ts": "node ./scripts/verifyOldTs.mjs",
     "verify-pnp": "node ./scripts/verifyPnP.mjs",
     "watch": "yarn build:js && node ./scripts/watch.mjs",

--- a/packages/jest-config/src/__tests__/Defaults.test.ts
+++ b/packages/jest-config/src/__tests__/Defaults.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {defaults} from '../index';
+import {defaults} from '../';
 
 test('get configuration defaults', () => {
   expect(defaults).toBeDefined();

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -38,7 +38,7 @@ let virtualModuleRegexes: Array<RegExp>;
 beforeEach(() => {
   virtualModuleRegexes = [/jest-circus/, /babel-jest/];
 });
-const findNodeModule = jest.fn(name => {
+const findNodeModule = jest.fn((name: string) => {
   if (virtualModuleRegexes.some(regex => regex.test(name))) {
     return name;
   }
@@ -59,7 +59,9 @@ beforeEach(() => {
   expectedPathAbs = path.join(root, 'an', 'abs', 'path');
   expectedPathAbsAnother = path.join(root, 'another', 'abs', 'path');
 
-  require('jest-resolve').default.findNodeModule = findNodeModule;
+  (
+    require('jest-resolve') as typeof import('jest-resolve')
+  ).default.findNodeModule = findNodeModule;
 
   jest.spyOn(console, 'warn');
 });
@@ -94,7 +96,9 @@ it('keeps custom project id based on the projects rootDir', async () => {
     {} as Config.Argv,
   );
 
-  expect(options.projects[0].id).toBe(id);
+  expect((options.projects as Array<Config.InitialProjectOptions>)[0].id).toBe(
+    id,
+  );
 });
 
 it('keeps custom ids based on the rootDir', async () => {
@@ -256,10 +260,11 @@ describe('roots', () => {
 });
 
 describe('reporters', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => name);
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => name);
   });
 
   it('allows empty list', async () => {
@@ -303,6 +308,7 @@ describe('reporters', () => {
     await expect(
       normalize(
         {
+          // @ts-expect-error: Testing runtime error
           reporters: [123],
           rootDir: '/root/',
         },
@@ -316,6 +322,7 @@ describe('reporters', () => {
     await expect(
       normalize(
         {
+          // @ts-expect-error: Testing runtime error
           reporters: [[123]],
           rootDir: '/root/',
         },
@@ -329,6 +336,7 @@ describe('reporters', () => {
     await expect(
       normalize(
         {
+          // @ts-expect-error: Testing runtime error
           reporters: [['some-reporter']],
           rootDir: '/root/',
         },
@@ -342,6 +350,7 @@ describe('reporters', () => {
     await expect(
       normalize(
         {
+          // @ts-expect-error: Testing runtime error
           reporters: [['some-reporter', true]],
           rootDir: '/root/',
         },
@@ -352,10 +361,11 @@ describe('reporters', () => {
 });
 
 describe('transform', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => name);
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => name);
   });
 
   it('normalizes the path', async () => {
@@ -398,10 +408,11 @@ describe('transform', () => {
 });
 
 describe('haste', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => name);
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => name);
   });
 
   it('normalizes the path for hasteImplModulePath', async () => {
@@ -422,10 +433,11 @@ describe('haste', () => {
 });
 
 describe('setupFilesAfterEnv', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name =>
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) =>
       name.startsWith('/') ? name : `/root/path/foo${path.sep}${name}`,
     );
   });
@@ -684,8 +696,9 @@ describe('testRunner', () => {
   });
 
   it('resolves jasmine', async () => {
-    const Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => name);
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => name);
     const {options} = await normalize(
       {
         rootDir: '/root/path/foo',
@@ -699,8 +712,9 @@ describe('testRunner', () => {
   });
 
   it('is overwritten by argv', async () => {
-    const Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => name);
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => name);
     const {options} = await normalize(
       {
         rootDir: '/root/path/foo',
@@ -728,10 +742,11 @@ describe('coverageDirectory', () => {
 });
 
 describe('testEnvironment', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (['jsdom', 'jest-environment-jsdom'].includes(name)) {
         return `node_modules/${name}`;
       }
@@ -793,10 +808,11 @@ describe('testEnvironment', () => {
 });
 
 describe('babel-jest', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name =>
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) =>
       name.indexOf('babel-jest') === -1
         ? `${path.sep}node_modules${path.sep}${name}`
         : name,
@@ -944,8 +960,9 @@ describe('moduleDirectories', () => {
 
 describe('preset', () => {
   beforeEach(() => {
-    const Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (name === 'react-native/jest-preset') {
         return '/node_modules/react-native/jest-preset.json';
       }
@@ -1084,6 +1101,7 @@ describe('preset', () => {
     jest.doMock(
       '/node_modules/react-native-js-preset/jest-preset.js',
       () => ({
+        // @ts-expect-error: Testing runtime error
         transform: {}.nonExistingProp.call(),
       }),
       {virtual: true},
@@ -1118,11 +1136,11 @@ describe('preset', () => {
 
   test.each(['react-native-js-preset', 'cjs-preset'])(
     'works with cjs preset',
-    async presetName => {
+    async preset => {
       await expect(
         normalize(
           {
-            preset: presetName,
+            preset,
             rootDir: '/root/path/foo',
           },
           {} as Config.Argv,
@@ -1144,7 +1162,8 @@ describe('preset', () => {
   });
 
   test('searches for .json, .js, .cjs, .mjs preset files', async () => {
-    const Resolver = require('jest-resolve').default;
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
 
     await normalize(
       {
@@ -1154,7 +1173,7 @@ describe('preset', () => {
       {} as Config.Argv,
     );
 
-    const options = Resolver.findNodeModule.mock.calls[0][1];
+    const options = jest.mocked(Resolver.findNodeModule).mock.calls[0][1];
     expect(options.extensions).toEqual(['.json', '.js', '.cjs', '.mjs']);
   });
 
@@ -1258,8 +1277,9 @@ describe('preset', () => {
 
 describe('preset with globals', () => {
   beforeEach(() => {
-    const Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (name === 'global-foo/jest-preset') {
         return '/node_modules/global-foo/jest-preset.json';
       }
@@ -1314,12 +1334,13 @@ describe('preset with globals', () => {
   });
 });
 
-describe.each(['setupFiles', 'setupFilesAfterEnv'])(
+describe.each(['setupFiles', 'setupFilesAfterEnv'] as const)(
   'preset without %s',
   configKey => {
     let Resolver;
     beforeEach(() => {
-      Resolver = require('jest-resolve').default;
+      Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+        .default;
       Resolver.findNodeModule = jest.fn(
         name => `${path.sep}node_modules${path.sep}${name}`,
       );
@@ -1359,8 +1380,9 @@ describe.each(['setupFiles', 'setupFilesAfterEnv'])(
 
 describe("preset with 'reporters' option", () => {
   beforeEach(() => {
-    const Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    const Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (name === 'with-reporters/jest-preset') {
         return '/node_modules/with-reporters/jest-preset.json';
       }
@@ -1407,10 +1429,11 @@ describe("preset with 'reporters' option", () => {
 });
 
 describe('runner', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (['eslint', 'jest-runner-eslint', 'my-runner-foo'].includes(name)) {
         return `node_modules/${name}`;
       }
@@ -1465,10 +1488,11 @@ describe('runner', () => {
 });
 
 describe('watchPlugins', () => {
-  let Resolver;
+  let Resolver: typeof import('jest-resolve').default;
   beforeEach(() => {
-    Resolver = require('jest-resolve').default;
-    Resolver.findNodeModule = jest.fn(name => {
+    Resolver = (require('jest-resolve') as typeof import('jest-resolve'))
+      .default;
+    Resolver.findNodeModule = jest.fn((name: string) => {
       if (
         ['typeahead', 'jest-watch-typeahead', 'my-watch-plugin'].includes(name)
       ) {
@@ -1614,7 +1638,9 @@ describe('testPathPattern', () => {
             'path',
             () => jest.requireActual<typeof import('path')>('path').win32,
           );
-          require('jest-resolve').default.findNodeModule = findNodeModule;
+          (
+            require('jest-resolve') as typeof import('jest-resolve')
+          ).default.findNodeModule = findNodeModule;
         });
 
         afterEach(() => {
@@ -1622,31 +1648,28 @@ describe('testPathPattern', () => {
         });
 
         it('preserves any use of "\\"', async () => {
-          const argv = {[opt.property]: ['a\\b', 'c\\\\d']};
-          const {options} = await require('../normalize').default(
-            initialOptions,
-            argv,
-          );
+          const argv = {[opt.property]: ['a\\b', 'c\\\\d']} as Config.Argv;
+          const {options} = await (
+            require('../normalize') as typeof import('../normalize')
+          ).default(initialOptions, argv);
 
           expect(options.testPathPattern).toBe('a\\b|c\\\\d');
         });
 
         it('replaces POSIX path separators', async () => {
-          const argv = {[opt.property]: ['a/b']};
-          const {options} = await require('../normalize').default(
-            initialOptions,
-            argv,
-          );
+          const argv = {[opt.property]: ['a/b']} as Config.Argv;
+          const {options} = await (
+            require('../normalize') as typeof import('../normalize')
+          ).default(initialOptions, argv);
 
           expect(options.testPathPattern).toBe('a\\\\b');
         });
 
         it('replaces POSIX paths in multiple args', async () => {
-          const argv = {[opt.property]: ['a/b', 'c/d']};
-          const {options} = await require('../normalize').default(
-            initialOptions,
-            argv,
-          );
+          const argv = {[opt.property]: ['a/b', 'c/d']} as Config.Argv;
+          const {options} = await (
+            require('../normalize') as typeof import('../normalize')
+          ).default(initialOptions, argv);
 
           expect(options.testPathPattern).toBe('a\\\\b|c\\\\d');
         });
@@ -1688,7 +1711,7 @@ describe('moduleFileExtensions', () => {
     ]);
   });
 
-  it.each([undefined, 'jest-runner'])(
+  it.each([undefined, 'jest-runner'] as const)(
     'throws if missing `js` but using jest-runner',
     async runner => {
       await expect(
@@ -1747,7 +1770,7 @@ describe('Defaults', () => {
 });
 
 describe('displayName', () => {
-  test.each`
+  test.each<{displayName: Config.DisplayName; description: string}>`
     displayName             | description
     ${{}}                   | ${'is an empty object'}
     ${{name: 'hello'}}      | ${'missing color'}
@@ -1949,6 +1972,7 @@ describe('logs a deprecation warning', () => {
   test("when 'browser' option is passed", async () => {
     await normalize(
       {
+        // @ts-expect-error: Testing deprecated option
         browser: true,
         rootDir: '/root/',
       },
@@ -1961,6 +1985,7 @@ describe('logs a deprecation warning', () => {
   test("when 'collectCoverageOnlyFrom' option is passed", async () => {
     await normalize(
       {
+        // @ts-expect-error: Testing deprecated option
         collectCoverageOnlyFrom: {
           '<rootDir>/this-directory-is-covered/Covered.js': true,
         },
@@ -1975,6 +2000,7 @@ describe('logs a deprecation warning', () => {
   test("when 'extraGlobals' option is passed", async () => {
     await normalize(
       {
+        // @ts-expect-error: Testing deprecated option
         extraGlobals: ['Math'],
         rootDir: '/root/',
       },
@@ -1987,6 +2013,7 @@ describe('logs a deprecation warning', () => {
   test("when 'moduleLoader' option is passed", async () => {
     await normalize(
       {
+        // @ts-expect-error: Testing deprecated option
         moduleLoader: '<rootDir>/runtime.js',
         rootDir: '/root/',
       },
@@ -1999,6 +2026,7 @@ describe('logs a deprecation warning', () => {
   test("when 'preprocessorIgnorePatterns' option is passed", async () => {
     await normalize(
       {
+        // @ts-expect-error: Testing deprecated option
         preprocessorIgnorePatterns: ['/node_modules/'],
         rootDir: '/root/',
       },
@@ -2012,6 +2040,7 @@ describe('logs a deprecation warning', () => {
     await normalize(
       {
         rootDir: '/root/',
+        // @ts-expect-error: Testing deprecated option
         scriptPreprocessor: 'preprocessor.js',
       },
       {} as Config.Argv,
@@ -2024,6 +2053,7 @@ describe('logs a deprecation warning', () => {
     await normalize(
       {
         rootDir: '/root/',
+        // @ts-expect-error: Testing deprecated option
         setupTestFrameworkScriptFile: 'setup.js',
       },
       {} as Config.Argv,
@@ -2036,6 +2066,7 @@ describe('logs a deprecation warning', () => {
     await normalize(
       {
         rootDir: '/root/',
+        // @ts-expect-error: Testing deprecated option
         testPathDirs: ['<rootDir>'],
       },
       {} as Config.Argv,
@@ -2048,6 +2079,7 @@ describe('logs a deprecation warning', () => {
     await normalize(
       {
         rootDir: '/root/',
+        // @ts-expect-error: Testing deprecated option
         testURL: 'https://jestjs.io',
       },
       {} as Config.Argv,
@@ -2060,6 +2092,7 @@ describe('logs a deprecation warning', () => {
     await normalize(
       {
         rootDir: '/root/',
+        // @ts-expect-error: Testing deprecated option
         timers: 'real',
       },
       {} as Config.Argv,

--- a/packages/jest-config/src/__tests__/readConfig.test.ts
+++ b/packages/jest-config/src/__tests__/readConfig.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {readConfig} from '../index';
+import {readConfig} from '../';
 
 test('readConfig() throws when an object is passed without a file path', async () => {
   await expect(

--- a/packages/jest-config/src/__tests__/readConfigs.test.ts
+++ b/packages/jest-config/src/__tests__/readConfigs.test.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {readConfigs} from '../index';
+import {readConfigs} from '../';
 
 jest.mock('graceful-fs', () => ({
   ...jest.requireActual<typeof import('fs')>('fs'),

--- a/packages/jest-config/src/__tests__/readInitialOptions.test.ts
+++ b/packages/jest-config/src/__tests__/readInitialOptions.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import type {Config} from '@jest/types';
-import {readInitialOptions} from '../index';
+import {readInitialOptions} from '../';
 
 describe(readInitialOptions, () => {
   test('should be able to use serialized jest config', async () => {

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -19,18 +19,18 @@ describe('CustomConsole', () => {
     _stderr = '';
 
     const stdout = new Writable({
-      write(chunk, encoding, callback) {
+      write(chunk: string, _encoding, callback) {
         _stdout += chunk.toString();
         callback();
       },
-    });
+    }) as NodeJS.WriteStream;
 
     const stderr = new Writable({
-      write(chunk, encoding, callback) {
+      write(chunk: string, _encoding, callback) {
         _stderr += chunk.toString();
         callback();
       },
-    });
+    }) as NodeJS.WriteStream;
 
     _console = new CustomConsole(stdout, stderr);
   });

--- a/packages/jest-console/src/__tests__/bufferedConsole.test.ts
+++ b/packages/jest-console/src/__tests__/bufferedConsole.test.ts
@@ -20,7 +20,7 @@ describe('CustomConsole', () => {
   };
 
   beforeEach(() => {
-    _console = new BufferedConsole(() => null);
+    _console = new BufferedConsole();
   });
 
   describe('assert', () => {

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -33,7 +33,7 @@ describe('getConsoleOutput', () => {
     'log',
     'time',
     'warn',
-  ] as const)('takes noStackTrace and pass it on for $logType', logType => {
+  ] as const)('takes noStackTrace and pass it on for %s', logType => {
     getConsoleOutput(
       BufferedConsole.write([], logType, 'message', 4),
       {

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -9,7 +9,6 @@ import {makeGlobalConfig} from '@jest/test-utils';
 import {formatStackTrace} from 'jest-message-util';
 import BufferedConsole from '../BufferedConsole';
 import getConsoleOutput from '../getConsoleOutput';
-import type {LogType} from '../types';
 
 jest.mock('jest-message-util', () => ({
   formatStackTrace: jest.fn(),
@@ -17,25 +16,26 @@ jest.mock('jest-message-util', () => ({
 
 describe('getConsoleOutput', () => {
   const globalConfig = makeGlobalConfig({noStackTrace: true});
-  formatStackTrace.mockImplementation(() => 'throw new Error("Whoops!");');
+  jest
+    .mocked(formatStackTrace)
+    .mockImplementation(() => 'throw new Error("Whoops!");');
 
-  it.each`
-    logType
-    ${'assert'}
-    ${'count'}
-    ${'debug'}
-    ${'dir'}
-    ${'dirxml'}
-    ${'error'}
-    ${'group'}
-    ${'groupCollapsed'}
-    ${'info'}
-    ${'log'}
-    ${'time'}
-    ${'warn'}
-  `('takes noStackTrace and pass it on for $logType', logType => {
+  it.each([
+    'assert',
+    'count',
+    'debug',
+    'dir',
+    'dirxml',
+    'error',
+    'group',
+    'groupCollapsed',
+    'info',
+    'log',
+    'time',
+    'warn',
+  ] as const)('takes noStackTrace and pass it on for $logType', logType => {
     getConsoleOutput(
-      BufferedConsole.write([], logType as LogType, 'message', 4),
+      BufferedConsole.write([], logType, 'message', 4),
       {
         rootDir: 'root',
         testMatch: [],


### PR DESCRIPTION
## Summary

Cleaned up typings and added typechecks for tests of `jest-cli`, `jest-config` and `@jest/console` packages.

## Test plan

Green CI.