### PR TITLE
feat: Added `skipped` and `focused` status to `FormattedTestResult`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-test-result]` Added `skipped` and `focused` status to `FormattedTestResult` ([#13700](https://github.com/facebook/jest/pull/13700))
+
 ### Fixes
 
 - `[jest-resolve]` add global paths to `require.resolve.paths` ([#13633](https://github.com/facebook/jest/pull/13633))

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -26,10 +26,57 @@ describe('formatTestResults', () => {
     ],
   };
 
-  it('includes test full name', () => {
-    const result = formatTestResults(results, undefined, null);
-    expect(result.testResults[0].assertionResults[0].fullName).toEqual(
-      assertion.fullName,
+  const skippedAssertion = {
+    fullName: 'Pending test',
+    status: 'pending',
+    title: 'is still pending',
+  };
+
+  const skippedResults: AggregatedResult = {
+    testResults: [
+      {
+        numFailingTests: 0,
+        numPassingTests: 0,
+        numPendingTests: 2,
+        numTodoTests: 2,
+        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
+        // @ts-expect-error
+        testResults: [skippedAssertion],
+      },
+    ],
+  };
+
+  it('should mark result status to skipped', () => {
+    const result = formatTestResults(skippedResults, undefined, null);
+    expect(result.testResults[0].assertionResults[0].status).toEqual(
+      skippedAssertion.status,
+    );
+  });
+
+  const focusedAssertion = {
+    fullName: 'Focused test',
+    status: 'focused',
+    title: 'focused test',
+  };
+
+  const focusedResults: AggregatedResult = {
+    testResults: [
+      {
+        numFailingTests: 0,
+        numPassingTests: 1,
+        numPendingTests: 1,
+        numTodoTests: 2,
+        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
+        // @ts-expect-error
+        testResults: [focusedAssertion],
+      },
+    ],
+  };
+
+  it('should mark result status to focused', () => {
+    const result = formatTestResults(focusedResults, undefined, null);
+    expect(result.testResults[0].assertionResults[0].status).toEqual(
+      focusedAssertion.status,
     );
   });
 });

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,7 +6,7 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import type {AggregatedResult, AssertionResult} from '../types';
+import type {AggregatedResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
@@ -36,7 +36,7 @@ describe('formatTestResults', () => {
     fullName: 'Pending test',
     status: 'pending',
     title: 'is still pending',
-  } as AssertionResult;
+  };
 
   const skippedResults = {
     testResults: [

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,7 +6,7 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import type {AggregatedResult} from '../types';
+import type {AggregatedResult, AssertionResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
@@ -36,7 +36,7 @@ describe('formatTestResults', () => {
     fullName: 'Pending test',
     status: 'pending',
     title: 'is still pending',
-  };
+  } as AssertionResult;
 
   const skippedResults = {
     testResults: [

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,7 +6,7 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import {AggregatedResult} from '../types';
+import type {AggregatedResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
@@ -25,6 +25,13 @@ describe('formatTestResults', () => {
       },
     ],
   };
+
+  it('includes test full name', () => {
+    const result = formatTestResults(results, undefined, null);
+    expect(result.testResults[0].assertionResults[0].fullName).toEqual(
+      assertion.fullName,
+    );
+  });
 
   const skippedAssertion = {
     fullName: 'Pending test',

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -9,75 +9,75 @@ import formatTestResults from '../formatTestResults';
 import type {AggregatedResult, AssertionResult} from '../types';
 
 describe('formatTestResults', () => {
-  const assertion = {
-    fullName: 'TestedModule#aMethod when some condition is met returns true',
-    status: 'passed',
-    title: 'returns true',
-  } as AssertionResult;
-
-  const results = {
-    testResults: [
-      {
-        numFailingTests: 0,
-        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        testResults: [assertion],
-      },
-    ],
-  } as AggregatedResult;
-
   it('includes test full name', () => {
+    const assertion = {
+      fullName: 'TestedModule#aMethod when some condition is met returns true',
+      status: 'passed',
+      title: 'returns true',
+    } as AssertionResult;
+
+    const results = {
+      testResults: [
+        {
+          numFailingTests: 0,
+          perfStats: {end: 2, runtime: 1, slow: false, start: 1},
+          testResults: [assertion],
+        },
+      ],
+    } as AggregatedResult;
+
     const result = formatTestResults(results, undefined, null);
     expect(result.testResults[0].assertionResults[0].fullName).toEqual(
       assertion.fullName,
     );
   });
 
-  const skippedAssertion = {
-    fullName: 'Pending test',
-    status: 'pending',
-    title: 'is still pending',
-  } as AssertionResult;
-
-  const skippedResults = {
-    testResults: [
-      {
-        numFailingTests: 0,
-        numPassingTests: 0,
-        numPendingTests: 2,
-        numTodoTests: 2,
-        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        testResults: [skippedAssertion],
-      },
-    ],
-  } as AggregatedResult;
-
   it('should mark result status to skipped', () => {
+    const skippedAssertion = {
+      fullName: 'Pending test',
+      status: 'pending',
+      title: 'is still pending',
+    } as AssertionResult;
+
+    const skippedResults = {
+      testResults: [
+        {
+          numFailingTests: 0,
+          numPassingTests: 0,
+          numPendingTests: 2,
+          numTodoTests: 2,
+          perfStats: {end: 2, runtime: 1, slow: false, start: 1},
+          testResults: [skippedAssertion],
+        },
+      ],
+    } as AggregatedResult;
+
     const result = formatTestResults(skippedResults, undefined, null);
     expect(result.testResults[0].assertionResults[0].status).toEqual(
       skippedAssertion.status,
     );
   });
 
-  const focusedAssertion = {
-    fullName: 'Focused test',
-    status: 'focused',
-    title: 'focused test',
-  } as AssertionResult;
-
-  const focusedResults = {
-    testResults: [
-      {
-        numFailingTests: 0,
-        numPassingTests: 1,
-        numPendingTests: 1,
-        numTodoTests: 2,
-        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        testResults: [focusedAssertion],
-      },
-    ],
-  } as AggregatedResult;
-
   it('should mark result status to focused', () => {
+    const focusedAssertion = {
+      fullName: 'Focused test',
+      status: 'focused',
+      title: 'focused test',
+    } as AssertionResult;
+
+    const focusedResults = {
+      testResults: [
+        {
+          numFailingTests: 0,
+          numPassingTests: 1,
+          numPendingTests: 1,
+          numTodoTests: 2,
+          perfStats: {end: 2, runtime: 1, slow: false, start: 1},
+          testResults: [focusedAssertion],
+        },
+      ],
+    } as AggregatedResult;
+
     const result = formatTestResults(focusedResults, undefined, null);
     expect(result.testResults[0].assertionResults[0].status).toEqual(
       focusedAssertion.status,

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,25 +6,24 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import type {AggregatedResult} from '../types';
+import type {AggregatedResult, AssertionResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
     fullName: 'TestedModule#aMethod when some condition is met returns true',
     status: 'passed',
     title: 'returns true',
-  };
+  } as AssertionResult;
 
-  const results: AggregatedResult = {
+  const results = {
     testResults: [
       {
         numFailingTests: 0,
         perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        // @ts-expect-error
         testResults: [assertion],
       },
     ],
-  };
+  } as AggregatedResult;
 
   it('includes test full name', () => {
     const result = formatTestResults(results, undefined, null);
@@ -37,9 +36,9 @@ describe('formatTestResults', () => {
     fullName: 'Pending test',
     status: 'pending',
     title: 'is still pending',
-  };
+  } as AssertionResult;
 
-  const skippedResults: AggregatedResult = {
+  const skippedResults = {
     testResults: [
       {
         numFailingTests: 0,
@@ -47,11 +46,10 @@ describe('formatTestResults', () => {
         numPendingTests: 2,
         numTodoTests: 2,
         perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        // @ts-expect-error
         testResults: [skippedAssertion],
       },
     ],
-  };
+  } as AggregatedResult;
 
   it('should mark result status to skipped', () => {
     const result = formatTestResults(skippedResults, undefined, null);
@@ -64,9 +62,9 @@ describe('formatTestResults', () => {
     fullName: 'Focused test',
     status: 'focused',
     title: 'focused test',
-  };
+  } as AssertionResult;
 
-  const focusedResults: AggregatedResult = {
+  const focusedResults = {
     testResults: [
       {
         numFailingTests: 0,
@@ -74,11 +72,10 @@ describe('formatTestResults', () => {
         numPendingTests: 1,
         numTodoTests: 2,
         perfStats: {end: 2, runtime: 1, slow: false, start: 1},
-        // @ts-expect-error
         testResults: [focusedAssertion],
       },
     ],
-  };
+  } as AggregatedResult;
 
   it('should mark result status to focused', () => {
     const result = formatTestResults(focusedResults, undefined, null);

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,14 +6,14 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import type {AggregatedResult, AssertionResult} from '../types';
+import type {AggregatedResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
     fullName: 'TestedModule#aMethod when some condition is met returns true',
     status: 'passed',
     title: 'returns true',
-  } as AssertionResult;
+  };
 
   const results = {
     testResults: [
@@ -36,7 +36,7 @@ describe('formatTestResults', () => {
     fullName: 'Pending test',
     status: 'pending',
     title: 'is still pending',
-  } as AssertionResult;
+  };
 
   const skippedResults = {
     testResults: [
@@ -62,7 +62,7 @@ describe('formatTestResults', () => {
     fullName: 'Focused test',
     status: 'focused',
     title: 'focused test',
-  } as AssertionResult;
+  };
 
   const focusedResults = {
     testResults: [

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -6,14 +6,14 @@
  */
 
 import formatTestResults from '../formatTestResults';
-import type {AggregatedResult} from '../types';
+import type {AggregatedResult, AssertionResult} from '../types';
 
 describe('formatTestResults', () => {
   const assertion = {
     fullName: 'TestedModule#aMethod when some condition is met returns true',
     status: 'passed',
     title: 'returns true',
-  };
+  } as AssertionResult;
 
   const results = {
     testResults: [
@@ -36,7 +36,7 @@ describe('formatTestResults', () => {
     fullName: 'Pending test',
     status: 'pending',
     title: 'is still pending',
-  };
+  } as AssertionResult;
 
   const skippedResults = {
     testResults: [
@@ -62,7 +62,7 @@ describe('formatTestResults', () => {
     fullName: 'Focused test',
     status: 'focused',
     title: 'focused test',
-  };
+  } as AssertionResult;
 
   const focusedResults = {
     testResults: [

--- a/packages/jest-test-result/src/formatTestResults.ts
+++ b/packages/jest-test-result/src/formatTestResults.ts
@@ -59,11 +59,11 @@ const formatTestResult = (
     message: testResult.failureMessage ?? '',
     name: testResult.testFilePath,
     startTime: testResult.perfStats.start,
-    status: allTestsExecuted
-      ? allTestsPassed
+    status: allTestsPassed
+      ? allTestsExecuted
         ? 'passed'
-        : 'failed'
-      : 'focused',
+        : 'focused'
+      : 'failed',
     summary: '',
   };
 };

--- a/packages/jest-test-result/src/formatTestResults.ts
+++ b/packages/jest-test-result/src/formatTestResults.ts
@@ -33,6 +33,21 @@ const formatTestResult = (
     };
   }
 
+  if (testResult.skipped) {
+    const now = Date.now();
+    return {
+      assertionResults: testResult.testResults,
+      coverage: {},
+      endTime: now,
+      message: testResult.failureMessage ?? '',
+      name: testResult.testFilePath,
+      startTime: now,
+      status: 'skipped',
+      summary: '',
+    };
+  }
+
+  const allTestsExecuted = testResult.numPendingTests === 0;
   const allTestsPassed = testResult.numFailingTests === 0;
   return {
     assertionResults: testResult.testResults,
@@ -44,7 +59,11 @@ const formatTestResult = (
     message: testResult.failureMessage ?? '',
     name: testResult.testFilePath,
     startTime: testResult.perfStats.start,
-    status: allTestsPassed ? 'passed' : 'failed',
+    status: allTestsExecuted
+      ? allTestsPassed
+        ? 'passed'
+        : 'failed'
+      : 'focused',
     summary: '',
   };
 };

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -125,7 +125,7 @@ export type FormattedTestResult = {
   message: string;
   name: string;
   summary: string;
-  status: 'failed' | 'passed';
+  status: 'failed' | 'passed' | 'skipped' | 'focused';
   startTime: number;
   endTime: number;
   coverage: unknown;

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -5,7 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-type Status = 'passed' | 'failed' | 'skipped' | 'pending' | 'todo' | 'disabled';
+type Status =
+  | 'passed'
+  | 'failed'
+  | 'skipped'
+  | 'pending'
+  | 'todo'
+  | 'disabled'
+  | 'focused';
 
 type Callsite = {
   column: number;


### PR DESCRIPTION
fix #5711 

## Summary
Added the `skipped` and `focused` status to `FormattedTestResult` as suggested in [this](https://github.com/facebook/jest/issues/5711#issuecomment-464114468) comment.
In my implementation, I consider the test `skipped` if the `testResult.skipped` flag is true.
I consider the test `focused` if there are still pending tests and no failures occur.
Let me know if this is the correct approach or if changes need to be made.
