### PR TITLE
feat: Allow mocking property value in tests

### DIFF
--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -320,6 +320,16 @@ export interface Jest {
    */
   spyOn: ModuleMocker['spyOn'];
   /**
+   * Replaces property on object with mock value.
+   *
+   * This method does not work on 'get' or 'set' accessors, and cannot be called
+   * on already replaced value.
+   *
+   * @remarks
+   * For mocking functions, use `jest.spyOn()` instead.
+   */
+  mockProperty: ModuleMocker['mockProperty'];
+  /**
    * Indicates that the module system should never return a mocked version of
    * the specified module from `require()` (e.g. that it should always return the
    * real module).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

PR is adding new feature that allows mocking values of object properties, that are not methods. Method is inspired to Sinon.js'es `sandbox.replace(object, property, replacement);`, but written from scratch.

Ref: https://sinonjs.org/releases/v14/sandbox/#sandboxreplaceobject-property-replacement

Method is now named `mockProperty()`, is sitting next to the `spyOn()` method in `jest-mock` package. Ideally, it should be exposed in global Jest object as well.

`mockProperty()` returns a method that exposes `mockRestore()` method to restore previous value. This restorer is called also in `restoreAllMocks()` cleanup method.

I tried to limit the usage as much as possible, so it could be potentially extended without breaking any compatibility. That is why it:
1. forbids replacement of `function`s (one should use `spyOn()` for that)
2. forbids replacement of getters and setters (just for sake of simplicity)
3. forbids replacement of a value with different type (here I borrowed the idea from Sinon.js, have no clear opinion on that, but feel that starting stricter might make sense) 
4. forbids replacement of property that has been already replaced (mixed feelings here. What if I want to "clear" the property in one before* block, and somewhere deeper I'd like to change it? Such as adding some extra variable to process.env?)

🚧 This PR is still a draft, because @SimenB wanted to see this feature (issue #13465 ) in the code. To make it complete, it needs a bit more tests, exposing correctly the method on global Jest object + adding some documentation.

I am looking forward for your thoughts

Fixes #13465.

The **motivation** for this feature is to allow simpler way of mocking property values, which, right now, have to be split into multiple places, which might introduce problems on multiple places:

```js
/// BEFORE
let oldEnv;

beforeEach(() => {
  oldEnv = process.env;
  process.env = {
    FOO: 1,
  };
});

afterEach(() => {
  process.env = oldEnv;
});

/// AFTER (VARIANT 1)
let processEnvMock;

beforeEach(() => {
  processEnvMock = jest.mockProperty(process, 'env', {FOO: 1});
});

afterEach(() => {
  processEnvMock.mockRestore();
});

/// AFTER (VARIANT 2)
beforeEach(() => {
  jest.mockProperty(process, 'env', {FOO: 1});
});

afterEach(() => {
  jest.restoreAllMocks();
});
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Unit tests have been added. 

🚧 Type tests and tests for global Jest object still have to be added.

## Open questions

* General thoughts - does this even make sense?
* Naming + interface - is the method named correctly? Is it okay to return what it returns?
* Possible code reuse inside jest-mock - right now, few pieces are duplicated between `spyOn()` and `mockProperty()`. Is it okay or should it be refactored?
