### PR TITLE
fix(@jest/reporters): do not transform file paths into hyperlinks

### DIFF
--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -35,7 +35,6 @@
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",
-    "terminal-link": "^2.0.0",
     "v8-to-istanbul": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/jest-reporters/src/__tests__/getResultHeader.test.js
+++ b/packages/jest-reporters/src/__tests__/getResultHeader.test.js
@@ -7,9 +7,6 @@
 
 import {makeGlobalConfig} from '@jest/test-utils';
 import getResultHeader from '../getResultHeader';
-const terminalLink = require('terminal-link');
-
-jest.mock('terminal-link', () => jest.fn(() => 'wannabehyperlink'));
 
 const endTime = 1577717671160;
 const testTime = 5500;
@@ -37,26 +34,6 @@ const testResultFast = {
 };
 
 const globalConfig = makeGlobalConfig();
-
-beforeEach(() => {
-  terminalLink.mockClear();
-});
-
-test('should call `terminal-link` correctly', () => {
-  getResultHeader(testResult, globalConfig);
-
-  expect(terminalLink).toHaveBeenCalledWith(
-    expect.stringContaining('foo'),
-    'file:///foo',
-    expect.objectContaining({fallback: expect.any(Function)}),
-  );
-});
-
-test('should render the terminal link', () => {
-  const result = getResultHeader(testResult, globalConfig);
-
-  expect(result).toContain('wannabehyperlink');
-});
 
 test('should display test time for slow test', () => {
   const result = getResultHeader(testResultSlow, globalConfig);

--- a/packages/jest-reporters/src/getResultHeader.ts
+++ b/packages/jest-reporters/src/getResultHeader.ts
@@ -6,7 +6,6 @@
  */
 
 import chalk = require('chalk');
-import terminalLink = require('terminal-link');
 import type {TestResult} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import {formatTime} from 'jest-util';
@@ -33,13 +32,6 @@ export default function getResultHeader(
   projectConfig?: Config.ProjectConfig,
 ): string {
   const testPath = result.testFilePath;
-  const formattedTestPath = formatTestPath(
-    projectConfig ? projectConfig : globalConfig,
-    testPath,
-  );
-  const fileLink = terminalLink(formattedTestPath, `file://${testPath}`, {
-    fallback: () => formattedTestPath,
-  });
   const status =
     result.numFailingTests > 0 || result.testExecError ? FAIL : PASS;
 
@@ -61,7 +53,8 @@ export default function getResultHeader(
       ? `${printDisplayName(projectConfig)} `
       : '';
 
-  return `${status} ${projectDisplayName}${fileLink}${
-    testDetail.length ? ` (${testDetail.join(', ')})` : ''
-  }`;
+  return `${status} ${projectDisplayName}${formatTestPath(
+    projectConfig ?? globalConfig,
+    testPath,
+  )}${testDetail.length ? ` (${testDetail.join(', ')})` : ''}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,7 +2874,6 @@ __metadata:
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
-    terminal-link: ^2.0.0
     tsd-lite: ^0.6.0
     v8-to-istanbul: ^9.0.1
   peerDependencies:
@@ -19536,16 +19535,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-hyperlinks@npm:^2.0.0":
-  version: 2.2.0
-  resolution: "supports-hyperlinks@npm:2.2.0"
-  dependencies:
-    has-flag: ^4.0.0
-    supports-color: ^7.0.0
-  checksum: aef04fb41f4a67f1bc128f7c3e88a81b6cf2794c800fccf137006efe5bafde281da3e42e72bf9206c2fcf42e6438f37e3a820a389214d0a88613ca1f2d36076a
-  languageName: node
-  linkType: hard
-
 "supports-preserve-symlinks-flag@npm:^1.0.0":
   version: 1.0.0
   resolution: "supports-preserve-symlinks-flag@npm:1.0.0"
@@ -19705,16 +19694,6 @@ __metadata:
     type-fest: ^0.16.0
     unique-string: ^2.0.0
   checksum: e77ca4440af18e42dc64d8903b7ed0be673455b76680ff94a7d7c6ee7c16f7604bdcdee3c39436342b1082c23eda010dbe48f6094e836e0bd53c8b1aa63e5b95
-  languageName: node
-  linkType: hard
-
-"terminal-link@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "terminal-link@npm:2.1.1"
-  dependencies:
-    ansi-escapes: ^4.2.1
-    supports-hyperlinks: ^2.0.0
-  checksum: ce3d2cd3a438c4a9453947aa664581519173ea40e77e2534d08c088ee6dda449eabdbe0a76d2a516b8b73c33262fedd10d5270ccf7576ae316e3db170ce6562f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts #8980

## Summary

There was a plan to revert the above mentioned PR already (see https://github.com/facebook/jest/pull/8980#issuecomment-564506127) and there was a PR trying to do so #9294. The reasons are well explained there

I would like to add that VS Code was added to `supports-hyperlinks` list [recently](https://github.com/jamestalmage/supports-hyperlinks/commit/45ff1a8e4601618bd074d2a8d30bfb13d792160c). Hence the issue will be visible for much more users now.

This change could look breaking and I could agree with that. In the other hand, this is mostly aesthetic change. Just to be sure, I was trying out few terminal apps (e.g. iTerm). Only the underlines get removed, but `cmd/ctrl + click` works as expected.

Also note that current implementation lacks consistency. Paths in the stack trace are not underlined, as well as paths with RUNS:

<img width="867" alt="Screenshot 2022-10-07 at 13 11 13" src="https://user-images.githubusercontent.com/72159681/194530199-65835eeb-2b31-49c1-9723-50f8b27af56b.png">

(This screenshot still looks alright. In realty readability is worse.)

## Test plan

Green CI.