### PR TITLE
Add preposition 'on' after verb 'spy' in error msgs and docs

### DIFF
--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1299,16 +1299,16 @@ describe('moduleMocker', () => {
     it('should throw on invalid input', () => {
       expect(() => {
         moduleMocker.spyOn(null, 'method');
-      }).toThrow('spyOn could not find an object to spy upon for method');
+      }).toThrow('spyOn could not find an object to spy on for method');
       expect(() => {
         moduleMocker.spyOn({}, 'method');
       }).toThrow(
-        "Cannot spy the method property because it is not a function; undefined given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
+        "Cannot spy on the method property because it is not a function; undefined given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
       );
       expect(() => {
         moduleMocker.spyOn({method: 10}, 'method');
       }).toThrow(
-        "Cannot spy the method property because it is not a function; number given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
+        "Cannot spy on the method property because it is not a function; number given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
       );
     });
 
@@ -1469,16 +1469,16 @@ describe('moduleMocker', () => {
     it('should throw on invalid input', () => {
       expect(() => {
         moduleMocker.spyOn(null, 'method');
-      }).toThrow('spyOn could not find an object to spy upon for method');
+      }).toThrow('spyOn could not find an object to spy on for method');
       expect(() => {
         moduleMocker.spyOn({}, 'method');
       }).toThrow(
-        "Cannot spy the method property because it is not a function; undefined given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
+        "Cannot spy on the method property because it is not a function; undefined given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
       );
       expect(() => {
         moduleMocker.spyOn({method: 10}, 'method');
       }).toThrow(
-        "Cannot spy the method property because it is not a function; number given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
+        "Cannot spy on the method property because it is not a function; number given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
       );
     });
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1152,7 +1152,7 @@ export class ModuleMocker {
 
     if (!object) {
       throw new Error(
-        `spyOn could not find an object to spy upon for ${String(methodKey)}`,
+        `spyOn could not find an object to spy on for ${String(methodKey)}`,
       );
     }
 
@@ -1169,7 +1169,7 @@ export class ModuleMocker {
     if (!this.isMockFunction(original)) {
       if (typeof original !== 'function') {
         throw new Error(
-          `Cannot spy the ${String(
+          `Cannot spy on the ${String(
             methodKey,
           )} property because it is not a function; ${this._typeOf(
             original,
@@ -1260,7 +1260,7 @@ export class ModuleMocker {
     if (!this.isMockFunction(original)) {
       if (typeof original !== 'function') {
         throw new Error(
-          `Cannot spy the ${String(
+          `Cannot spy on the ${String(
             propertyKey,
           )} property because it is not a function; ${this._typeOf(
             original,

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-27.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.x/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-28.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-28.x/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-29.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.0/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-29.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.1/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-29.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.2/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below

--- a/website/versioned_docs/version-29.3/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.3/Es6ClassMocks.md
@@ -263,7 +263,7 @@ This will throw **_TypeError: \_soundPlayer2.default is not a constructor_**, un
 
 ## Mocking a specific method of a class
 
-Lets say that you want to mock or spy the method `playSoundFile` within the class `SoundPlayer`. A simple example:
+Lets say that you want to mock or spy on the method `playSoundFile` within the class `SoundPlayer`. A simple example:
 
 ```javascript
 // your jest test file below
@@ -306,7 +306,7 @@ export default class SoundPlayer {
 }
 ```
 
-You can mock/spy them easily, here is an example:
+You can mock/spy on them easily, here is an example:
 
 ```javascript
 // your jest test file below


### PR DESCRIPTION
Error messages (and docs) frequently used the verb 'spy' without the required preposition 'on' after it, e.g., 'Cannot spy the …' instead of 'Cannot spy **on** the …'.