### PR TITLE
Fix: issue #13492 - [Bug]: Checking for invalid date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 ### Fixes
-
+- `[@expect-utils]` Checking for invalid date [(#13492](https://github.com/facebook/jest/issues/13492))
 - `[@jest/test-sequencer]` Make sure sharding does not produce empty groups ([#13476](https://github.com/facebook/jest/pull/13476))
 
 ### Chore & Maintenance

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -115,7 +115,7 @@ function eq(
       // Coerce dates to numeric primitive values. Dates are compared by their
       // millisecond representations. Note that invalid dates with millisecond representations
       // of `NaN` are not equivalent.
-      return +a == +b;
+      return decodeURI(a) == decodeURI(b);
     // RegExps are compared by their source patterns and flags.
     case '[object RegExp]':
       return a.source === b.source && a.flags === b.flags;

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2956,6 +2956,13 @@ Expected: not <g>1</>
 
 `;
 
+exports[`.toEqual() {pass: true} expect(Date { NaN }).not.toEqual(Date { NaN }) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>Date { NaN }</>
+
+`;
+
 exports[`.toEqual() {pass: true} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2]) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -708,6 +708,7 @@ describe('.toEqual()', () => {
     [true, true],
     [1, 1],
     [NaN, NaN],
+    [new Date(NaN), new Date(NaN)],
     [0, Number(0)],
     [Number(0), 0],
     [new Number(0), new Number(0)],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
`(+a == +b) in file /expect-utils->jasmineUtils.ts`
There is a comparison of non-numeric values, converted to numbers.
I removed that comparison and instead did a conversion of (dates with millisecond representations), even though they are NaN, they are converted to string and used for comparisons.
Done that solves issue #13492 by using expect to compare `new Date(NaN) === new Date(NaN)`.

## Test plan

I used the decodeURI method to decoding encoded URI(Date) returning a string.
It could be done with String(value) or value.string() which would also work, but I chose decodeURI because it's safer in relation to object-type values.
