### PR TITLE
fix(jest-transform): ensure correct config is passed to preprocessors specified multiple times in `transform`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-runtime]` Support Wasm files that import JS resources ([#13608](https://github.com/facebook/jest/pull/13608))
 - `[jest-runtime]` Using the scriptTransformer cache in jest-runner ([#13735](https://github.com/facebook/jest/pull/13735))
 - `[jest-snapshot]` Make sure to import `babel` outside of the sandbox ([#13694](https://github.com/facebook/jest/pull/13694))
+- `[jest-transform]` Ensure the correct configuration is passed to preprocessors specified multiple times in the `transform` option ([#13770](https://github.com/facebook/jest/pull/13770))
 
 ### Chore & Maintenance
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -134,6 +134,10 @@ class ScriptTransformer {
       .substring(0, 32);
   }
 
+  private _buildTransformCacheKey(pattern: string, filepath: string) {
+    return pattern + filepath;
+  }
+
   private _getCacheKey(
     fileData: string,
     filename: string,
@@ -243,25 +247,35 @@ class ScriptTransformer {
     return this._createCachedFilename(filename, cacheKey);
   }
 
-  private _getTransformPath(filename: string) {
-    const transformRegExp = this._cache.transformRegExp;
-    if (!transformRegExp) {
+  private _getTransformPatternAndPath(filename: string) {
+    const transformEntry = this._cache.transformRegExp;
+    if (transformEntry == null) {
       return undefined;
     }
 
-    for (let i = 0; i < transformRegExp.length; i++) {
-      if (transformRegExp[i][0].test(filename)) {
-        return transformRegExp[i][1];
+    for (let i = 0; i < transformEntry.length; i++) {
+      const [transformRegExp, transformPath] = transformEntry[i];
+      if (transformRegExp.test(filename)) {
+        return [transformRegExp.source, transformPath];
       }
     }
 
     return undefined;
   }
 
+  private _getTransformPath(filename: string) {
+    const transformInfo = this._getTransformPatternAndPath(filename);
+    if (!Array.isArray(transformInfo)) {
+      return undefined;
+    }
+
+    return transformInfo[1];
+  }
+
   async loadTransformers(): Promise<void> {
     await Promise.all(
       this._config.transform.map(
-        async ([, transformPath, transformerConfig]) => {
+        async ([transformPattern, transformPath, transformerConfig], i) => {
           let transformer: Transformer | TransformerFactory<Transformer> =
             await requireOrImportModule(transformPath);
 
@@ -278,7 +292,13 @@ class ScriptTransformer {
             throw new Error(makeInvalidTransformerError(transformPath));
           }
           const res = {transformer, transformerConfig};
-          this._transformCache.set(transformPath, res);
+          const transformCacheKey = this._buildTransformCacheKey(
+            this._cache.transformRegExp && this._cache.transformRegExp[i]
+              ? this._cache.transformRegExp[i][0].source
+              : new RegExp(transformPattern).source,
+            transformPath,
+          );
+          this._transformCache.set(transformCacheKey, res);
         },
       ),
     );
@@ -297,15 +317,19 @@ class ScriptTransformer {
       return null;
     }
 
-    const transformPath = this._getTransformPath(filename);
-
-    if (transformPath == null) {
+    const transformPatternAndPath = this._getTransformPatternAndPath(filename);
+    if (!Array.isArray(transformPatternAndPath)) {
       return null;
     }
 
-    const cached = this._transformCache.get(transformPath);
-    if (cached != null) {
-      return cached;
+    const [transformPattern, transformPath] = transformPatternAndPath;
+    const transformCacheKey = this._buildTransformCacheKey(
+      transformPattern,
+      transformPath,
+    );
+    const transformer = this._transformCache.get(transformCacheKey);
+    if (transformer !== undefined) {
+      return transformer;
     }
 
     throw new Error(

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -293,9 +293,8 @@ class ScriptTransformer {
           }
           const res = {transformer, transformerConfig};
           const transformCacheKey = this._buildTransformCacheKey(
-            this._cache.transformRegExp && this._cache.transformRegExp[i]
-              ? this._cache.transformRegExp[i][0].source
-              : new RegExp(transformPattern).source,
+            this._cache.transformRegExp?.[i]?.[0].source ??
+              new RegExp(transformPattern).source,
             transformPath,
           );
           this._transformCache.set(transformCacheKey, res);


### PR DESCRIPTION
Fixes #13769.

## Summary

Regarding the `transform` option of Jest configuration, it's not currently possible to use the same preprocessor with different configuration objects for different match patterns. This is because the latest entry in `transform` for a given preprocessor [will always overwrite the configuration of earlier entries](https://github.com/facebook/jest/blob/61a64b53fe72b00fb17d7aabe5a54c4d415a845f/packages/jest-transform/src/ScriptTransformer.ts#L281). See #13769 for more context.

## Implementation

Instead of caching preprocessors and the corresponding configuration based solely on the preprocessor path, we can cache based on the match pattern + preprocessor path pair. While there are different ways of going about this, here I've updated `transformCache` to use a simple string concatenation of the file match pattern + preprocessor path for its keys. This ensures that the correct configuration can be identified.

Please let me know if you'd prefer an alternative means of solving this problem - I'm happy to adjust.

## Test plan

I included a new unit test which validates this case. In addition to ensuring all current tests pass, please let me know if there's any other tests that would be useful to write.
