### PR TITLE
perf: use sha1 instead of sha256 for hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Performance
 
-- Use sha1 instead of sha256 for hashing [#13421](https://github.com/facebook/jest/pull/13421)
+- `[*]` Use sha1 instead of sha256 for hashing [#13421](https://github.com/facebook/jest/pull/13421)
 
 ## 29.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Performance
 
+- Use sha1 instead of sha256 for hashing [#13421](https://github.com/facebook/jest/pull/13421)
+
 ## 29.2.0
 
 ### Features

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -78,7 +78,7 @@ function getCacheKeyFromConfig(
 
   const configPath = [babelOptions.config ?? '', babelOptions.babelrc ?? ''];
 
-  return createHash('sha256')
+  return createHash('sha1')
     .update(THIS_FILE)
     .update('\0', 'utf8')
     .update(JSON.stringify(babelOptions.options))

--- a/packages/jest-circus/src/__mocks__/testUtils.ts
+++ b/packages/jest-circus/src/__mocks__/testUtils.ts
@@ -31,7 +31,7 @@ interface Result extends ExecaSyncReturnValue {
 }
 
 export const runTest = (source: string) => {
-  const filename = createHash('sha256')
+  const filename = createHash('sha1')
     .update(source)
     .digest('hex')
     .substring(0, 32);

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -72,7 +72,7 @@ afterEach(() => {
 
 it('picks an id based on the rootDir', async () => {
   const rootDir = '/root/path/foo';
-  const expected = createHash('sha256')
+  const expected = createHash('sha1')
     .update('/root/path/foo')
     .update(String(Infinity))
     .digest('hex')

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -301,7 +301,7 @@ const normalizeMissingOptions = (
   projectIndex: number,
 ): Config.InitialOptionsWithRootDir => {
   if (!options.id) {
-    options.id = createHash('sha256')
+    options.id = createHash('sha1')
       .update(options.rootDir)
       // In case we load config from some path that has the same root dir
       .update(configPath || '')

--- a/packages/jest-create-cache-key-function/src/index.ts
+++ b/packages/jest-create-cache-key-function/src/index.ts
@@ -49,7 +49,7 @@ function getGlobalCacheKey(files: Array<string>, values: Array<string>) {
   ]
     .reduce(
       (hash, chunk) => hash.update('\0', 'utf8').update(chunk || ''),
-      createHash('sha256'),
+      createHash('sha1'),
     )
     .digest('hex')
     .substring(0, 32);
@@ -62,7 +62,7 @@ function getCacheKeyFunction(globalCacheKey: string): GetCacheKeyFunction {
     const inferredOptions = options || configString;
     const {config, instrument} = inferredOptions;
 
-    return createHash('sha256')
+    return createHash('sha1')
       .update(globalCacheKey)
       .update('\0', 'utf8')
       .update(sourceText)

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -295,7 +295,7 @@ class HasteMap extends EventEmitter implements IHasteMap {
   }
 
   private async setupCachePath(options: Options): Promise<void> {
-    const rootDirHash = createHash('sha256')
+    const rootDirHash = createHash('sha1')
       .update(options.rootDir)
       .digest('hex')
       .substring(0, 32);
@@ -344,7 +344,7 @@ class HasteMap extends EventEmitter implements IHasteMap {
     id: string,
     ...extra: Array<string>
   ): string {
-    const hash = createHash('sha256').update(extra.join(''));
+    const hash = createHash('sha1').update(extra.join(''));
     return path.join(
       tmpdir,
       `${id.replace(/\W/g, '-')}-${hash.digest('hex').substring(0, 32)}`,

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -117,14 +117,14 @@ class ScriptTransformer {
     transformerCacheKey: string | undefined,
   ): string {
     if (transformerCacheKey != null) {
-      return createHash('sha256')
+      return createHash('sha1')
         .update(transformerCacheKey)
         .update(CACHE_VERSION)
         .digest('hex')
         .substring(0, 32);
     }
 
-    return createHash('sha256')
+    return createHash('sha1')
       .update(fileData)
       .update(transformOptions.configString)
       .update(transformOptions.instrument ? 'instrument' : '')
@@ -882,7 +882,7 @@ const stripShebang = (content: string) => {
  * could get corrupted, out-of-sync, etc.
  */
 function writeCodeCacheFile(cachePath: string, code: string) {
-  const checksum = createHash('sha256')
+  const checksum = createHash('sha1')
     .update(code)
     .digest('hex')
     .substring(0, 32);
@@ -901,7 +901,7 @@ function readCodeCacheFile(cachePath: string): string | null {
     return null;
   }
   const code = content.substring(33);
-  const checksum = createHash('sha256')
+  const checksum = createHash('sha1')
     .update(code)
     .digest('hex')
     .substring(0, 32);


### PR DESCRIPTION
This should be more performant while still being FIPS compliant (see #12722).

sha1 isn't as secure as sha256, but since the usage context is just "has this file changed? 🤔", this should be an acceptable degredation.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
