### PR TITLE
`.todo` tests are shown as `todo` when inside a focussed describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-circus]` Test marked as `todo` are shown as todo when inside a focussed describe ([#13504](https://github.com/facebook/jest/pull/13504))
 - `[@jest/test-sequencer]` Make sure sharding does not produce empty groups ([#13476](https://github.com/facebook/jest/pull/13476))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-- `[jest-circus]` Test marked as `todo` are shown as todo when inside a focussed describe ([#13504](https://github.com/facebook/jest/pull/13504))
 - `[@jest/test-sequencer]` Make sure sharding does not produce empty groups ([#13476](https://github.com/facebook/jest/pull/13476))
+- `[jest-circus]` Test marked as `todo` are shown as todo when inside a focussed describe ([#13504](https://github.com/facebook/jest/pull/13504))
 - `[jest-mock]` Ensure mock resolved and rejected values are promises from correct realm ([#13503](https://github.com/facebook/jest/pull/13503))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/__snapshots__/testTodo.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testTodo.test.ts.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`counts todo tests when inside of a \`describe.only\` 1`] = `
+"PASS __tests__/only-todo.test.js
+  with .only, should show 'passed', 'todo', 'todo'
+    ✓ passing test
+    ✎ todo todo test 1
+    ✎ todo todo test 2
+
+Test Suites: 1 passed, 1 total
+Tests:       2 todo, 1 passed, 3 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /only-todo.test.js/i."
+`;
+
 exports[`shows error messages when called with invalid argument 1`] = `
 "FAIL __tests__/todoNonString.test.js
   ● Test suite failed to run

--- a/e2e/__tests__/testTodo.test.ts
+++ b/e2e/__tests__/testTodo.test.ts
@@ -44,3 +44,10 @@ test('shows todo messages when in verbose mode', () => {
   const {rest} = extractSummary(result.stderr);
   expect(rest).toMatchSnapshot();
 });
+
+test('counts todo tests when inside of a `describe.only`', () => {
+  const result = runJest(dir, ['only-todo.test.js']);
+  expect(result.exitCode).toBe(0);
+  const {rest, summary} = extractSummary(result.stderr);
+  expect(`${rest}\n\n${summary}`).toMatchSnapshot();
+});

--- a/e2e/test-todo/__tests__/only-todo.test.js
+++ b/e2e/test-todo/__tests__/only-todo.test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+describe.only("with .only, should show 'passed', 'todo', 'todo'", () => {
+  test('passing test', () => {});
+  test.todo('todo test 1');
+  test.todo('todo test 2');
+});

--- a/e2e/test-todo/__tests__/only-todo.test.js
+++ b/e2e/test-todo/__tests__/only-todo.test.js
@@ -4,6 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/* eslint-disable jest/no-focused-tests */
+
 'use strict';
 
 describe.only("with .only, should show 'passed', 'todo', 'todo'", () => {

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -147,7 +147,7 @@ const _runTest = async (
   const isSkipped =
     parentSkipped ||
     test.mode === 'skip' ||
-    (hasFocusedTests && test.mode !== 'only') ||
+    (hasFocusedTests && test.mode === undefined) ||
     (testNamePattern && !testNamePattern.test(getTestID(test)));
 
   if (isSkipped) {


### PR DESCRIPTION
## Summary
Fix #13482 by changing `.todo` tests to not be marked as `skipped` when inside of a focussed describe block.

## Test plan

I've added an e2e test for this case and no other tests should break

