### PR TITLE
docs: nit: `testNamePattern` alias `-t` be in inline code format

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -437,7 +437,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 

--- a/website/versioned_docs/version-27.x/CLI.md
+++ b/website/versioned_docs/version-27.x/CLI.md
@@ -357,7 +357,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 Note: The regex is matched against the full name, which is a combination of the test name and all its surrounding describe blocks.
 

--- a/website/versioned_docs/version-28.x/CLI.md
+++ b/website/versioned_docs/version-28.x/CLI.md
@@ -423,7 +423,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 

--- a/website/versioned_docs/version-29.0/CLI.md
+++ b/website/versioned_docs/version-29.0/CLI.md
@@ -417,7 +417,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 

--- a/website/versioned_docs/version-29.1/CLI.md
+++ b/website/versioned_docs/version-29.1/CLI.md
@@ -417,7 +417,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 

--- a/website/versioned_docs/version-29.2/CLI.md
+++ b/website/versioned_docs/version-29.2/CLI.md
@@ -437,7 +437,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 

--- a/website/versioned_docs/version-29.3/CLI.md
+++ b/website/versioned_docs/version-29.3/CLI.md
@@ -437,7 +437,7 @@ The glob patterns Jest uses to detect test files. Please refer to the [`testMatc
 
 ### `--testNamePattern=<regex>`
 
-Alias: -t. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
+Alias: `-t`. Run only tests with a name that matches the regex. For example, suppose you want to run only tests related to authorization which will have names like "GET /api/posts with auth", then you can use jest -t=auth.
 
 :::tip
 


### PR DESCRIPTION
## Summary

Just nit formatting correction. The `-t` alias wasn't in an inline code format.
Before::
![Screen Shot 2023-01-06 at 10 39 53 PM](https://user-images.githubusercontent.com/4698973/211129644-0f4108ee-7b75-4fca-bbe3-60956b2e9a5f.png)

After::
![Screen Shot 2023-01-06 at 10 38 20 PM](https://user-images.githubusercontent.com/4698973/211129600-2ca1d5ef-b4ed-46fb-92d0-d7d98c360a57.png)
