### PR TITLE
chore: bump TypeScript

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -15,7 +15,7 @@
     "core-js": "^3.2.1",
     "rxjs": "^7.5.5",
     "tslib": "^2.0.0",
-    "typescript": "^4.8.2",
+    "typescript": "^4.9.4",
     "zone.js": "~0.11.3"
   },
   "devDependencies": {

--- a/examples/expect-extend/package.json
+++ b/examples/expect-extend/package.json
@@ -10,7 +10,7 @@
     "babel-jest": "workspace:^",
     "expect": "workspace:^",
     "jest": "workspace:^",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.4"
   },
   "scripts": {
     "test": "jest"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "react": "17.0.2",
     "react-dom": "^17.0.1",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.4"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@lerna-lite/cli": "^1.11.3",
     "@microsoft/api-extractor": "^7.33.4",
     "@tsconfig/node14": "^1.0.3",
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.0.0",
     "@types/babel__template": "^7.0.2",
@@ -80,7 +80,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "typescript": "^4.8.2",
+    "typescript": "^4.9.4",
     "which": "^3.0.0"
   },
   "scripts": {

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -20,7 +20,7 @@
     "jest-get-type": "workspace:^"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "immutable": "^4.0.0",
     "jest-matcher-utils": "workspace:^",
     "tsd-lite": "^0.6.0"

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@fast-check/jest": "^1.3.0",
     "@jest/test-utils": "workspace:^",
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "chalk": "^4.0.0",
     "immutable": "^4.0.0",
     "tsd-lite": "^0.6.0"

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -58,7 +58,7 @@
     "@types/micromatch": "^4.0.1",
     "semver": "^7.3.5",
     "ts-node": "^10.5.0",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.4"
   },
   "engines": {
     "node": "^14.15.0 || ^16.10.0 || >=18.0.0"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -21,7 +21,7 @@
     "jest-snapshot": "workspace:^"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "tsd-lite": "^0.6.0"
   },
   "engines": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -22,7 +22,7 @@
     "jest-util": "workspace:^"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "tsd-lite": "^0.6.0"
   },
   "engines": {

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:^",
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/exit": "^0.1.30",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -28,7 +28,7 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/graceful-fs": "^4.1.3",
     "@types/pnpapi": "^0.0.2",
     "@types/resolve": "^1.20.2",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -40,7 +40,7 @@
     "source-map-support": "0.5.13"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.3",
     "@types/source-map-support": "^0.5.0",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-flow": "^7.7.2",
     "@babel/preset-react": "^7.12.1",
     "@jest/test-utils": "workspace:^",
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
     "@types/semver": "^7.1.0",

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "tsd-lite": "^0.6.0"
   },
   "publishConfig": {

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -23,7 +23,7 @@
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",
     "get-stream": "^6.0.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -19,7 +19,7 @@
     "jest-cli": "workspace:^"
   },
   "devDependencies": {
-    "@tsd/typescript": "^4.9.0",
+    "@tsd/typescript": "^4.9.4",
     "tsd-lite": "^0.6.0"
   },
   "peerDependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -55,6 +55,6 @@
     "graphql": "^16.3.0",
     "graphql-request": "^5.0.0",
     "js-yaml": "^4.1.0",
-    "typescript": "^4.8.2"
+    "typescript": "^4.9.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,7 +2736,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect-utils@workspace:packages/expect-utils"
   dependencies:
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     immutable: ^4.0.0
     jest-get-type: "workspace:^"
     jest-matcher-utils: "workspace:^"
@@ -2748,7 +2748,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect@workspace:packages/jest-expect"
   dependencies:
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     expect: "workspace:^"
     jest-snapshot: "workspace:^"
     tsd-lite: ^0.6.0
@@ -2797,7 +2797,7 @@ __metadata:
     "@lerna-lite/cli": ^1.11.3
     "@microsoft/api-extractor": ^7.33.4
     "@tsconfig/node14": ^1.0.3
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/babel__core": ^7.1.14
     "@types/babel__generator": ^7.0.0
     "@types/babel__template": ^7.0.2
@@ -2862,7 +2862,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    typescript: ^4.8.2
+    typescript: ^4.9.4
     which: ^3.0.0
   languageName: unknown
   linkType: soft
@@ -2878,7 +2878,7 @@ __metadata:
     "@jest/transform": "workspace:^"
     "@jest/types": "workspace:^"
     "@jridgewell/trace-mapping": ^0.3.15
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/exit": ^0.1.30
     "@types/glob": ^7.1.1
     "@types/graceful-fs": ^4.1.3
@@ -3045,7 +3045,7 @@ __metadata:
   resolution: "@jest/types@workspace:packages/jest-types"
   dependencies:
     "@jest/schemas": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
@@ -4299,7 +4299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsd/typescript@npm:^4.9.0":
+"@tsd/typescript@npm:^4.9.4":
   version: 4.9.4
   resolution: "@tsd/typescript@npm:4.9.4"
   checksum: 08eafe058e0e8b2421945d0faa477ca443eee0fcb81a05e4405d5123b7379578d8b4918f9079e4d31538b4ce2bb69f32d62406b9f52b07e90e39fb725c4ee2b0
@@ -5640,7 +5640,7 @@ __metadata:
     jest-zone-patch: "*"
     rxjs: ^7.5.5
     tslib: ^2.0.0
-    typescript: ^4.8.2
+    typescript: ^4.9.4
     zone.js: ~0.11.3
   languageName: unknown
   linkType: soft
@@ -9425,7 +9425,7 @@ __metadata:
     babel-jest: "workspace:^"
     expect: "workspace:^"
     jest: "workspace:^"
-    typescript: ^4.8.2
+    typescript: ^4.9.4
   languageName: unknown
   linkType: soft
 
@@ -9556,7 +9556,7 @@ __metadata:
     jest: "workspace:^"
     react: 17.0.2
     react-dom: ^17.0.1
-    typescript: ^4.8.2
+    typescript: ^4.9.4
   languageName: unknown
   linkType: soft
 
@@ -9621,7 +9621,7 @@ __metadata:
     "@fast-check/jest": ^1.3.0
     "@jest/expect-utils": "workspace:^"
     "@jest/test-utils": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     chalk: ^4.0.0
     immutable: ^4.0.0
     jest-get-type: "workspace:^"
@@ -12404,7 +12404,7 @@ __metadata:
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
-    typescript: ^4.8.2
+    typescript: ^4.9.4
   peerDependencies:
     "@types/node": "*"
     ts-node: ">=9.0.0"
@@ -12607,7 +12607,7 @@ __metadata:
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
     "@jest/types": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/node": "*"
     jest-util: "workspace:^"
     tsd-lite: ^0.6.0
@@ -12690,7 +12690,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-resolve@workspace:packages/jest-resolve"
   dependencies:
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/graceful-fs": ^4.1.3
     "@types/pnpapi": ^0.0.2
     "@types/resolve": ^1.20.2
@@ -12730,7 +12730,7 @@ __metadata:
     "@jest/test-result": "workspace:^"
     "@jest/transform": "workspace:^"
     "@jest/types": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/exit": ^0.1.30
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
@@ -12831,7 +12831,7 @@ __metadata:
     "@jest/test-utils": "workspace:^"
     "@jest/transform": "workspace:^"
     "@jest/types": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/babel__traverse": ^7.0.6
     "@types/graceful-fs": ^4.1.3
     "@types/natural-compare": ^1.4.0
@@ -12985,7 +12985,7 @@ __metadata:
     react-github-btn: ^1.3.0
     react-lite-youtube-embed: ^2.2.2
     react-markdown: ^8.0.0
-    typescript: ^4.8.2
+    typescript: ^4.9.4
   languageName: unknown
   linkType: soft
 
@@ -12993,7 +12993,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-worker@workspace:packages/jest-worker"
   dependencies:
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"
     "@types/supports-color": ^8.1.0
@@ -13044,7 +13044,7 @@ __metadata:
   dependencies:
     "@jest/core": "workspace:^"
     "@jest/types": "workspace:^"
-    "@tsd/typescript": ^4.9.0
+    "@tsd/typescript": ^4.9.4
     import-local: ^3.0.2
     jest-cli: "workspace:^"
     tsd-lite: ^0.6.0
@@ -20045,7 +20045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.2":
+"typescript@npm:^4.9.4":
   version: 4.9.4
   resolution: "typescript@npm:4.9.4"
   bin:
@@ -20065,7 +20065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.8.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^4.9.4#~builtin<compat/typescript>":
   version: 4.9.4
   resolution: "typescript@patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=d73830"
   bin:


### PR DESCRIPTION
## Summary

Perhaps upgrading TypeScript could solve that odd error in test type check on CI:

<img width="988" alt="Screenshot 2022-12-22 at 21 43 03" src="https://user-images.githubusercontent.com/72159681/209215688-884a400c-2f24-413b-8dd8-b184614cc984.png">

## Test plan

Let’s see what CI thinks.
