### PR TITLE
Fix grammatical errors in docs

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -253,7 +253,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -305,7 +305,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -374,7 +374,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -393,7 +393,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -439,11 +439,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -457,12 +457,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -551,7 +551,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -573,7 +573,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -608,7 +608,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -625,7 +625,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -646,10 +646,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -663,10 +663,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -697,7 +697,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -729,7 +729,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -868,7 +868,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -885,7 +885,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -928,10 +928,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -945,10 +945,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-25.x/GlobalAPI.md
+++ b/website/versioned_docs/version-25.x/GlobalAPI.md
@@ -245,7 +245,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -277,7 +277,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -346,7 +346,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -365,7 +365,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -411,11 +411,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -429,12 +429,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -490,7 +490,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -512,7 +512,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -571,7 +571,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -588,7 +588,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -631,10 +631,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -648,10 +648,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-26.x/GlobalAPI.md
+++ b/website/versioned_docs/version-26.x/GlobalAPI.md
@@ -245,7 +245,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -277,7 +277,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -346,7 +346,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -365,7 +365,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -411,11 +411,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -429,12 +429,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -512,7 +512,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -534,7 +534,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -569,7 +569,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -586,7 +586,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -607,10 +607,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -624,10 +624,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -655,7 +655,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -677,7 +677,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -736,7 +736,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -753,7 +753,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -796,10 +796,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -813,10 +813,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-27.x/GlobalAPI.md
+++ b/website/versioned_docs/version-27.x/GlobalAPI.md
@@ -249,7 +249,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -301,7 +301,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -370,7 +370,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -389,7 +389,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -435,11 +435,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -453,12 +453,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -536,7 +536,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -558,7 +558,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -593,7 +593,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -610,7 +610,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -631,10 +631,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -648,10 +648,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -683,7 +683,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -715,7 +715,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -774,7 +774,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -791,7 +791,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -834,10 +834,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -851,10 +851,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-28.x/GlobalAPI.md
+++ b/website/versioned_docs/version-28.x/GlobalAPI.md
@@ -249,7 +249,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -301,7 +301,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -370,7 +370,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -389,7 +389,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -435,11 +435,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -453,12 +453,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -536,7 +536,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -558,7 +558,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -593,7 +593,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -610,7 +610,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -631,10 +631,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -648,10 +648,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -683,7 +683,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -715,7 +715,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. _Note: The default timeout is 5 seconds._
 
 Example:
@@ -830,7 +830,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -847,7 +847,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -890,10 +890,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -907,10 +907,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-29.0/GlobalAPI.md
+++ b/website/versioned_docs/version-29.0/GlobalAPI.md
@@ -253,7 +253,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -305,7 +305,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -374,7 +374,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -393,7 +393,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -439,11 +439,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -457,12 +457,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -551,7 +551,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -573,7 +573,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -608,7 +608,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -625,7 +625,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -646,10 +646,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -663,10 +663,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -697,7 +697,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -729,7 +729,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -868,7 +868,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -885,7 +885,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -928,10 +928,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -945,10 +945,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-29.1/GlobalAPI.md
+++ b/website/versioned_docs/version-29.1/GlobalAPI.md
@@ -253,7 +253,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -305,7 +305,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -374,7 +374,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -393,7 +393,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -439,11 +439,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -457,12 +457,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -551,7 +551,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -573,7 +573,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -608,7 +608,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -625,7 +625,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -646,10 +646,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -663,10 +663,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -697,7 +697,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -729,7 +729,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -868,7 +868,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -885,7 +885,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -928,10 +928,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -945,10 +945,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-29.2/GlobalAPI.md
+++ b/website/versioned_docs/version-29.2/GlobalAPI.md
@@ -253,7 +253,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -305,7 +305,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -374,7 +374,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -393,7 +393,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -439,11 +439,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -457,12 +457,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -551,7 +551,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -573,7 +573,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -608,7 +608,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -625,7 +625,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -646,10 +646,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -663,10 +663,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -697,7 +697,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -729,7 +729,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -868,7 +868,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -885,7 +885,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -928,10 +928,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -945,10 +945,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```

--- a/website/versioned_docs/version-29.3/GlobalAPI.md
+++ b/website/versioned_docs/version-29.3/GlobalAPI.md
@@ -253,7 +253,7 @@ Use `describe.each` if you keep duplicating the same test suites with different 
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -305,7 +305,7 @@ describe.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test suite, use `$variable` to inject test data into the suite title from the tagged template expressions, and `$#` for the index of the row.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the suite of tests to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the suite of tests to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -374,7 +374,7 @@ describe.only.each([
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -393,7 +393,7 @@ describe.only.each`
   });
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -439,11 +439,11 @@ describe.skip.each([
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
   test(`returns ${expected}`, () => {
-    expect(a + b).toBe(expected); // will not be ran
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -457,12 +457,12 @@ describe.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  test('will not be ran', () => {
-    expect(a + b).toBe(expected); // will not be ran
+  test('will not be run', () => {
+    expect(a + b).toBe(expected); // will not be run
   });
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -551,7 +551,7 @@ Use `test.concurrent.each` if you keep duplicating the same test with different 
     - `%o` - Object.
     - `%#` - Index of the test case.
     - `%%` - single percent sign ('%'). This does not consume an argument.
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -573,7 +573,7 @@ test.concurrent.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object, **this will have to be an asynchronous function**.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -608,7 +608,7 @@ test.concurrent.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -625,7 +625,7 @@ test.concurrent.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -646,10 +646,10 @@ test.concurrent.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', async (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -663,10 +663,10 @@ test.concurrent.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', async ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -697,7 +697,7 @@ Use `test.each` if you keep duplicating the same test with different data. `test
     - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
     - You can use `$#` to inject the index of the test case
     - You cannot use `$variable` with the `printf` formatting except for `%%`
-- `fn`: `Function` the test to be ran, this is the function that will receive the parameters in each row as function arguments.
+- `fn`: `Function` the test to be run, this is the function that will receive the parameters in each row as function arguments.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -729,7 +729,7 @@ test.each([
   - One or more subsequent rows of data supplied as template literal expressions using `${value}` syntax.
 - `name`: `String` the title of the test, use `$variable` to inject test data into the test title from the tagged template expressions.
   - To inject nested object values use you can supply a keyPath i.e. `$variable.path.to.value`
-- `fn`: `Function` the test to be ran, this is the function that will receive the test data object.
+- `fn`: `Function` the test to be run, this is the function that will receive the test data object.
 - Optionally, you can provide a `timeout` (in milliseconds) for specifying how long to wait for each row before aborting. The default timeout is 5 seconds.
 
 Example:
@@ -868,7 +868,7 @@ test.only.each([
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -885,7 +885,7 @@ test.only.each`
   expect(a + b).toBe(expected);
 });
 
-test('will not be ran', () => {
+test('will not be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -928,10 +928,10 @@ test.skip.each([
   [1, 2, 3],
   [2, 1, 3],
 ])('.add(%i, %i)', (a, b, expected) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```
@@ -945,10 +945,10 @@ test.skip.each`
   ${1} | ${2} | ${3}
   ${2} | ${1} | ${3}
 `('returns $expected when $a is added $b', ({a, b, expected}) => {
-  expect(a + b).toBe(expected); // will not be ran
+  expect(a + b).toBe(expected); // will not be run
 });
 
-test('will be ran', () => {
+test('will be run', () => {
   expect(1 / 0).toBe(Infinity);
 });
 ```


### PR DESCRIPTION
Changed occurrences of 'ran' to 'run', such as in 'will not be ran' (which is incorrect).