### PR TITLE
Chore:- Changed window.document.defaultView to window

### DIFF
--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -66,8 +66,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
         ...projectConfig.testEnvironmentOptions,
       },
     );
-    const global = (this.global = this.dom.window.document
-      .defaultView as unknown as Win);
+    const global = (this.global = this.dom.window as unknown as Win);
 
     if (global == null) {
       throw new Error('JSDOM did not return a Window object');


### PR DESCRIPTION
the window object gives us the same value as the window.document.defaultView, so we can just directly use the window and avoid drilling it more 
![Developer Tools — about_blank 1_3_2023 9_00_24 PM](https://user-images.githubusercontent.com/72331432/210391319-13105b52-cb25-42e5-a953-2a2ec2c95bf1.png)

