### PR TITLE
fix(jest-environment-node): make `performance` writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[jest-environment-node]` make `globalThis.performance` writable for Node 19 and fake timers ([#13467](https://github.com/facebook/jest/pull/13467))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1082,6 +1082,10 @@ describe('preset', () => {
       jest.requireActual('./jest-preset.json'),
     );
 
+    const errorMessage = semver.satisfies(process.versions.node, '<19.0.0')
+      ? /Unexpected token } in JSON at position (104|110)[\s\S]* at /
+      : 'SyntaxError: Expected double-quoted property name in JSON at position 104';
+
     await expect(
       normalize(
         {
@@ -1090,9 +1094,7 @@ describe('preset', () => {
         },
         {} as Config.Argv,
       ),
-    ).rejects.toThrow(
-      /Unexpected token } in JSON at position (104|110)[\s\S]* at /,
-    );
+    ).rejects.toThrow(errorMessage);
   });
 
   test('throws when preset evaluation throws type error', async () => {
@@ -1105,9 +1107,9 @@ describe('preset', () => {
       {virtual: true},
     );
 
-    const errorMessage = semver.satisfies(process.versions.node, '>=16.9.1')
-      ? "TypeError: Cannot read properties of undefined (reading 'call')"
-      : /TypeError: Cannot read property 'call' of undefined[\s\S]* at /;
+    const errorMessage = semver.satisfies(process.versions.node, '<16.9.1')
+      ? /TypeError: Cannot read property 'call' of undefined[\s\S]* at /
+      : "TypeError: Cannot read properties of undefined (reading 'call')";
 
     await expect(
       normalize(

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -90,7 +90,10 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
               configurable: descriptor.configurable,
               enumerable: descriptor.enumerable,
               value: val,
-              writable: descriptor.writable,
+              writable:
+                descriptor.writable === true ||
+                // Node 19 makes performance non-readable. This is probably not the correct solution.
+                nodeGlobalsKey === 'performance',
             });
             return val;
           },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Ref https://github.com/nodejs/node/pull/44626#issuecomment-1282191258

---

Note that there is a single failing test still: `Runtime requireModule › resolves platform extensions based on the default platform`

<img width="736" alt="image" src="https://user-images.githubusercontent.com/1404810/196429850-6b407d7e-6191-4f85-b13c-b886d94cec64.png">

It's some weird `haste` thing - we should probably throw `haste` in a bin at some point 😅 There are cleaner ways of achieving custom resolution than polluting config with weird `haste` options.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan 

Running with nightly locally.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
