### PR TITLE
[Feature]: Chain nthCalledWith

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -969,6 +969,32 @@ The nth argument must be positive integer starting from 1.
 
 :::
 
+### `.toBeNth(nthCall)`
+
+If you have a function that doesn't have any arguments, instead of `toHaveBeenNthCalledWith` you can use `toBeNth` for better readability. The goal is when someone reads your test, the person does not misurderstand the first argument of `toHaveBeenNthCalledWith` (which is the nth) and thinks that since the function that needs to be tested doens't have arguments, it shouldn't be provided.
+
+Example with nthCalledWith:
+
+```js
+bar();
+bar('foo');
+expect(bar).toHaveBeenNthCalledWith(1); //novice PR reviewer: "but bar isn't called with 1"
+expect(bar).toHaveBeenNthCalledWith(2, 'foo'); //this context makes it obvious
+```
+
+Example with toBeNth:
+
+```js
+bar();
+expect(bar).toBeNth(1);
+```
+
+:::note
+
+The nth argument must be positive integer starting from 1.
+
+:::
+
 ### `.toHaveReturned()`
 
 Also under the alias: `.toReturn()`

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
@@ -1229,6 +1229,61 @@ Received:     <r>0</>, <r>["foo", undefined]</>
 Number of calls: <r>1</>
 `;
 
+exports[`toBeNth includes the custom mock name in the error message 1`] = `
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toBeNth<d>(</>n<d>, </><g>...expected</><d>)</>
+
+n: 1
+
+Number of calls: <r>1</>
+`;
+
+exports[`toBeNth negative throw matcher error for n that is not integer 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNth<d>(</>expected<d>, </><g>...expected</><d>)</>
+
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
+
+Expected has type:  number
+Expected has value: <g>Infinity</>
+`;
+
+exports[`toBeNth positive throw matcher error for n that is not integer 1`] = `
+<d>expect(</><r>received</><d>).</>toBeNth<d>(</>expected<d>, </><g>...expected</><d>)</>
+
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
+
+Expected has type:  number
+Expected has value: <g>0.1</>
+`;
+
+exports[`toBeNth positive throw matcher error for n that is not positive integer 1`] = `
+<d>expect(</><r>received</><d>).</>toBeNth<d>(</>expected<d>, </><g>...expected</><d>)</>
+
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
+
+Expected has type:  number
+Expected has value: <g>-1</>
+`;
+
+exports[`toBeNth works only on spies or jest.fn 1`] = `
+<d>expect(</><r>received</><d>).</>toBeNth<d>(</>n<d>, </><g>...expected</><d>)</>
+
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
+
+Received has type:  function
+Received has value: <r>[Function fn]</>
+`;
+
+exports[`toBeNth works with three calls 1`] = `
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeNth<d>(</>n<d>, </><g>...expected</><d>)</>
+
+n: 1
+Received
+->     1:     <r>1</>
+       2:     <r>2</>
+
+Number of calls: <r>3</>
+`;
+
 exports[`toHaveBeenCalled .not fails with any argument passed 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalled<d>()</>
 

--- a/packages/expect/src/__tests__/spyMatchers.test.ts
+++ b/packages/expect/src/__tests__/spyMatchers.test.ts
@@ -185,6 +185,85 @@ describe.each(['toBeCalledTimes', 'toHaveBeenCalledTimes'] as const)(
   },
 );
 
+describe.each(['toBeNth'] as const)('%s', calledWith => {
+  test('works only on spies or jest.fn', () => {
+    const fn = function fn() {};
+
+    expect(() => jestExpect(fn)[calledWith](3)).toThrowErrorMatchingSnapshot();
+  });
+
+  test('works with no arguments', () => {
+    const fn = jest.fn();
+    fn();
+
+    jestExpect(createSpy(fn))[calledWith];
+    jestExpect(fn)[calledWith];
+  });
+
+  test('works with arguments that match', () => {
+    const fn = jest.fn();
+    fn(1);
+
+    jestExpect(createSpy(fn))[calledWith](1);
+    jestExpect(fn)[calledWith](1);
+
+    expect(() => jestExpect(fn)[calledWith](1)).not.toThrow();
+  });
+
+  test('works with three calls', () => {
+    const fn = jest.fn();
+    fn(1);
+    fn(2);
+    fn(3);
+
+    jestExpect(fn)[calledWith](1);
+    jestExpect(fn)[calledWith](2);
+    jestExpect(fn)[calledWith](3);
+
+    expect(() => {
+      jestExpect(fn).not[calledWith](1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('positive throw matcher error for n that is not positive integer', async () => {
+    const fn = jest.fn();
+    fn(-1);
+
+    expect(() => {
+      jestExpect(fn)[calledWith](-1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('positive throw matcher error for n that is not integer', async () => {
+    const fn = jest.fn();
+    fn(0.1);
+
+    expect(() => {
+      jestExpect(fn)[calledWith](0.1);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('negative throw matcher error for n that is not integer', async () => {
+    const fn = jest.fn();
+    fn(Infinity);
+
+    expect(() => {
+      jestExpect(fn).not[calledWith](Infinity);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('includes the custom mock name in the error message', () => {
+    const fn = jest.fn().mockName('named-mock');
+    fn(1);
+
+    jestExpect(fn)[calledWith](1);
+
+    expect(() =>
+      jestExpect(fn).not[calledWith](1),
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
 describe.each([
   'lastCalledWith',
   'toHaveBeenLastCalledWith',

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -209,6 +209,13 @@ export interface Matchers<R extends void | Promise<void>> {
    * This is the same as `.toBe(null)` but the error messages are a bit nicer.
    * So use `.toBeNull()` when you want to check that something is null.
    */
+  toBeNth(expected: number): R;
+  /**
+   * This is the same to `.nthCalledWith(number)` but easier to read when the function
+   * you want to check has no arguments. It avoids a misunderstandings of thinking
+   * that the first argument of nthCalledWith is the argument of the function you want
+   * to test
+   */
   toBeNull(): R;
   /**
    * Use when you don't care what a value is, you just want to ensure a value

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -263,6 +263,10 @@ expectType<void>(
 );
 expectError(expect(jest.fn()).nthCalledWith());
 
+expectType<void>(expect(jest.fn()).toBeNth(2));
+expectError(expect(jest.fn()).toBeNth());
+expectError(expect(jest.fn()).toBeNth('foo'));
+
 expectType<void>(expect(jest.fn()).toHaveBeenNthCalledWith(2));
 expectType<void>(expect(jest.fn()).toHaveBeenNthCalledWith(1, 'value'));
 expectType<void>(expect(jest.fn()).toHaveBeenNthCalledWith(1, 'value', 123));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This add a new matcher `toBeNth` to be used when the function you want to test have no arguments for better understanding of the reader. This was requested at this issue [#13646](https://github.com/facebook/jest/issues/13646)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```js
test('works with arguments that match', () => {
    const fn = jest.fn();
    fn(1);

    jestExpect(createSpy(fn))[calledWith](1);
    jestExpect(fn)[calledWith](1);

    expect(() => jestExpect(fn)[calledWith](1)).not.toThrow();
  });
```