### PR TITLE
chore(ci): run tests with `--detectLeaks` in separate job

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -112,6 +112,25 @@ jobs:
     with:
       os: windows-latest
 
+  test-leak:
+    name: Node LTS on Ubuntu with coverage (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: prepare-yarn-cache-ubuntu
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: install
+        run: yarn --immutable
+      - name: build
+        run: yarn build:js
+      - name: run tests with leak detection
+        run: yarn test-leak
+
   test-coverage:
     name: Node LTS on Ubuntu with coverage (${{ matrix.shard }})
     strategy:
@@ -136,9 +155,7 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1
       - name: run tests with coverage
-        run: |
-          yarn jest-coverage --color --config jest.config.ci.mjs --max-workers ${{ steps.cpu-cores.outputs.count }} --shard=${{ matrix.shard }}
-          yarn test-leak
+        run: yarn jest-coverage --color --config jest.config.ci.mjs --max-workers ${{ steps.cpu-cores.outputs.count }} --shard=${{ matrix.shard }}
       - name: map coverage
         run: node ./scripts/mapCoverage.mjs
         if: always()

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -113,7 +113,7 @@ jobs:
       os: windows-latest
 
   test-leak:
-    name: Node LTS on Ubuntu with coverage (${{ matrix.shard }})
+    name: Node LTS on Ubuntu with leak detection
     runs-on: ubuntu-latest
     needs: prepare-yarn-cache-ubuntu
 

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -155,7 +155,7 @@ const supportsNodeColonModulePrefixInRequire = (() => {
 export default class Runtime {
   private readonly _cacheFS: Map<string, string>;
   private readonly _config: Config.ProjectConfig;
-  private _globalConfig?: Config.GlobalConfig | null;
+  private readonly _globalConfig?: Config.GlobalConfig;
   private readonly _coverageOptions: ShouldInstrumentOptions;
   private _currentlyExecutingModulePath: string;
   private readonly _environment: JestEnvironment;
@@ -1265,7 +1265,6 @@ export default class Runtime {
     this.resetAllMocks();
     this.resetModules();
 
-    this._globalConfig = null;
     this._internalModuleRegistry.clear();
     this._mainModule = null;
     this._mockFactories.clear();

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -155,7 +155,7 @@ const supportsNodeColonModulePrefixInRequire = (() => {
 export default class Runtime {
   private readonly _cacheFS: Map<string, string>;
   private readonly _config: Config.ProjectConfig;
-  private readonly _globalConfig?: Config.GlobalConfig;
+  private _globalConfig?: Config.GlobalConfig | null;
   private readonly _coverageOptions: ShouldInstrumentOptions;
   private _currentlyExecutingModulePath: string;
   private readonly _environment: JestEnvironment;
@@ -1265,6 +1265,7 @@ export default class Runtime {
     this.resetAllMocks();
     this.resetModules();
 
+    this._globalConfig = null;
     this._internalModuleRegistry.clear();
     this._mainModule = null;
     this._mockFactories.clear();


### PR DESCRIPTION
## Summary

I was trying to figure out why test run with coverage started failing recently on CI.

Apparently the failure comes not from coverage collection, but from test run with leak detection! Not sure how that works, but perhaps it makes sense to move the `test-leak` run to a separate job in CI? This give better readability.

## Test plan

Let’s see what CI thinks.