### PR TITLE
feat(expect, @jest/expect): support type inference for `toBe` assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[expect, @jest/expect]` support type inference for `toBe` assertions ([#xxxxx](https://github.com/facebook/jest/pull/xxxxx))
+- `[expect, @jest/expect]` support type inference for `toBe` assertions ([#13470](https://github.com/facebook/jest/pull/13470))
 - `[@jest/globals, jest-mock]` Add `jest.Spied*` utility types ([#13440](https://github.com/facebook/jest/pull/13440))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[expect, @jest/expect]` support type inference for `toBe` assertions ([#xxxxx](https://github.com/facebook/jest/pull/xxxxx))
 - `[@jest/globals, jest-mock]` Add `jest.Spied*` utility types ([#13440](https://github.com/facebook/jest/pull/13440))
 
 ### Fixes

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -94,9 +94,9 @@ export interface BaseExpect {
 }
 
 export type Expect = {
-  <T = unknown>(actual: T): Matchers<void> &
-    Inverse<Matchers<void>> &
-    PromiseMatchers;
+  <T = unknown>(actual: T): Matchers<void, T> &
+    Inverse<Matchers<void, T>> &
+    PromiseMatchers<T>;
 } & BaseExpect &
   AsymmetricMatchers &
   Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
@@ -118,20 +118,20 @@ export interface AsymmetricMatchers {
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }
 
-type PromiseMatchers = {
+type PromiseMatchers<T = unknown> = {
   /**
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-export interface Matchers<R extends void | Promise<void>> {
+export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensures the last call to a mock function was provided specific args.
    */
@@ -152,7 +152,7 @@ export interface Matchers<R extends void | Promise<void>> {
    * Checks that a value is what you expect. It calls `Object.is` to compare values.
    * Don't use `toBe` with floating-point numbers.
    */
-  toBe(expected: unknown): R;
+  toBe(expected: T): R;
   /**
    * Ensures that a mock function is called.
    */

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -95,7 +95,7 @@ export interface BaseExpect {
 
 export type Expect = {
   <T = unknown>(actual: T): Matchers<void, T> &
-    Inverse<Matchers<void, T>> &
+    Inverse<Matchers<void>> &
     PromiseMatchers<T>;
 } & BaseExpect &
   AsymmetricMatchers &
@@ -129,7 +129,7 @@ type PromiseMatchers<T = unknown> = {
    * If the promise is rejected the assertion fails.
    */
   resolves: Matchers<Promise<void>, Awaited<T>> &
-    Inverse<Matchers<Promise<void>, Awaited<T>>>;
+    Inverse<Matchers<Promise<void>>>;
 };
 
 export interface Matchers<R extends void | Promise<void>, T = unknown> {

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -123,12 +123,13 @@ type PromiseMatchers<T = unknown> = {
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
+  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>, T>>;
+  resolves: Matchers<Promise<void>, Awaited<T>> &
+    Inverse<Matchers<Promise<void>, Awaited<T>>>;
 };
 
 export interface Matchers<R extends void | Promise<void>, T = unknown> {

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -29,7 +29,7 @@ type Inverse<Matchers> = {
   not: Matchers;
 };
 
-type JestMatchers<R extends void | Promise<void>, T> = Matchers<R> &
+type JestMatchers<R extends void | Promise<void>, T> = Matchers<R, T> &
   SnapshotMatchers<R, T>;
 
 type PromiseMatchers<T = unknown> = {

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -29,7 +29,10 @@ type Inverse<Matchers> = {
   not: Matchers;
 };
 
-type JestMatchers<R extends void | Promise<void>, T> = Matchers<R, T> &
+type JestMatchers<R extends void | Promise<void>, T = unknown> = Matchers<
+  R,
+  T
+> &
   SnapshotMatchers<R, T>;
 
 type PromiseMatchers<T = unknown> = {
@@ -37,14 +40,13 @@ type PromiseMatchers<T = unknown> = {
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: JestMatchers<Promise<void>, T> &
-    Inverse<JestMatchers<Promise<void>, T>>;
+  rejects: JestMatchers<Promise<void>> & Inverse<JestMatchers<Promise<void>>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: JestMatchers<Promise<void>, T> &
-    Inverse<JestMatchers<Promise<void>, T>>;
+  resolves: JestMatchers<Promise<void>, Awaited<T>> &
+    Inverse<JestMatchers<Promise<void>, Awaited<T>>>;
 };
 
 declare module 'expect' {

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -46,7 +46,7 @@ type PromiseMatchers<T = unknown> = {
    * If the promise is rejected the assertion fails.
    */
   resolves: JestMatchers<Promise<void>, Awaited<T>> &
-    Inverse<JestMatchers<Promise<void>, Awaited<T>>>;
+    Inverse<JestMatchers<Promise<void>>>;
 };
 
 declare module 'expect' {

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -478,7 +478,6 @@ declare module 'expect' {
   interface AsymmetricMatchers {
     toBeWithinRange(floor: number, ceiling: number): void;
   }
-
   interface Matchers<R> {
     toBeWithinRange(floor: number, ceiling: number): R;
   }

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -221,8 +221,10 @@ expectType<void>(
   ),
 );
 
-expectType<void>(expect(3).toBe(5));
-expectError(expect(3).toBe('5'));
+expectType<void>(
+  expect({name: 'someName', age: 12}).toBe({name: 'someOtherName', age: 13}),
+);
+expectError(expect({name: 'someName', age: 12}).toBe({name: 'someOtherName'}));
 
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith());
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
@@ -476,6 +478,7 @@ declare module 'expect' {
   interface AsymmetricMatchers {
     toBeWithinRange(floor: number, ceiling: number): void;
   }
+
   interface Matchers<R> {
     toBeWithinRange(floor: number, ceiling: number): R;
   }

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -221,6 +221,9 @@ expectType<void>(
   ),
 );
 
+expectType<void>(expect(3).toBe(5));
+expectError(expect(3).toBe('5'));
+
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith());
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123, 'value'));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -222,9 +222,9 @@ expectType<void>(
 );
 
 expectType<void>(
-  expect({name: 'someName', age: 12}).toBe({name: 'someOtherName', age: 13}),
+  expect({age: 12, name: 'someName'}).toBe({age: 13, name: 'someOtherName'}),
 );
-expectError(expect({name: 'someName', age: 12}).toBe({name: 'someOtherName'}));
+expectError(expect({age: 12, name: 'someName'}).toBe({name: 'someOtherName'}));
 
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith());
 expectType<void>(expect(jest.fn()).toHaveBeenCalledWith(123));


### PR DESCRIPTION
## Summary
relates to https://github.com/facebook/jest/issues/13334
This is a continuation of https://github.com/facebook/jest/pull/13268, which was merged and reverted in https://github.com/facebook/jest/pull/13339. It adds only one use case that should be safe.
It should improve developer experience by adding type inference for the types passed to the `toBe` assertion

## Test plan
added automated tests

What do you guys think? @SimenB @mrazauskas 