### PR TITLE
docs: improve TypeScript Usage documentation with few additional notes

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -168,7 +168,13 @@ In order for Jest to transpile TypeScript with `ts-jest`, you may also need to c
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+You can use type definitions which ships with Jest and will update each time you update Jest. Install the `@jest/globals` package:
+
+```bash npm2yarn
+npm install --save-dev @jest/globals
+```
+
+And import the APIs from it:
 
 ```ts title="sum.test.ts"
 import {describe, expect, test} from '@jest/globals';

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -973,6 +973,8 @@ test.todo('add should be associative');
 
 ## TypeScript Usage
 
+<TypeScriptExamplesNote />
+
 ### `.each`
 
 The `.each` modifier offers few different ways to define a table of the test cases. Some of the APIs have caveats related with the type inference of the arguments which are passed to `describe` or `test` callback functions. Let's take a look at each of them.

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -517,11 +517,7 @@ test('async test', async () => {
 
 ## TypeScript Usage
 
-:::tip
-
-Please consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
-:::
+<TypeScriptExamplesNote />
 
 ### `jest.fn(implementation?)`
 

--- a/docs/_TypeScriptExamplesNote.md
+++ b/docs/_TypeScriptExamplesNote.md
@@ -6,4 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+
 :::

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -164,7 +164,13 @@ In order for Jest to transpile TypeScript with `ts-jest`, you may also need to c
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+You can use type definitions which ships with Jest and will update each time you update Jest. Install the `@jest/globals` package:
+
+```bash npm2yarn
+npm install --save-dev @jest/globals
+```
+
+And import the APIs from it:
 
 ```ts title="sum.test.ts"
 import {describe, expect, test} from '@jest/globals';

--- a/website/versioned_docs/version-29.0/GlobalAPI.md
+++ b/website/versioned_docs/version-29.0/GlobalAPI.md
@@ -973,6 +973,8 @@ test.todo('add should be associative');
 
 ## TypeScript Usage
 
+<TypeScriptExamplesNote />
+
 ### `.each`
 
 The `.each` modifier offers few different ways to define a table of the test cases. Some of the APIs have caveats related with the type inference of the arguments which are passed to `describe` or `test` callback functions. Let's take a look at each of them.

--- a/website/versioned_docs/version-29.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.0/MockFunctionAPI.md
@@ -480,11 +480,7 @@ test('async test', async () => {
 
 ## TypeScript Usage
 
-:::tip
-
-Please consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
-:::
+<TypeScriptExamplesNote />
 
 ### `jest.fn(implementation?)`
 

--- a/website/versioned_docs/version-29.0/_TypeScriptExamplesNote.md
+++ b/website/versioned_docs/version-29.0/_TypeScriptExamplesNote.md
@@ -6,4 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+
 :::

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -168,7 +168,13 @@ In order for Jest to transpile TypeScript with `ts-jest`, you may also need to c
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+You can use type definitions which ships with Jest and will update each time you update Jest. Install the `@jest/globals` package:
+
+```bash npm2yarn
+npm install --save-dev @jest/globals
+```
+
+And import the testing APIs from it:
 
 ```ts title="sum.test.ts"
 import {describe, expect, test} from '@jest/globals';

--- a/website/versioned_docs/version-29.1/GlobalAPI.md
+++ b/website/versioned_docs/version-29.1/GlobalAPI.md
@@ -973,6 +973,8 @@ test.todo('add should be associative');
 
 ## TypeScript Usage
 
+<TypeScriptExamplesNote />
+
 ### `.each`
 
 The `.each` modifier offers few different ways to define a table of the test cases. Some of the APIs have caveats related with the type inference of the arguments which are passed to `describe` or `test` callback functions. Let's take a look at each of them.

--- a/website/versioned_docs/version-29.1/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.1/MockFunctionAPI.md
@@ -517,11 +517,7 @@ test('async test', async () => {
 
 ## TypeScript Usage
 
-:::tip
-
-Please consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
-:::
+<TypeScriptExamplesNote />
 
 ### `jest.fn(implementation?)`
 

--- a/website/versioned_docs/version-29.1/_TypeScriptExamplesNote.md
+++ b/website/versioned_docs/version-29.1/_TypeScriptExamplesNote.md
@@ -6,4 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+
 :::

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -168,7 +168,13 @@ In order for Jest to transpile TypeScript with `ts-jest`, you may also need to c
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+You can use type definitions which ships with Jest and will update each time you update Jest. Install the `@jest/globals` package:
+
+```bash npm2yarn
+npm install --save-dev @jest/globals
+```
+
+And import the testing APIs from it:
 
 ```ts title="sum.test.ts"
 import {describe, expect, test} from '@jest/globals';

--- a/website/versioned_docs/version-29.2/GlobalAPI.md
+++ b/website/versioned_docs/version-29.2/GlobalAPI.md
@@ -973,6 +973,8 @@ test.todo('add should be associative');
 
 ## TypeScript Usage
 
+<TypeScriptExamplesNote />
+
 ### `.each`
 
 The `.each` modifier offers few different ways to define a table of the test cases. Some of the APIs have caveats related with the type inference of the arguments which are passed to `describe` or `test` callback functions. Let's take a look at each of them.

--- a/website/versioned_docs/version-29.2/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.2/MockFunctionAPI.md
@@ -517,11 +517,7 @@ test('async test', async () => {
 
 ## TypeScript Usage
 
-:::tip
-
-Please consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
-:::
+<TypeScriptExamplesNote />
 
 ### `jest.fn(implementation?)`
 

--- a/website/versioned_docs/version-29.2/_TypeScriptExamplesNote.md
+++ b/website/versioned_docs/version-29.2/_TypeScriptExamplesNote.md
@@ -6,4 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+
 :::

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -168,7 +168,13 @@ In order for Jest to transpile TypeScript with `ts-jest`, you may also need to c
 
 There are two ways to have [Jest global APIs](GlobalAPI.md) typed for test files written in TypeScript.
 
-You can use type definitions which ships with Jest and will update each time you update Jest. Simply import the APIs from `@jest/globals` package:
+You can use type definitions which ships with Jest and will update each time you update Jest. Install the `@jest/globals` package:
+
+```bash npm2yarn
+npm install --save-dev @jest/globals
+```
+
+And import the testing APIs from it:
 
 ```ts title="sum.test.ts"
 import {describe, expect, test} from '@jest/globals';

--- a/website/versioned_docs/version-29.3/GlobalAPI.md
+++ b/website/versioned_docs/version-29.3/GlobalAPI.md
@@ -973,6 +973,8 @@ test.todo('add should be associative');
 
 ## TypeScript Usage
 
+<TypeScriptExamplesNote />
+
 ### `.each`
 
 The `.each` modifier offers few different ways to define a table of the test cases. Some of the APIs have caveats related with the type inference of the arguments which are passed to `describe` or `test` callback functions. Let's take a look at each of them.

--- a/website/versioned_docs/version-29.3/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.3/MockFunctionAPI.md
@@ -517,11 +517,7 @@ test('async test', async () => {
 
 ## TypeScript Usage
 
-:::tip
-
-Please consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
-:::
+<TypeScriptExamplesNote />
 
 ### `jest.fn(implementation?)`
 

--- a/website/versioned_docs/version-29.3/_TypeScriptExamplesNote.md
+++ b/website/versioned_docs/version-29.3/_TypeScriptExamplesNote.md
@@ -6,4 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+
 :::


### PR DESCRIPTION
Closes #13598

## Summary

A couple of improvements based on user feedback from the above mentioned issue:

- currently the Getting Started guide is only telling to import from the `@jest/globals` package. The install step is missing. Let’s add it?
- both TypeScript Usage sections are missing the note that types will work only if imported from `@jest/globals`. The note is on top of the page. That is right place to have it, also it is easy to skip it. Perhaps it is useful to repeat the note?

## Test plan

Deploy preview