### PR TITLE
fix: add missing package.json type to tsIntegration tests

### DIFF
--- a/e2e/__tests__/tsIntegration.test.ts
+++ b/e2e/__tests__/tsIntegration.test.ts
@@ -158,7 +158,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
           const config: Config.InitialOptions = {verbose: true};
           export default get config;
           `,
-      'package.json': '{}',
+      'package.json': '{"type": "module"}',
     });
 
     const {stderr, exitCode} = runJest(DIR);
@@ -314,7 +314,7 @@ describe('when `Config` type is imported from "jest"', () => {
           const config: Config = {verbose: true};
           export default get config;
           `,
-      'package.json': '{}',
+      'package.json': '{"type": "module"}',
     });
 
     const {stderr, exitCode} = runJest(DIR);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

PR updates two tests in `tsIntegration.test.ts` to use `type: "module"` in the package.json where the description says `when package.json#type=module` but the test did not actually set that. This makes these tests look identical to the tests above that have that same suffix.

I noticed this while working on #13742 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

That CI passes, or by doing:

```
$ yarn jest -c jest.config.ts.mjs e2e/__tests__/tsIntegration.test.ts
 PASS   ts-integration  e2e/__tests__/tsIntegration.test.ts (9.98 s)
  when `Config` type is imported from "@jest/types"
    ✓ with object config exported from TS file (623 ms)
    ✓ with function config exported from TS file (708 ms)
    ✓ throws if type errors are encountered (576 ms)
    ✓ throws if syntax errors are encountered (567 ms)
    ✓ works with object config exported from TS file when package.json#type=module (577 ms)
    ✓ works with function config exported from TS file when package.json#type=module (594 ms)
    ✓ throws if type errors are encountered when package.json#type=module (565 ms)
    ✓ throws if syntax errors are encountered when package.json#type=module (559 ms)
  when `Config` type is imported from "jest"
    ✓ with object config exported from TS file (620 ms)
    ✓ with function config exported from TS file (664 ms)
    ✓ throws if type errors are encountered (600 ms)
    ✓ throws if syntax errors are encountered (620 ms)
    ✓ works with object config exported from TS file when package.json#type=module (639 ms)
    ✓ works with function config exported from TS file when package.json#type=module (644 ms)
    ✓ throws if type errors are encountered when package.json#type=module (611 ms)
    ✓ throws if syntax errors are encountered when package.json#type=module (666 ms)

Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        10.146 s, estimated 13 s
Ran all test suites matching /e2e\/__tests__\/tsIntegration.test.ts/i
```