### PR TITLE
refactor(jest-mock): remove useless conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Fixes
 
 - `[jest-mock]` Treat cjs modules as objects so they can be mocked ([#13513](https://github.com/facebook/jest/pull/13513))
-- `[jest-mock]` Remove useless conditional ([#13561](https://github.com/facebook/jest/pull/13561))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-mock]` Treat cjs modules as objects so they can be mocked ([#13513](https://github.com/facebook/jest/pull/13513))
+- `[jest-mock]` Remove useless conditional ([#13561](https://github.com/facebook/jest/pull/13561))
 
 ### Chore & Maintenance
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -876,7 +876,7 @@ export class ModuleMocker {
     const boundFunctionPrefix = 'bound ';
     let bindCall = '';
     // if-do-while for perf reasons. The common case is for the if to fail.
-    if (name && name.startsWith(boundFunctionPrefix)) {
+    if (name.startsWith(boundFunctionPrefix)) {
       do {
         name = name.substring(boundFunctionPrefix.length);
         // Call bind() just to alter the function name.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Conditional always evaluates to true, and is caught a few lines above anyway:

https://github.com/facebook/jest/blob/4670d3be0d80d47844673eb163666253e788f006/packages/jest-mock/src/index.ts#L871-L873

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
N/A
