### PR TITLE
fix(jest-config): do not warn about presets in project config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-config]` Do not warn about `preset` in `ProjectConfig`
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-config]` Do not warn about `preset` in `ProjectConfig`
+- `[jest-config]` Do not warn about `preset` in `ProjectConfig` [#13583](https://github.com/facebook/jest/pull/13583)
 
 ### Chore & Maintenance
 

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -261,6 +261,7 @@ export const initialProjectOptions: Config.InitialProjectOptions = {
   },
   modulePathIgnorePatterns: ['<rootDir>/build/'],
   modulePaths: ['/shared/vendor/modules'],
+  preset: 'react-native',
   prettierPath: '<rootDir>/node_modules/prettier',
   resetMocks: false,
   resetModules: false,

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -448,6 +448,7 @@ export type ProjectConfig = {
   moduleNameMapper: Array<[string, string]>;
   modulePathIgnorePatterns: Array<string>;
   modulePaths?: Array<string>;
+  preset?: string;
   prettierPath: string;
   resetMocks: boolean;
   resetModules: boolean;

--- a/packages/jest-validate/src/utils.ts
+++ b/packages/jest-validate/src/utils.ts
@@ -22,6 +22,8 @@ export const format = (value: unknown): string =>
 export const formatPrettyObject = (value: unknown): string =>
   typeof value === 'function'
     ? value.toString()
+    : typeof value === 'undefined'
+    ? 'undefined'
     : JSON.stringify(value, null, 2).split('\n').join('\n    ');
 
 export class ValidationError extends Error {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Ref https://github.com/facebook/jest/pull/13565#issuecomment-1307263897 and #13576

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

No warning when running test in the Jest repo

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
