### PR TITLE
chore: tweak `Cannot spyOn on a primitive value` error msg

### DIFF
--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1146,7 +1146,7 @@ export class ModuleMocker {
   ): MockInstance {
     if (typeof object !== 'object' && typeof object !== 'function') {
       throw new Error(
-        `Cannot spyOn on a primitive value; ${this._typeOf(object)} given`,
+        `Cannot spyOn a primitive value; ${this._typeOf(object)} given`,
       );
     }
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1146,7 +1146,7 @@ export class ModuleMocker {
   ): MockInstance {
     if (typeof object !== 'object' && typeof object !== 'function') {
       throw new Error(
-        `Cannot spyOn a primitive value; ${this._typeOf(object)} given`,
+        `Cannot use spyOn on a primitive value; ${this._typeOf(object)} given`,
       );
     }
 


### PR DESCRIPTION
The error message previously read 'Cannot spyOn on a primite value', which sounds a bit clunky.
