### PR TITLE
feat: add taskTimeout option to allow non-responsive worker processes to be stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-cli, jest-config, jest-core, jest-reporters, jest-runner, jest-types, jest-worker]` Add taskTimeout option to allow non-responsive worker processes to be stopped ([#13473](https://github.com/facebook/jest/pull/13473))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -404,6 +404,10 @@ Can also be set in configuration. See [`showSeed`](Configuration.md#showseed-boo
 
 Prevent tests from printing messages through the console.
 
+### `--taskTimeout=<number>`
+
+Timeout for each test file in milliseconds before worker process is killed and restarted. Default value: undefined. Only supported for child_process workers. Unlike other timeouts, this will stop tests even if the event loop is blocked. Not compatible with runInBand.
+
 ### `--testEnvironmentOptions=<json string>`
 
 A JSON string with options that will be passed to the `testEnvironment`. The relevant options depend on the environment.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1770,6 +1770,12 @@ More about serializers API can be found [here](https://github.com/facebook/jest/
 
 :::
 
+### `taskTimeout` \[number | undefined]
+
+Default: `undefined`
+
+Timeout for each test file in milliseconds before worker process is killed and restarted. Default value: unlimited. Only supported for child_process workers. Unlike other timeouts, this will stop tests even if the event loop is blocked. Not compatible with runInBand.
+
 ### `testEnvironment` \[string]
 
 Default: `"node"`

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -26,6 +26,23 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
+exports[`exceeds the command line taskTimeout with infinite loop 1`] = `
+"FAIL __tests__/a-banana.js
+  ● Test suite failed to run
+
+    running task on worker exceeded timeout and worker had to be killed
+
+      at ../../packages/jest-worker/build/Farm.js:71:19"
+`;
+
+exports[`exceeds the command line taskTimeout with infinite loop 2`] = `
+"Test Suites: 1 failed, 1 total
+Tests:       0 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
 exports[`exceeds the command line testTimeout 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
@@ -37,6 +54,19 @@ Ran all test suites."
 exports[`exceeds the timeout 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`finishes before the command line taskTimeout 1`] = `
+"PASS __tests__/a-banana.js
+  ✓ banana"
+`;
+
+exports[`finishes before the command line taskTimeout 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites."

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -107,3 +107,48 @@ test('does not exceed the command line testTimeout', () => {
   expect(summary).toMatchSnapshot();
   expect(exitCode).toBe(0);
 });
+
+test('exceeds the command line taskTimeout with infinite loop', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+
+      test('banana', () => {
+        while (true) {}
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '--taskTimeout=1000',
+  ]);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+  expect(exitCode).toBe(1);
+});
+
+test('finishes before the command line taskTimeout', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+
+      test('banana', () => {
+        let start = Date.now();
+        while (200 < (Date.now() - start)) {}
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '--taskTimeout=1000',
+  ]);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+  expect(exitCode).toBe(0);
+});

--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -568,6 +568,11 @@ export const options: {[key: string]: Options} = {
     string: true,
     type: 'array',
   },
+  taskTimeout: {
+    description:
+      'Timeout for each test file in milliseconds before worker process is killed and restarted. Default value: undefined. Only supported for child_process workers. Unlike other timeouts, this will stop tests even if the event loop is blocked.',
+    type: 'number',
+  },
   testEnvironment: {
     description: 'Alias for --env',
     type: 'string',

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -145,6 +145,7 @@ const initialOptions: Config.InitialOptions = {
   snapshotFormat: PRETTY_FORMAT_DEFAULTS,
   snapshotResolver: '<rootDir>/snapshotResolver.js',
   snapshotSerializers: ['my-serializer-module'],
+  taskTimeout: 50000,
   testEnvironment: 'jest-environment-node',
   testEnvironmentOptions: {
     url: 'http://localhost',

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -121,6 +121,7 @@ const groupOptions = (
     silent: options.silent,
     skipFilter: options.skipFilter,
     snapshotFormat: options.snapshotFormat,
+    taskTimeout: options.taskTimeout,
     testFailureExitCode: options.testFailureExitCode,
     testNamePattern: options.testNamePattern,
     testPathPattern: options.testPathPattern,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -863,10 +863,11 @@ export default async function normalize(
         }
         break;
       }
+      case 'taskTimeout':
       case 'testTimeout': {
         if (oldOptions[key] < 0) {
           throw createConfigError(
-            `  Option "${chalk.bold('testTimeout')}" must be a natural number.`,
+            `  Option "${chalk.bold(key)}" must be a natural number.`,
           );
         }
 

--- a/packages/jest-core/src/testSchedulerHelper.ts
+++ b/packages/jest-core/src/testSchedulerHelper.ts
@@ -13,11 +13,22 @@ const SLOW_TEST_TIME = 1000;
 export function shouldRunInBand(
   tests: Array<Test>,
   timings: Array<number>,
-  {detectOpenHandles, maxWorkers, watch, watchAll}: Config.GlobalConfig,
+  {
+    detectOpenHandles,
+    maxWorkers,
+    watch,
+    watchAll,
+    taskTimeout,
+  }: Config.GlobalConfig,
 ): boolean {
   // detectOpenHandles makes no sense without runInBand, because it cannot detect leaks in workers
   if (detectOpenHandles) {
     return true;
+  }
+
+  // taskTimeout cannot be enforced if tests are run in the same process
+  if (taskTimeout) {
+    return false;
   }
 
   /*

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -151,6 +151,7 @@ export default class CoverageReporter extends BaseReporter {
         forkOptions: {serialization: 'json'},
         maxRetries: 2,
         numWorkers: this._globalConfig.maxWorkers,
+        taskTimeout: this._globalConfig.taskTimeout,
       }) as JestWorkerFarm<CoverageWorker>;
     }
 

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -116,6 +116,7 @@ export default class TestRunner extends EmittingTestRunner {
       maxRetries: 3,
       numWorkers: this._globalConfig.maxWorkers,
       setupArgs: [{serializableResolvers: Array.from(resolvers.values())}],
+      taskTimeout: this._globalConfig.taskTimeout,
     }) as JestWorkerFarm<TestWorker>;
 
     if (worker.getStdout()) worker.getStdout().pipe(process.stdout);

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -300,6 +300,7 @@ export type InitialOptions = Partial<{
   snapshotSerializers: Array<string>;
   snapshotFormat: SnapshotFormat;
   errorOnDeprecated: boolean;
+  taskTimeout?: number;
   testEnvironment: string;
   testEnvironmentOptions: Record<string, unknown>;
   testFailureExitCode: string | number;
@@ -402,6 +403,7 @@ export type GlobalConfig = {
   skipFilter: boolean;
   snapshotFormat: SnapshotFormat;
   errorOnDeprecated: boolean;
+  taskTimeout?: number;
   testFailureExitCode: number;
   testNamePattern?: string;
   testPathPattern: string;

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -118,6 +118,7 @@ export class Worker {
       {
         computeWorkerKey: this._options.computeWorkerKey,
         taskQueue: this._options.taskQueue,
+        taskTimeout: this._options.taskTimeout,
         workerSchedulingPolicy: this._options.workerSchedulingPolicy,
       },
     );

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -76,6 +76,7 @@ export interface WorkerInterface {
 
   waitForExit(): Promise<void>;
   forceExit(): void;
+  forceExitAndRestart?(): Promise<void>;
 
   getWorkerId(): number;
   getStderr(): NodeJS.ReadableStream | null;
@@ -144,6 +145,7 @@ export type WorkerFarmOptions = {
   ) => WorkerPoolInterface;
   workerSchedulingPolicy?: WorkerSchedulingPolicy;
   idleMemoryLimit?: number;
+  taskTimeout?: number;
 };
 
 export type WorkerPoolOptions = {

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -432,6 +432,15 @@ export default class ChildProcessWorker
     this._exitPromise.then(() => clearTimeout(sigkillTimeout));
   }
 
+  forceExitAndRestart(): Promise<void> {
+    this.forceExit();
+
+    return this.waitForExit().then(() => {
+      this.state = WorkerStates.STARTING;
+      this.initialize();
+    });
+  }
+
   getWorkerId(): number {
     return this._options.workerId;
   }

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.ts
@@ -665,3 +665,18 @@ it('should check for memory limits and restart if above absolute limit', async (
   expect(totalmem).not.toHaveBeenCalled();
   expect(forkInterface.kill).toHaveBeenCalledTimes(1);
 });
+
+it('should force exit and restart the child process if forceExitAndRestart is called', async () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo',
+  });
+
+  const exitResult = worker.forceExitAndRestart();
+  expect(forkInterface.kill.mock.calls).toEqual([['SIGTERM']]);
+  expect(childProcess.fork).toHaveBeenCalledTimes(1);
+  forkInterface.emit('exit', 0);
+  await exitResult;
+  expect(childProcess.fork).toHaveBeenCalledTimes(2);
+});


### PR DESCRIPTION
## Summary

This adds a new option, taskTimeout, to address https://github.com/facebook/jest/issues/6947

Existing timeout options can only be enforced when a test yields to the event loop, so a test with a synchronous infinite loop will run forever and never be killed. This became particularly problematic for me when upgrading a large project to React v18 triggered infinite loops in about 100 out of several thousand test files, since it is difficult to identify which specific test files are causing problems.

To address this, a new timeout is added that is applied to each task that is farmed out to a worker process. If the task takes longer than the timeout, the worker is killed and a new one restarted to replace it.

Limitations: this approach will only work when tests are run in a separate child process, so it will not work with the runInBand or with the worker_threads options, but I believe that the value of the feature is high despite these limitations.

## Test plan

A new e2e test case demonstrates that the feature works and fails an infinitely looping test case with the error 

```
FAIL __tests__/a-banana.js
  ● Test suite failed to run
    running task on worker exceeded timeout and worker had to be killed
      at ../../packages/jest-worker/build/Farm.js:71:19
```

I also used this to run the tests in the project where I was encountering this problem. Instead of hanging once each worker hit a test with an infinite loop, it instead ran through all of the tests in the project and correctly identified the tests with infinite loops as failing.