### PR TITLE
fix(circus): don't print beforeAll/afterAll errors for skipped tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-circus]` Don't print `beforeAll` / `afterAll` errors for skipped tests ([#13423](https://github.com/facebook/jest/pull/13423))
 - `[@jest/cli, jest-config]` A seed for the test run will be randomly generated, or set by a CLI option ([#13400](https://github.com/facebook/jest/pull/13400))
 - `[@jest/cli, jest-config]` `--show-seed` will display the seed value in the report, and can be set via a CLI flag or through the config file ([#13400](https://github.com/facebook/jest/pull/13400))
 - `[jest-config]` Add `readInitialConfig` utility function ([#13356](https://github.com/facebook/jest/pull/13356))

--- a/e2e/__tests__/beforeAllFailing.test.ts
+++ b/e2e/__tests__/beforeAllFailing.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {isJestJasmineRun} from '@jest/test-utils';
+import runJest from '../runJest';
+
+it('beforeAll failures are not reported for skipped tests', () => {
+  if (isJestJasmineRun()) return;
+  const {stderr} = runJest('before-all-failing');
+  const failures = [...stderr.matchAll(/● .+?$/gm)].map(m => m[0].slice(2));
+  expect(failures).toEqual(['foo', 'nested › foo']);
+});

--- a/e2e/before-all-failing/__tests__/beforeAllFailing.test.js
+++ b/e2e/before-all-failing/__tests__/beforeAllFailing.test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+beforeAll(() => {
+  throw new Error('Fail');
+});
+
+it('foo', () => {
+  console.log('It Foo');
+});
+
+it.skip('foo 2', () => {
+  console.log('It Foo 2');
+});
+
+it('bar', () => {
+  console.log('It Bar');
+});
+
+describe('nested', () => {
+  it('foo', () => {
+    console.log('It Foo');
+  });
+
+  it.skip('foo 2', () => {
+    console.log('It Foo 2');
+  });
+
+  it('bar', () => {
+    console.log('It Bar');
+  });
+});

--- a/e2e/before-all-failing/package.json
+++ b/e2e/before-all-failing/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testNamePattern": "foo"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When a `beforeAll` / `afterAll` hook fails (throws), the error gets attached to every test, even if the test was going to be skipped (due to `it.skip`, `testNamePattern` etc). This can create a lot of noise in the output, particularly when working with a single test case in isolation. With this change we only attach the error to those tests that would have actually run had the hook not errored.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I added an integration test that verifies `jest` output. 

Before (error printed for all 6 tests, including 4 that were skipped):
```
 FAIL  __tests__/beforeAllFailing.test.js
  ✕ foo (1 ms)
  ○ skipped foo 2
  ○ skipped bar
  nested
    ✕ foo
    ○ skipped foo 2
    ○ skipped bar

  ● foo

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● foo 2

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● bar

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● nested › foo

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● nested › foo 2

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● nested › bar

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 4 skipped, 6 total
Snapshots:   0 total
Time:        0.137 s, estimated 1 s
Ran all test suites with tests matching "foo".
```

After (error printed only for the 2 non-skipped tests):
```
 FAIL  __tests__/beforeAllFailing.test.js
  ✕ foo
  ○ skipped foo 2
  ○ skipped bar
  nested
    ✕ foo
    ○ skipped foo 2
    ○ skipped bar

  ● foo

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

  ● nested › foo

    Fail

       7 |
       8 | beforeAll(() => {
    >  9 |   throw new Error('Fail');
         |         ^
      10 | });
      11 |
      12 | it('foo', () => {

      at Object.<anonymous> (__tests__/beforeAllFailing.test.js:9:9)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 4 skipped, 6 total
Snapshots:   0 total
Time:        0.131 s, estimated 1 s
Ran all test suites with tests matching "foo".
```