### PR TITLE
Defer reading of transform source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Performance
 
+- `[jest-runtime]` Defer reading of source files, because it's out-of-date if the transform output is up-to-date [#13419](https://github.com/facebook/jest/pull/13419)
+
 ## 29.2.0
 
 ### Features

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1506,10 +1506,8 @@ export default class Runtime {
     filename: string,
     options?: InternalModuleOptions,
   ): string {
-    const source = this.readFile(filename);
-
     if (options?.isInternalModule) {
-      return source;
+      return this.readFile(filename);
     }
 
     let transformedFile: TransformResult | undefined =
@@ -1522,7 +1520,6 @@ export default class Runtime {
     transformedFile = this._scriptTransformer.transform(
       filename,
       this._getFullTransformationOptions(options),
-      source,
     );
 
     this._fileTransforms.set(filename, {


### PR DESCRIPTION
If test files are already compiled and in the FS cache, then their source doesn't need to be read for the purposes of transforming.

Note that they're probably still read elsewhere for hashing, but this reduces some potential unnecessary reads.

Signed-off-by: Mitchell Hentges <mhentges@spotify.com>

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Test plan

Within `_scriptTransformer.transform(...)`, it already has behaviour to populate `source` when it's not provided, so this should be solid.
The existing test suite should provide some confidence too.
