### PR TITLE
Add matcher to compare array

### DIFF
--- a/website/versioned_docs/version-25.x/UsingMatchers.md
+++ b/website/versioned_docs/version-25.x/UsingMatchers.md
@@ -119,6 +119,7 @@ test('but there is a "stop" in Christoph', () => {
 
 ## Arrays and iterables
 
+To compare arrays , use `toEqual` instead of  `toBe`  
 You can check if an array or iterable contains a particular item using `toContain`:
 
 ```js
@@ -135,6 +136,7 @@ test('the shopping list has beer on it', () => {
   expect(new Set(shoppingList)).toContain('beer');
 });
 ```
+
 
 ## Exceptions
 


### PR DESCRIPTION
To compare array we have to use `toEqual` else it will throw an error `Serialize to same thing`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

For comparing array we must specify to use `toEqual` matcher to avoid error

## Test plan

![image](https://user-images.githubusercontent.com/77909827/194616557-3b933116-3dc6-4528-8ed5-a6f4b35189a9.png)
