### PR TITLE
refactor(jest-mock): clean up internal typings

### DIFF
--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/// <reference lib="dom" />
+
 import {
   expectAssignable,
   expectError,
@@ -476,3 +478,17 @@ expectType<SpiedSetter<typeof optionalSpiedObject.propertyD>>(
 
 expectError(spyOn(optionalSpiedObject, 'propertyA'));
 expectError(spyOn(optionalSpiedObject, 'propertyB'));
+
+// properties of `prototype`
+
+expectType<SpiedFunction<(key: string, value: string) => void>>(
+  spyOn(Storage.prototype, 'setItem').mockImplementation(
+    (key: string, value: string) => {},
+  ),
+);
+
+expectError(
+  spyOn(Storage.prototype, 'setItem').mockImplementation(
+    (key: string, value: number) => {},
+  ),
+);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -114,9 +114,9 @@ export type SpiedGetter<T> = MockInstance<() => T>;
 export type SpiedSetter<T> = MockInstance<(arg: T) => void>;
 
 export type Spied<T extends ClassLike | FunctionLike> = T extends ClassLike
-  ? MockInstance<(...args: ConstructorParameters<T>) => InstanceType<T>>
+  ? SpiedClass<T>
   : T extends FunctionLike
-  ? MockInstance<(...args: Parameters<T>) => ReturnType<T>>
+  ? SpiedFunction<T>
   : never;
 
 // TODO in Jest 30 remove `SpyInstance` in favour of `Spied`
@@ -730,8 +730,7 @@ export class ModuleMocker {
 
       const f = this._createMockFunction(metadata, mockConstructor) as Mock;
       f._isMockFunction = true;
-      f.getMockImplementation = () =>
-        this._ensureMockConfig(f).mockImpl as UnknownFunction;
+      f.getMockImplementation = () => this._ensureMockConfig(f).mockImpl as T;
 
       if (typeof restore === 'function') {
         this._spyState.add(restore);
@@ -791,7 +790,7 @@ export class ModuleMocker {
           this._environmentGlobal.Promise.reject(value),
         );
 
-      f.mockImplementationOnce = (fn: UnknownFunction) => {
+      f.mockImplementationOnce = (fn: T) => {
         // next function call will use this mock implementation return value
         // or default mock implementation return value
         const mockConfig = this._ensureMockConfig(f);
@@ -827,7 +826,7 @@ export class ModuleMocker {
         }
       }
 
-      f.mockImplementation = (fn: UnknownFunction) => {
+      f.mockImplementation = (fn: T) => {
         // next function call will use mock implementation return value
         const mockConfig = this._ensureMockConfig(f);
         mockConfig.mockImpl = fn;


### PR DESCRIPTION
## Summary

Just some clean up of internal typings.

Found these while looking though the code, because of https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/63129. `@types/jest` definitions have an issue, if `spyOn` is called on `prototype` methods. I double checked and looks like everything works just fine with Jest build-in types. This use case is not covered so I added a type test as well. Just to prevent regression.

## Test plan

Green CI.
