### PR TITLE
fix(jest-runtime): `VMModule` is not a type

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -689,7 +689,7 @@ export default class Runtime {
   async unstable_importModule(
     from: string,
     moduleName?: string,
-  ): Promise<VMModule | void> {
+  ): Promise<unknown | void> {
     invariant(
       runtimeSupportsVmModules,
       'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/ecmascript-modules',


### PR DESCRIPTION
## Summary

`@types/node` does not provide typings for `Module` from `node:vm` module:

https://github.com/facebook/jest/blob/54ce1053aa462cd745127ac41d571d812c268580/packages/jest-runtime/src/index.ts#L18-L20

In a way this is implicit `any`. That is not nice and build is failing as well.

Should be possible to add typings through ambient type declaration. I will think about it (; Perhaps `unknown` is good enough for now as a quick fix?

## Test plan

Green CI
