### PR TITLE
docs: mention needing additional configuration for `ts-jest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2173,7 +2173,7 @@ We skipped 24.2.0 because a draft was accidentally published. Please use `24.3.0
 
 - `[jest-jasemine2]` Add dependency on jest-each ([#6308](https://github.com/facebook/jest/pull/6308))
 - `[jest-each]` Move jest-each into core Jest ([#6278](https://github.com/facebook/jest/pull/6278))
-- `[examples]` Update typescript example to using ts-jest ([#6260](https://github.com/facebook/jest/pull/6260))
+- `[examples]` Update typescript example to using `ts-jest` ([#6260](https://github.com/facebook/jest/pull/6260))
 
 ### Fixes
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -162,6 +162,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 #### Type definitions
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -162,7 +162,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 #### Type definitions
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -166,7 +166,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 yarn add --dev ts-jest
 ```
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 #### Type definitions
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -166,6 +166,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 yarn add --dev ts-jest
 ```
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -170,6 +170,8 @@ yarn add --dev ts-jest
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 :::note
 
 For `@types/*` modules it's recommended to try to match the version of the associated module. For example, if you are using `26.4.0` of `jest` then using `26.4.x` of `@types/jest` is ideal. In general, try to match the major (`26`) and minor (`4`) version as closely as possible.

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -170,7 +170,7 @@ yarn add --dev ts-jest
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 :::note
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -168,7 +168,7 @@ yarn add --dev ts-jest
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 :::note
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -168,6 +168,8 @@ yarn add --dev ts-jest
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 :::note
 
 For `@types/*` modules it's recommended to try to match the version of the associated module. For example, if you are using `26.4.0` of `jest` then using `26.4.x` of `@types/jest` is ideal. In general, try to match the major (`26`) and minor (`4`) version as closely as possible.

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -158,7 +158,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 #### Type definitions
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -158,6 +158,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 #### Type definitions
 
 You may also want to install the [`@types/jest`](https://www.npmjs.com/package/@types/jest) module for the version of Jest you're using. This will help provide full typing when writing your tests with TypeScript.

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -158,7 +158,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 #### Type definitions
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -158,6 +158,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 #### Type definitions
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -162,6 +162,8 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
+In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+
 #### Type definitions
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -162,7 +162,7 @@ However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transf
 npm install --save-dev ts-jest
 ```
 
-In order for Jest to transpile TypeScript with ts-jest, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
+In order for Jest to transpile TypeScript with `ts-jest`, you may also need to create a [configuration](https://kulshekhar.github.io/ts-jest/docs/getting-started/installation#jest-config-file) file.
 
 #### Type definitions
 


### PR DESCRIPTION
## Summary

I added a link to ts-jest docs configuration. Currently, if you try to run parse .ts files without a config file, you are brought to this page on the docs. There is only a link to the github repo for ts-jest. This small change will help save time and googling for users. We won't have to worry about keeping this up to date since it's just a link to their documentation page.

## Test plan

None, this is just a change to the docs.