### PR TITLE
Rely on ScriptTransformer cache in jest-runner 

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1543,23 +1543,18 @@ export default class Runtime {
       return source;
     }
 
-    let transformedFile: TransformResult | undefined =
-      this._fileTransforms.get(filename);
-
-    if (transformedFile) {
-      return transformedFile.code;
-    }
-
-    transformedFile = this._scriptTransformer.transform(
+    const transformedFile = this._scriptTransformer.transform(
       filename,
       this._getFullTransformationOptions(options),
       source,
     );
 
-    this._fileTransforms.set(filename, {
-      ...transformedFile,
-      wrapperLength: this.constructModuleWrapperStart().length,
-    });
+    if (this._fileTransforms.get(filename)?.code !== transformedFile.code) {
+      this._fileTransforms.set(filename, {
+        ...transformedFile,
+        wrapperLength: this.constructModuleWrapperStart().length,
+      });
+    }
 
     if (transformedFile.sourceMapPath) {
       this._sourceMapRegistry.set(filename, transformedFile.sourceMapPath);
@@ -1577,23 +1572,18 @@ export default class Runtime {
       return source;
     }
 
-    let transformedFile: TransformResult | undefined =
-      this._fileTransforms.get(filename);
-
-    if (transformedFile) {
-      return transformedFile.code;
-    }
-
-    transformedFile = await this._scriptTransformer.transformAsync(
+    const transformedFile = await this._scriptTransformer.transformAsync(
       filename,
       this._getFullTransformationOptions(options),
       source,
     );
 
-    this._fileTransforms.set(filename, {
-      ...transformedFile,
-      wrapperLength: 0,
-    });
+    if (this._fileTransforms.get(filename)?.code !== transformedFile.code) {
+      this._fileTransforms.set(filename, {
+        ...transformedFile,
+        wrapperLength: 0,
+      });
+    }
 
     if (transformedFile.sourceMapPath) {
       this._sourceMapRegistry.set(filename, transformedFile.sourceMapPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Hello, thank you all for your work on the library 🙏🏾 . 
I have a library: https://github.com/salazarm/jspatch/ that uses jest's code-transformation feature to transform files that are under test depending on what calls the test file is making. Basically, `getCacheKey` for a file can change depending on which test file is running.  Currently the jest-runtime has a `_fileTransforms` cache that it checks before deciding to call `_scriptTransformer.transform`. I propose we remove the cache check and instead rely on `_scriptTransformer.transform`'s cache. Internally it's already maintaining a cache using `getCacheKey` so there shouldn't be a major negative performance impact to this change. 



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I tested this change with my library and confirmed that files get properly transformed again if `getCacheKey` changes but I'm a little unsure how to test this since it's testing the boundary between `jest-transform` and `jest-runtime` packages.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
