### PR TITLE
feat(expect): expose `*ExpectationResult` types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[jest-config]` Add `readInitialConfig` utility function ([#13356](https://github.com/facebook/jest/pull/13356))
 - `[jest-core]` Enable testResultsProcessor to be async ([#13343](https://github.com/facebook/jest/pull/13343))
 - `[expect, @jest/expect-utils]` Allow `isA` utility to take a type argument ([#13355](https://github.com/facebook/jest/pull/13355))
+- `[expect]` Expose `AsyncExpectationResult` and `SyncExpectationResult` types ([#13411](https://github.com/facebook/jest/pull/13411))
 
 ### Fixes
 

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -53,6 +53,7 @@ import type {
 
 export {AsymmetricMatcher} from './asymmetricMatchers';
 export type {
+  AsyncExpectationResult,
   AsymmetricMatchers,
   BaseExpect,
   Expect,
@@ -63,6 +64,7 @@ export type {
   MatcherState,
   MatcherUtils,
   Matchers,
+  SyncExpectationResult,
 } from './types';
 
 export class JestAssertionError extends Error {


### PR DESCRIPTION
## Summary

It would be useful to expose `AsyncExpectationResult` and `SyncExpectationResult` types from `expect` package. See https://github.com/facebook/jest/pull/13408/files#r990637692

## Test plan

Green CI.
