### PR TITLE
docs: add "shorthand for" notes in Mock Function API documentation

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-25.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-25.x/MockFunctionAPI.md
@@ -210,6 +210,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js
@@ -221,6 +227,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-26.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-26.x/MockFunctionAPI.md
@@ -210,6 +210,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js
@@ -221,6 +227,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-27.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-27.x/MockFunctionAPI.md
@@ -220,6 +220,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js
@@ -231,6 +237,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-28.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.x/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-29.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.0/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-29.1/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.1/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-29.2/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.2/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 

--- a/website/versioned_docs/version-29.3/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.3/MockFunctionAPI.md
@@ -296,6 +296,12 @@ jest.fn(function () {
 
 ### `mockFn.mockReturnValue(value)`
 
+Shorthand for:
+
+```js
+jest.fn().mockImplementation(() => value);
+```
+
 Accepts a value that will be returned whenever the mock function is called.
 
 ```js tab
@@ -319,6 +325,12 @@ mock(); // 43
 ```
 
 ### `mockFn.mockReturnValueOnce(value)`
+
+Shorthand for:
+
+```js
+jest.fn().mockImplementationOnce(() => value);
+```
 
 Accepts a value that will be returned for one call to the mock function. Can be chained so that successive calls to the mock function return different values. When there are no more `mockReturnValueOnce` values to use, calls will return a value specified by `mockReturnValue`.
 


### PR DESCRIPTION
Closes #12552

## Summary

The above mentioned PR got stale. It was nice idea to add two more "shorthand for" notes in Mock Function API documentation.

## Test plan

Deploy preview.