### PR TITLE
Fix:- afterEach,afterall hooks reverse order

### DIFF
--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`afterEach & afterAll run in reverse order 1`] = `
+"add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+start_describe_definition: Scoped / Nested block
+add_hook: beforeAll
+add_hook: afterAll
+add_hook: beforeEach
+add_hook: afterEach
+add_test: 
+finish_describe_definition: Scoped / Nested block
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+hook_start: beforeAll
+1 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+1 - test
+test_fn_success: 
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+run_describe_start: Scoped / Nested block
+hook_start: beforeAll
+2 - beforeAll
+hook_success: beforeAll
+test_start: 
+hook_start: beforeEach
+1 - beforeEach
+hook_success: beforeEach
+hook_start: beforeEach
+2 - beforeEach
+hook_success: beforeEach
+test_fn_start: 
+2 - test
+test_fn_success: 
+hook_start: afterEach
+2 - afterEach
+hook_success: afterEach
+hook_start: afterEach
+1 - afterEach
+hook_success: afterEach
+test_done: 
+hook_start: afterAll
+2 - afterAll
+hook_success: afterAll
+run_describe_finish: Scoped / Nested block
+hook_start: afterAll
+1 - afterAll
+hook_success: afterAll
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0"
+`;
+
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1
 add_hook: beforeAll

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {test} from '..';
 import {runTest} from '../__mocks__/testUtils';
 
 test('beforeEach is executed before each test in current/child describe blocks', () => {

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {test} from '..';
 import {runTest} from '../__mocks__/testUtils';
 
 test('beforeEach is executed before each test in current/child describe blocks', () => {
@@ -68,6 +69,24 @@ test('beforeAll is exectued correctly', () => {
       });
     });
   `);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('afterEach & afterAll run in reverse order', () => {
+  const {stdout} = runTest(`
+      beforeAll(() => console.log('1 - beforeAll'));
+      afterAll(() => console.log('1 - afterAll'));
+      beforeEach(() => console.log('1 - beforeEach'));
+      afterEach(() => console.log('1 - afterEach'));
+      test('', () => console.log('1 - test'));
+      describe('Scoped / Nested block', () => {
+        beforeAll(() => console.log('2 - beforeAll'));
+        afterAll(() => console.log('2 - afterAll'));
+        beforeEach(() => console.log('2 - beforeEach'));
+        afterEach(() => console.log('2 - afterEach'));
+        test('', () => console.log('2 - test'));
+      });
+    `);
 
   expect(stdout).toMatchSnapshot();
 });

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -127,6 +127,8 @@ export const getAllHooksForDescribe = (
     }
   }
 
+  // The afterAll hook should run in the reverse order
+  result.afterAll.reverse();
   return result;
 };
 
@@ -146,20 +148,37 @@ export const getEachHooksForTest = (test: Circus.TestEntry): TestHooks => {
 
   do {
     const beforeEachForCurrentBlock = [];
+    const afterEachForCurrentBlock = [];
     for (const hook of block.hooks) {
       switch (hook.type) {
         case 'beforeEach':
           beforeEachForCurrentBlock.push(hook);
           break;
         case 'afterEach':
-          result.afterEach.push(hook);
+          afterEachForCurrentBlock.push(hook);
           break;
       }
     }
-    // 'beforeEach' hooks are executed from top to bottom, the opposite of the
-    // way we traversed it.
+    // to make it more simple, get both hook types in declaration order.
+    // Th comments below shows the repeat order:
+    //
+    // describe(() => { // <-- block.parent
+    //   beforeEach() // 3
+    //   beforeEach() // 4
+    //   describe(() => { // <-- test.parent
+    //     beforeEach() // 1
+    //     beforeEach() // 2
+    //     test() // <-- we start here
+    //   })
+    // })
     result.beforeEach = [...beforeEachForCurrentBlock, ...result.beforeEach];
+    result.afterEach = [...afterEachForCurrentBlock, ...result.afterEach];
   } while ((block = block.parent));
+
+  // The afterAll hook should run in reverse order
+
+  result.afterEach.reverse();
+
   return result;
 };
 


### PR DESCRIPTION
The jest circus package runs the hooks of afterAll and aftereach hooks in the order they have been declared, going to the current documentation , both the above hooks seem to run in reverse.

we can imitate the same in this way

I have tried to reverse the order of afterAll and afterEach , and this would happen even before they are executed.

```
const methodA: Method
const methodB: Method

beforeEach(() => {methodA= new  buildMethod() })
afterEach(()) => {methodA.dump() })

beforeEach(() => { methodB = new MethodUser(methodA) })
afterEach(() => { methodB.dump() }) 

```

