### PR TITLE
chore: use `jest/unbound-method` rule in `lintTs` script

### DIFF
--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -64,6 +64,16 @@ try {
             extends: [
               'plugin:@typescript-eslint/recommended-requiring-type-checking',
             ],
+            overrides: [
+              {
+                files: ['**/__tests__/**'],
+                plugins: ['jest'],
+                rules: {
+                  '@typescript-eslint/unbound-method': 'off',
+                  'jest/unbound-method': 'error',
+                },
+              },
+            ],
             parser: '@typescript-eslint/parser',
             parserOptions: {
               project: ['./tsconfig.json', `${packageDir}/tsconfig.json`],


### PR DESCRIPTION
## Summary

Adding [`jest/unbound-method` rule](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md) to `lintTs` script helps to "fix" around 50 lint errors only in test files of `jest-worker`. There are many other errors still left, of course. Tried it out locally.

## Test plan

Green CI.