### PR TITLE
docs: improve custom puppeteer example to prevent worker warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Chore & Maintenance
 
 - `[@jest/fake-timers]` Update `@sinonjs/fake-timers` ([#13612](https://github.com/facebook/jest/pull/13612))
+- `[docs]` Improve custom puppeteer example to prevent worker warnings ([#13619](https://github.com/facebook/jest/pull/13619))
 
 ### Performance
 

--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-25.x/Puppeteer.md
+++ b/website/versioned_docs/version-25.x/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-26.x/Puppeteer.md
+++ b/website/versioned_docs/version-26.x/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-27.x/Puppeteer.md
+++ b/website/versioned_docs/version-27.x/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-28.x/Puppeteer.md
+++ b/website/versioned_docs/version-28.x/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-29.0/Puppeteer.md
+++ b/website/versioned_docs/version-29.0/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-29.1/Puppeteer.md
+++ b/website/versioned_docs/version-29.1/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-29.2/Puppeteer.md
+++ b/website/versioned_docs/version-29.2/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 

--- a/website/versioned_docs/version-29.3/Puppeteer.md
+++ b/website/versioned_docs/version-29.3/Puppeteer.md
@@ -108,6 +108,9 @@ class PuppeteerEnvironment extends NodeEnvironment {
   }
 
   async teardown() {
+    if (this.global.__BROWSER_GLOBAL__) {
+      this.global.__BROWSER_GLOBAL__.disconnect();
+    }
     await super.teardown();
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Environment have to call `disconnect` during teardown otherwise it will generate a warning: 

> A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Just docs update ✌️ 