### PR TITLE
refactor(jest-snapshot): clean up argument typings of internal `printSnapshotAndReceived()` function

### DIFF
--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -235,7 +235,7 @@ export const printSnapshotAndReceived = (
   b: string, // received serialized but without extra line breaks
   received: unknown,
   expand: boolean, // CLI options: true if `--expand` or false if `--no-expand`
-  snapshotFormat: SnapshotFormat,
+  snapshotFormat?: SnapshotFormat,
 ): string => {
   const aAnnotation = 'Snapshot';
   const bAnnotation = 'Received';


### PR DESCRIPTION
## Summary

Looks like `snapshotFormat` argument of internal `printSnapshotAndReceived()` function can be marked as optional. All members of the `SnapshotFormat` type are optional. Also test are currently treating the argument as optional and they are passing. See https://github.com/facebook/jest/pull/13408#discussion_r990637927

## Test plan

Green CI.