### PR TITLE
Fixed TypeScript example that doesn't work

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -25,9 +25,9 @@ module.exports = config;
 ```
 
 ```ts tab
-import type {Config} from 'jest';
+import type {Config} from '@jest/types';
 
-const config: Config = {
+const config: Config.InitialOptions = {
   verbose: true,
 };
 
@@ -46,9 +46,9 @@ module.exports = async () => {
 ```
 
 ```ts tab
-import type {Config} from 'jest';
+import type {Config} from '@jest/types';
 
-export default async (): Promise<Config> => {
+export default async (): Promise<Config.InitialOptions> => {
   return {
     verbose: true,
   };


### PR DESCRIPTION
## Summary

This solves `Module '"jest"' has no exported member 'Config'.ts(2305)` import error

<img width="507" alt="image" src="https://user-images.githubusercontent.com/35376824/208784541-c9eac522-b5f7-489b-b261-e940eb6971da.png">

## Test plan

Testing a project with this `jest.config.ts` file totally works, the original one doesn't

<img width="520" alt="image" src="https://user-images.githubusercontent.com/35376824/208784393-2bdf2db0-4eae-4d50-bfda-e6834a1975cc.png">

Further documentation: https://swizec.com/blog/how-to-configure-jest-with-typescript/#improved-jest-config
