### PR TITLE
Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@
 
 ### Fixes
 
+- `[jest-core]` Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`. ([#13414](https://github.com/facebook/jest/pull/13414))
 - `[babel-plugin-jest-hoist]` Ignore `TSTypeQuery` when checking for hoisted references ([#13367](https://github.com/facebook/jest/pull/13367))
 - `[jest-mock]` Fix mocking of getters and setters on classes ([#13398](https://github.com/facebook/jest/pull/13398))
 - `[jest-reporters]` Revert: Transform file paths into hyperlinks ([#13399](https://github.com/facebook/jest/pull/13399))
 - `[@jest/types]` Infer type of `each` table correctly when the table is a tuple or array ([#13381](https://github.com/facebook/jest/pull/13381))
 - `[@jest/types]` Rework typings to allow the `*ReturnedWith` matchers to be called with no argument ([#13385](https://github.com/facebook/jest/pull/13385))
-- `[jest-core]` Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`. ([#13414](https://github.com/facebook/jest/pull/13414))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-reporters]` Revert: Transform file paths into hyperlinks ([#13399](https://github.com/facebook/jest/pull/13399))
 - `[@jest/types]` Infer type of `each` table correctly when the table is a tuple or array ([#13381](https://github.com/facebook/jest/pull/13381))
 - `[@jest/types]` Rework typings to allow the `*ReturnedWith` matchers to be called with no argument ([#13385](https://github.com/facebook/jest/pull/13385))
+- `[jest-core]` Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`. ([#13414](https://github.com/facebook/jest/pull/13414))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Fixes
 
-- `[jest-core]` Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`. ([#13414](https://github.com/facebook/jest/pull/13414))
 - `[babel-plugin-jest-hoist]` Ignore `TSTypeQuery` when checking for hoisted references ([#13367](https://github.com/facebook/jest/pull/13367))
+- `[jest-core]` Fix `detectOpenHandles` false positives for some special objects such as `TLSWRAP`. ([#13414](https://github.com/facebook/jest/pull/13414))
 - `[jest-mock]` Fix mocking of getters and setters on classes ([#13398](https://github.com/facebook/jest/pull/13398))
 - `[jest-reporters]` Revert: Transform file paths into hyperlinks ([#13399](https://github.com/facebook/jest/pull/13399))
 - `[@jest/types]` Infer type of `each` table correctly when the table is a tuple or array ([#13381](https://github.com/facebook/jest/pull/13381))

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -10,6 +10,7 @@ import * as crypto from 'crypto';
 import {promises as dns} from 'dns';
 import http from 'http';
 import {PerformanceObserver} from 'perf_hooks';
+import {TLSSocket} from 'tls';
 import zlib from 'zlib';
 import collectHandles from '../collectHandles';
 
@@ -133,5 +134,16 @@ describe('collectHandles', () => {
     expect(openHandles).toContainEqual(
       expect.objectContaining({message: 'TCPSERVERWRAP'}),
     );
+  });
+
+  it('should collect handles for some special objects such as `TLSWRAP`', async () => {
+    const handleCollector = collectHandles();
+
+    const socket = new TLSSocket();
+    socket.destroy();
+
+    const openHandles = await handleCollector();
+
+    expect(openHandles).toHaveLength(0);
   });
 });

--- a/packages/jest-core/src/__tests__/collectHandles.test.js
+++ b/packages/jest-core/src/__tests__/collectHandles.test.js
@@ -136,7 +136,7 @@ describe('collectHandles', () => {
     );
   });
 
-  it('should collect handles for some special objects such as `TLSWRAP`', async () => {
+  it('should not be false positives for some special objects such as `TLSWRAP`', async () => {
     const handleCollector = collectHandles();
 
     const socket = new TLSSocket();

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -47,7 +47,7 @@ const hasWeakRef = typeof WeakRef === 'function';
 
 const asyncSleep = promisify(setTimeout);
 
-let gcFunc: Function | undefined = (globalThis as any).gc;
+let gcFunc: (() => void) | undefined = (globalThis as any).gc;
 function runGC() {
   if (!gcFunc) {
     v8.setFlagsFromString('--expose-gc');
@@ -145,7 +145,7 @@ export default function collectHandles(): HandleCollectionResult {
     // callback, we will not yet have seen the resource be destroyed here.
     await asyncSleep(100);
 
-    if (activeHandles.size !== 0) {
+    if (activeHandles.size > 0) {
       // For some special objects such as `TLSWRAP`.
       // Ref: https://github.com/facebook/jest/issues/11665
       runGC();

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -54,11 +54,9 @@ function runGC() {
     gcFunc = vm.runInNewContext('gc');
     v8.setFlagsFromString('--no-expose-gc');
     if (!gcFunc) {
-      console.warn(
-        'Cannot find `global.gc` function. Please run node with `--expose-gc`',
+      throw new Error(
+        'Cannot find `global.gc` function. Please run node with `--expose-gc` and report this issue in jest repo.',
       );
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      gcFunc = () => {};
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes: #11665 

Some objects need to be garbage collected before being destroyed, currently `detectOpenHandles` gives false positives for this case, let's do a garbage collection when needed.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

CI Green