### PR TITLE
refactor(jest-validate): rework typings of `validateCLIOptions` function

### DIFF
--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -63,14 +63,13 @@ const logDeprecatedOptions = (
 
 export default function validateCLIOptions(
   argv: Config.Argv,
-  options: {
-    deprecationEntries: DeprecatedOptions;
-    [s: string]: Options;
-  },
+  options: Record<string, Options> & {
+    deprecationEntries?: DeprecatedOptions;
+  } = {},
   rawArgv: Array<string> = [],
 ): boolean {
   const yargsSpecialOptions = ['$0', '_', 'help', 'h'];
-  const deprecationEntries = options.deprecationEntries || {};
+  const deprecationEntries = options.deprecationEntries ?? {};
   const allowedOptions = Object.keys(options).reduce(
     (acc, option) =>
       acc.add(option).add((options[option].alias as string) || option),


### PR DESCRIPTION
## Summary

Found this while working of typechecks of `jest-validate` tests files. I think `options` argument of `validateCLIOptions` function can become optional through a default value, because all member of `options` object are optional.

## Test plan

Green CI.