### PR TITLE
chore: run type lint on `jest-watcher`

### DIFF
--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -72,7 +72,7 @@ export default class Prompt {
     switch (key) {
       case KEYS.ENTER:
         this._entering = false;
-        this._onSuccess(this._selection || this._value);
+        this._onSuccess(this._selection ?? this._value);
         this.abort();
         break;
       case KEYS.ESCAPE:

--- a/packages/jest-watcher/src/lib/formatTestNameByPattern.ts
+++ b/packages/jest-watcher/src/lib/formatTestNameByPattern.ts
@@ -32,7 +32,7 @@ export default function formatTestNameByPattern(
     return chalk.dim(inlineTestName);
   }
 
-  const startPatternIndex = Math.max(match.index || 0, 0);
+  const startPatternIndex = Math.max(match.index ?? 0, 0);
   const endPatternIndex = startPatternIndex + match[0].length;
 
   if (inlineTestName.length <= width) {

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -38,6 +38,7 @@ const packagesToTest = [
   'jest-test-result',
   'jest-test-sequencer',
   'jest-transform',
+  'jest-watcher',
   'jest-types',
   'test-globals',
   'test-utils',

--- a/scripts/lintTs.mjs
+++ b/scripts/lintTs.mjs
@@ -38,8 +38,8 @@ const packagesToTest = [
   'jest-test-result',
   'jest-test-sequencer',
   'jest-transform',
-  'jest-watcher',
   'jest-types',
+  'jest-watcher',
   'test-globals',
   'test-utils',
 ];


### PR DESCRIPTION
## Summary

Fixed a coupe of errors and added `jest-watcher` to the type lint list.

## Test plan

Green CI.