### PR TITLE
fix(jest-worker): fix hanging when workers are killed or unexpectedly exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - `[jest-mock]` Treat cjs modules as objects so they can be mocked ([#13513](https://github.com/facebook/jest/pull/13513))
-- `[jest-worker]` Throw an error instead of hanging when jest workers are killed ([#13566](https://github.com/facebook/jest/pull/13566))
+- `[jest-worker]` Throw an error instead of hanging when jest workers terminate unexpectedly ([#13566](https://github.com/facebook/jest/pull/13566))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-mock]` Treat cjs modules as objects so they can be mocked ([#13513](https://github.com/facebook/jest/pull/13513))
+- `[jest-worker]` Throw an error instead of hanging when jest workers are killed ([#13566](https://github.com/facebook/jest/pull/13566))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -254,6 +254,18 @@ export default class ExperimentalWorker
         this._worker.postMessage(this._request);
       }
     } else {
+      // If the worker thread exits while a request is still pending, throw an
+      // error. This is unexpected and tests may not have run to completion.
+      const isRequestStillPending = !!this._request;
+      if (isRequestStillPending) {
+        this._onProcessEnd(
+          new Error(
+            'A Jest worker thread exited unexpectedly before finishing tests for an unknown reason. One of the ways this can happen is if process.exit() was called in testing code.',
+          ),
+          null,
+        );
+      }
+
       this._shutdown();
     }
   }

--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
@@ -386,3 +386,68 @@ describe.each([
     });
   });
 });
+
+// This describe block only applies to the child process worker since it's
+// generally not possible for external processes to abruptly kill a thread of
+// another process.
+describe('should not hang on external process kill', () => {
+  let worker: ChildProcessWorker;
+
+  beforeEach(() => {
+    const options = {
+      childWorkerPath: processChildWorkerPath,
+      maxRetries: 0,
+      silent: true,
+      workerPath: join(__dirname, '__fixtures__', 'SelfKillWorker'),
+    } as unknown as WorkerOptions;
+
+    worker = new ChildProcessWorker(options);
+  });
+
+  afterEach(async () => {
+    await new Promise<void>(resolve => {
+      setTimeout(async () => {
+        if (worker) {
+          worker.forceExit();
+          await worker.waitForExit();
+        }
+
+        resolve();
+      }, 500);
+    });
+  });
+
+  // Regression test for https://github.com/facebook/jest/issues/13183
+  test('onEnd callback is called', async () => {
+    let onEndPromiseResolve: () => void;
+    let onEndPromiseReject: (err: Error) => void;
+    const onEndPromise = new Promise<void>((resolve, reject) => {
+      onEndPromiseResolve = resolve;
+      onEndPromiseReject = reject;
+    });
+
+    const onStart = jest.fn();
+    const onEnd = jest.fn((err: Error | null) => {
+      if (err) {
+        return onEndPromiseReject(err);
+      }
+      onEndPromiseResolve();
+    });
+    const onCustom = jest.fn();
+
+    await worker.waitForWorkerReady();
+
+    // The SelfKillWorker simulates an external process calling SIGTERM on it,
+    // but just SIGTERMs itself underneath the hood to make this test easier.
+    worker.send(
+      [CHILD_MESSAGE_CALL, true, 'selfKill', []],
+      onStart,
+      onEnd,
+      onCustom,
+    );
+
+    // The onEnd callback should be called when the child process exits.
+    await expect(onEndPromise).rejects.toBeInstanceOf(Error);
+    expect(onEnd).toHaveBeenCalled();
+  });
+});

--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
@@ -385,69 +385,66 @@ describe.each([
       );
     });
   });
-});
 
-// This describe block only applies to the child process worker since it's
-// generally not possible for external processes to abruptly kill a thread of
-// another process.
-describe('should not hang on external process kill', () => {
-  let worker: ChildProcessWorker;
+  describe('should not hang when worker is killed or unexpectedly terminated', () => {
+    let worker: ChildProcessWorker | ThreadsWorker;
 
-  beforeEach(() => {
-    const options = {
-      childWorkerPath: processChildWorkerPath,
-      maxRetries: 0,
-      silent: true,
-      workerPath: join(__dirname, '__fixtures__', 'SelfKillWorker'),
-    } as unknown as WorkerOptions;
+    beforeEach(() => {
+      const options = {
+        childWorkerPath: processChildWorkerPath,
+        maxRetries: 0,
+        silent: true,
+        workerPath: join(__dirname, '__fixtures__', 'SelfKillWorker'),
+      } as unknown as WorkerOptions;
 
-    worker = new ChildProcessWorker(options);
-  });
+      worker = new ChildProcessWorker(options);
+    });
 
-  afterEach(async () => {
-    await new Promise<void>(resolve => {
-      setTimeout(async () => {
-        if (worker) {
-          worker.forceExit();
-          await worker.waitForExit();
+    afterEach(async () => {
+      await new Promise<void>(resolve => {
+        setTimeout(async () => {
+          if (worker) {
+            worker.forceExit();
+            await worker.waitForExit();
+          }
+
+          resolve();
+        }, 500);
+      });
+    });
+
+    // Regression test for https://github.com/facebook/jest/issues/13183
+    test('onEnd callback is called', async () => {
+      let onEndPromiseResolve: () => void;
+      let onEndPromiseReject: (err: Error) => void;
+      const onEndPromise = new Promise<void>((resolve, reject) => {
+        onEndPromiseResolve = resolve;
+        onEndPromiseReject = reject;
+      });
+
+      const onStart = jest.fn();
+      const onEnd = jest.fn((err: Error | null) => {
+        if (err) {
+          return onEndPromiseReject(err);
         }
+        onEndPromiseResolve();
+      });
+      const onCustom = jest.fn();
 
-        resolve();
-      }, 500);
+      await worker.waitForWorkerReady();
+
+      // The SelfKillWorker simulates an external process calling SIGTERM on it,
+      // but just SIGTERMs itself underneath the hood to make this test easier.
+      worker.send(
+        [CHILD_MESSAGE_CALL, true, 'selfKill', []],
+        onStart,
+        onEnd,
+        onCustom,
+      );
+
+      // The onEnd callback should be called when the child process exits.
+      await expect(onEndPromise).rejects.toBeInstanceOf(Error);
+      expect(onEnd).toHaveBeenCalled();
     });
-  });
-
-  // Regression test for https://github.com/facebook/jest/issues/13183
-  test('onEnd callback is called', async () => {
-    let onEndPromiseResolve: () => void;
-    let onEndPromiseReject: (err: Error) => void;
-    const onEndPromise = new Promise<void>((resolve, reject) => {
-      onEndPromiseResolve = resolve;
-      onEndPromiseReject = reject;
-    });
-
-    const onStart = jest.fn();
-    const onEnd = jest.fn((err: Error | null) => {
-      if (err) {
-        return onEndPromiseReject(err);
-      }
-      onEndPromiseResolve();
-    });
-    const onCustom = jest.fn();
-
-    await worker.waitForWorkerReady();
-
-    // The SelfKillWorker simulates an external process calling SIGTERM on it,
-    // but just SIGTERMs itself underneath the hood to make this test easier.
-    worker.send(
-      [CHILD_MESSAGE_CALL, true, 'selfKill', []],
-      onStart,
-      onEnd,
-      onCustom,
-    );
-
-    // The onEnd callback should be called when the child process exits.
-    await expect(onEndPromise).rejects.toBeInstanceOf(Error);
-    expect(onEnd).toHaveBeenCalled();
   });
 });

--- a/packages/jest-worker/src/workers/__tests__/__fixtures__/SelfKillWorker.js
+++ b/packages/jest-worker/src/workers/__tests__/__fixtures__/SelfKillWorker.js
@@ -7,12 +7,9 @@
 const {isMainThread} = require('worker_threads');
 
 async function selfKill() {
-  // This test is intended for the child process worker. If the Node.js worker
-  // thread mode is accidentally tested instead, let's prevent a confusing
-  // situation where process.kill stops the Jest test harness itself.
   if (!isMainThread) {
     // process.exit is documented to only stop the current thread rather than
-    // the process in a worker_threads environment.
+    // the entire process in a worker_threads environment.
     process.exit();
   }
 

--- a/packages/jest-worker/src/workers/__tests__/__fixtures__/SelfKillWorker.js
+++ b/packages/jest-worker/src/workers/__tests__/__fixtures__/SelfKillWorker.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {isMainThread} = require('worker_threads');
+
+async function selfKill() {
+  // This test is intended for the child process worker. If the Node.js worker
+  // thread mode is accidentally tested instead, let's prevent a confusing
+  // situation where process.kill stops the Jest test harness itself.
+  if (!isMainThread) {
+    // process.exit is documented to only stop the current thread rather than
+    // the process in a worker_threads environment.
+    process.exit();
+  }
+
+  process.kill(process.pid);
+}
+
+module.exports = {
+  selfKill,
+};


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/jest/issues/13183.

### Before

Before this change, if a Jest worker process is killed externally (e.g. through `kill <PID>`), the Jest test harness is never informed and the test runs forever. This happens even if a finite timeout (default 5s) is set.

For my team specifically, we were observing [OOM-killer](https://lwn.net/Articles/317814/) on Linux kill `jest-worker` processes and cause CI tests to hang forever. **Since OOM-killer is included on all Linux distributions, I believe this bug affects any users of Jest on Linux.**

![hanging](https://user-images.githubusercontent.com/906558/197129963-f642217a-aaaa-4a83-9d83-9432b4d89f22.png)

This was difficult to root cause since there were no logs of the failure. Once we realized more memory was required on CI for our project, we bumped our container's memory limit. Previously hanging tests completed successfully from there.

### After

After the change in this PR, the test above exits with an error. See https://github.com/gluxon/test-jest-worker-killed-repro for the source code of this repro.

<img width="842" alt="Screenshot 2022-11-06 at 1 35 02 PM" src="https://user-images.githubusercontent.com/906558/200188825-bd5fedc9-282b-4e7d-9034-8677cedf38a3.png">

Although the scenarios in which a `jest-worker` running in a thread (rather than a subprocess) exit unexpectedly are much rarer, this situation was handled as well in the PR for consistency.

## Test plan

This change contains a new test. Before the fix, the test fails with:

Execution 
```
❯ yarn jest WorkerEdgeCases
 FAIL  packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts (23.206 s)
  ✓ workers/processChild.js should exist (1 ms)
  ✓ workers/threadChild.js should exist
  ✓ types.js should exist
  ProcessWorker
    ✓ should get memory usage (45 ms)
    ✓ should recycle on idle limit breach (652 ms)
    should automatically recycle on idle limit breach
      ✓ initial state (1 ms)
      ✓ new worker starts (71 ms)
      ✓ worker continues to run after kill delay (601 ms)
      ✓ expected state order (1 ms)
    should cleanly exit on out of memory crash
      ✓ starting state
      ✓ worker ready (1 ms)
      ✓ worker crashes and exits (127 ms)
      ✓ worker stays dead (3 ms)
      ✓ expected state order
    should handle regular fatal crashes
      ✓ starting state (1 ms)
      ✓ processes restart (4003 ms)
      ✓ processes exits (2 ms)
  ThreadWorker
    ✓ should get memory usage (75 ms)
    ✓ should recycle on idle limit breach (644 ms)
    should automatically recycle on idle limit breach
      ✓ initial state
      ✓ new worker starts (69 ms)
      ✓ worker continues to run after kill delay (601 ms)
      ✓ expected state order (1 ms)
    should cleanly exit on out of memory crash
      ✓ starting state (1 ms)
      ✓ worker ready
      ✓ worker crashes and exits (137 ms)
      ✓ worker stays dead
      ✓ expected state order
    should handle regular fatal crashes
      ✓ starting state (1 ms)
      ✓ processes restart (4002 ms)
      ✓ processes exits (2 ms)
  should not hang on external process kill
    ✕ onEnd callback is called (10505 ms)

  ● should not hang on external process kill › onEnd callback is called

    thrown: "Exceeded timeout of 10000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      at test (packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts:421:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 31 passed, 32 total
Snapshots:   0 total
Time:        23.351 s
Ran all test suites matching /WorkerEdgeCases/i.
```

After the fix, the test passes:

```
❯ yarn jest WorkerEdgeCases

> @jest/monorepo@0.0.0 jest /Users/gluxon/Developer/jest
> node ./packages/jest-cli/bin/jest.js "WorkerEdgeCases"

 PASS  packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts (13.28 s)
  ✓ workers/processChild.js should exist
  ✓ workers/threadChild.js should exist
  ✓ types.js should exist
  ProcessWorker
    ✓ should get memory usage (44 ms)
    ✓ should recycle on idle limit breach (649 ms)
    should automatically recycle on idle limit breach
      ✓ initial state (2 ms)
      ✓ new worker starts (80 ms)
      ✓ worker continues to run after kill delay (601 ms)
      ✓ expected state order (1 ms)
    should cleanly exit on out of memory crash
      ✓ starting state
      ✓ worker ready (1 ms)
      ✓ worker crashes and exits (141 ms)
      ✓ worker stays dead (4 ms)
      ✓ expected state order
    should handle regular fatal crashes
      ✓ starting state (1 ms)
      ✓ processes restart (4007 ms)
      ✓ processes exits (3 ms)
  ThreadWorker
    ✓ should get memory usage (78 ms)
    ✓ should recycle on idle limit breach (644 ms)
    should automatically recycle on idle limit breach
      ✓ initial state (1 ms)
      ✓ new worker starts (91 ms)
      ✓ worker continues to run after kill delay (601 ms)
      ✓ expected state order
    should cleanly exit on out of memory crash
      ✓ starting state
      ✓ worker ready
      ✓ worker crashes and exits (141 ms)
      ✓ worker stays dead
      ✓ expected state order (1 ms)
    should handle regular fatal crashes
      ✓ starting state (1 ms)
      ✓ processes restart (4003 ms)
      ✓ processes exits (2 ms)
  should not hang on external process kill
    ✓ onEnd callback is called (588 ms)

Test Suites: 1 passed, 1 total
Tests:       32 passed, 32 total
Snapshots:   0 total
Time:        13.45 s, estimated 24 s
Ran all test suites matching /WorkerEdgeCases/i.
```