### PR TITLE
chore: fix workflow status badge in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://github.com/facebook/jest/actions/workflows/nodejs.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/workflow/status/facebook/jest/Node%20CI?label=CI&logo=GitHub"></a>
+  <a href="https://github.com/facebook/jest/actions/workflows/nodejs.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/actions/workflow/status/facebook/jest/nodejs.yml?label=CI&logo=GitHub"></a>
   <a href="https://codecov.io/github/facebook/jest"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/facebook/jest/main.svg?maxAge=43200"></a>
 </p>
 <p align="center">


### PR DESCRIPTION
## Summary

The workflow status badge is currently broken in the readme file, because of breaking change in Badges API. See https://github.com/badges/shields/issues/8671

<img width="522" alt="Screenshot 2022-12-22 at 17 15 09" src="https://user-images.githubusercontent.com/72159681/209164998-3913eafe-4998-48c9-a410-3cae2f1743ec.png">

I followed instructions in the issue to fix this.

## Test plan

Checked preview locally.
