### PR TITLE
fix(jest-environment-jsdom): add optional peer dependency on canvas

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -29,6 +29,14 @@
   "devDependencies": {
     "@jest/test-utils": "workspace:^"
   },
+  "peerDependencies": {
+    "canvas": "^2.5.0"
+  },
+  "peerDependenciesMeta": {
+    "canvas": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12421,6 +12421,11 @@ __metadata:
     jest-mock: "workspace:^"
     jest-util: "workspace:^"
     jsdom: ^20.0.0
+  peerDependencies:
+    canvas: ^2.5.0
+  peerDependenciesMeta:
+    canvas:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

`jsdom` [has an optional peer dependency on canvas](https://github.com/jsdom/jsdom/blob/master/package.json#L53-L60) in order to [provide canvas support](https://github.com/jsdom/jsdom#canvas-support). `jest-environment-jsdom` does not forward this peer dependency and so canvas support does not work when using strict package managers like Yarn PnP. This PR propagates that optional peer dependency to `jest-environment-jsdom` since [peer dependencies should be forwarded](https://dev.to/arcanis/implicit-transitive-peer-dependencies-ed0) in order for the child package to have access to the peer dependency.

## Test plan

N/A? I don't know how to easily write an automated test this, let me know if there's a way.