### PR TITLE
fix(mock): consider modules as objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-mock]` Treat cjs modules as objects so they can be mocked ([#13513](https://github.com/facebook/jest/pull/13513))
+
 ### Chore & Maintenance
 
 - `[@jest/transform]` Update `convert-source-map` ([#13509](https://github.com/facebook/jest/pull/13509))

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -215,12 +215,7 @@ describe('moduleMocker', () => {
 
     it('mocks getters of cjs modules', () => {
       const foo = Object.defineProperties(
-        {
-          enumGetter: {
-            enumerable: true,
-            get: () => 10,
-          },
-        },
+        {foo: 'bar'},
         {
           __esModule: {value: true},
           [Symbol.toStringTag]: {value: 'Module'},
@@ -229,7 +224,7 @@ describe('moduleMocker', () => {
       const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo),
       );
-      expect(mock.enumGetter).toBeDefined();
+      expect(mock.foo).toBeDefined();
     });
 
     it('mocks ES2015 non-enumerable methods', () => {

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -213,7 +213,7 @@ describe('moduleMocker', () => {
       expect(mock.enumGetter).toBeDefined();
     });
 
-    it('mocks getters of cjs modules', () => {
+    it('handles custom toString of transpiled modules', () => {
       const foo = Object.defineProperties(
         {foo: 'bar'},
         {

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -213,6 +213,25 @@ describe('moduleMocker', () => {
       expect(mock.enumGetter).toBeDefined();
     });
 
+    it('mocks getters of cjs modules', () => {
+      const foo = Object.defineProperties(
+        {
+          enumGetter: {
+            enumerable: true,
+            get: () => 10,
+          },
+        },
+        {
+          __esModule: {value: true},
+          [Symbol.toStringTag]: {value: 'Module'},
+        },
+      );
+      const mock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(foo),
+      );
+      expect(mock.enumGetter).toBeDefined();
+    });
+
     it('mocks ES2015 non-enumerable methods', () => {
       class ClassFoo {
         foo() {}

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -426,7 +426,7 @@ function getType(ref?: unknown): MockMetadataType | null {
     return 'function';
   } else if (Array.isArray(ref)) {
     return 'array';
-  } else if (typeName === 'Object') {
+  } else if (typeName === 'Object' || typeName === 'Module') {
     return 'object';
   } else if (
     typeName === 'Number' ||


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When retrieving mock metadata of recent node modules, jest fails with the error `Error: Failed to get mock metadata`

An example of a node module that will fail mocking is `@sentry/vue` version 7.16 while version 7.15 will not

Here is the  difference between the 2 versions
```js
Object.defineProperty(exports, '__esModule', { value: true });

var browser = require('@sentry/browser');
var sdk = require('./sdk.js');
var router = require('./router.js');
var errorhandler = require('./errorhandler.js');
var tracing = require('./tracing.js');



exports.init = sdk.init;
exports.vueRouterInstrumentation = router.vueRouterInstrumentation;
exports.attachErrorHandler = errorhandler.attachErrorHandler;
exports.createTracingMixins = tracing.createTracingMixins;
for (var k in browser) {
	if (k !== 'default' && !exports.hasOwnProperty(k)) exports[k] = browser[k];
}
//# sourceMappingURL=index.js.map
```

```js
Object.defineProperties(exports, { __esModule: { value: true }, [Symbol.toStringTag]: { value: 'Module' } });

const browser = require('@sentry/browser');
const sdk = require('./sdk.js');
const router = require('./router.js');
const errorhandler = require('./errorhandler.js');
const tracing = require('./tracing.js');



exports.init = sdk.init;
exports.vueRouterInstrumentation = router.vueRouterInstrumentation;
exports.attachErrorHandler = errorhandler.attachErrorHandler;
exports.createTracingMixins = tracing.createTracingMixins;
for (const k in browser) {
	if (k !== 'default' && !exports.hasOwnProperty(k)) exports[k] = browser[k];
}
//# sourceMappingURL=index.js.map
```

As you can see, no difference except es6 modernization and this `[Symbol.toStringTag]: { value: 'Module' }`

But jest does not know how to handle `jest.mock('@sentry/vue')` with this new version

## Test plan

I did a test mocking `jest.mock('@sentry/vue')` before this change which fails with the previous error
And after this change the module is correctly mocked

Before the change `getType` would return `null` for an `[Object Module]` which shortcircuited the metadata retrievial and failed, now it returns `object` and retrieves metadata correctly

Here is a repo demonstrating the issue
https://github.com/Tofandel/sentry-vue-bug


This PR will very likely fix https://github.com/facebook/jest/issues/678