### PR TITLE
refactor(@jest/environment): keep alphabetic order in the `Jest` interface

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -555,7 +555,7 @@ test('works too', () => {
 
 Returns the `jest` object for chaining.
 
-### `jest.isEnvironmentTornDown(fn)`
+### `jest.isEnvironmentTornDown()`
 
 Returns `true` if test environment has been torn down.
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -555,10 +555,6 @@ test('works too', () => {
 
 Returns the `jest` object for chaining.
 
-### `jest.isEnvironmentTornDown()`
-
-Returns `true` if test environment has been torn down.
-
 ### `jest.isolateModules(fn)`
 
 `jest.isolateModules(fn)` goes a step further than `jest.resetModules()` and creates a sandbox registry for the modules that are loaded inside the callback function. This is useful to isolate specific modules for every test so that local module state doesn't conflict between tests.
@@ -993,23 +989,9 @@ Use the [`--showSeed`](CLI.md#--showseed) flag to print the seed in the test rep
 
 :::
 
-### `jest.setTimeout(timeout)`
+### `jest.isEnvironmentTornDown()`
 
-Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called. The default timeout interval is 5 seconds if this method is not called.
-
-Example:
-
-```js
-jest.setTimeout(1000); // 1 second
-```
-
-:::tip
-
-To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
-
-If you want to set the timeout for all test files, use [`testTimeout`](Configuration.md#testtimeout-number) configuration option.
-
-:::
+Returns `true` if test environment has been torn down.
 
 ### `jest.retryTimes(numRetries, options)`
 
@@ -1034,3 +1016,21 @@ test('will fail', () => {
 ```
 
 Returns the `jest` object for chaining.
+
+### `jest.setTimeout(timeout)`
+
+Set the default timeout interval (in milliseconds) for all tests and before/after hooks in the test file. This only affects the test file from which this function is called. The default timeout interval is 5 seconds if this method is not called.
+
+Example:
+
+```js
+jest.setTimeout(1000); // 1 second
+```
+
+:::tip
+
+To set timeout intervals on different tests in the same file, use the [`timeout` option on each individual test](GlobalAPI.md#testname-fn-timeout).
+
+If you want to set the timeout for all test files, use [`testTimeout`](Configuration.md#testtimeout-number) configuration option.
+
+:::

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -158,22 +158,21 @@ export interface Jest {
    */
   getTimerCount(): number;
   /**
-   * Returns the current time in ms of the fake timer clock.
-   */
-  now(): number;
-  /**
-   * Determines if the given function is a mocked function.
-   */
-  isMockFunction: ModuleMocker['isMockFunction'];
-  /**
    * Returns `true` if test environment has been torn down.
+   *
    * @example
+   * ```js
    * if (jest.isEnvironmentTornDown()) {
    *   // The Jest environment has been torn down, so stop doing work
    *   return;
    * }
+   * ```
    */
   isEnvironmentTornDown(): boolean;
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction: ModuleMocker['isMockFunction'];
   /**
    * `jest.isolateModules()` goes a step further than `jest.resetModules()` and
    * creates a sandbox registry for the modules that are loaded inside the callback
@@ -204,6 +203,23 @@ export interface Jest {
     options?: {virtual?: boolean},
   ): Jest;
   /**
+   * Wraps types of the `source` object and its deep members with type definitions
+   * of Jest mock function. Pass `{shallow: true}` option to disable the deeply
+   * mocked behavior.
+   */
+  mocked: ModuleMocker['mocked'];
+  /**
+   * Returns the current time in ms of the fake timer clock.
+   */
+  now(): number;
+  /**
+   * Replaces property on an object with another value.
+   *
+   * @remarks
+   * For mocking functions or 'get' or 'set' accessors, use `jest.spyOn()` instead.
+   */
+  replaceProperty: ModuleMocker['replaceProperty'];
+  /**
    * Returns the actual module instead of a mock, bypassing all checks on
    * whether the module should receive a mock implementation or not.
    *
@@ -226,19 +242,6 @@ export interface Jest {
    * ```
    */
   requireActual<T = unknown>(moduleName: string): T;
-  /**
-   * Wraps types of the `source` object and its deep members with type definitions
-   * of Jest mock function. Pass `{shallow: true}` option to disable the deeply
-   * mocked behavior.
-   */
-  mocked: ModuleMocker['mocked'];
-  /**
-   * Replaces property on an object with another value.
-   *
-   * @remarks
-   * For mocking functions or 'get' or 'set' accessors, use `jest.spyOn()` instead.
-   */
-  replaceProperty: ModuleMocker['replaceProperty'];
   /**
    * Returns a mock module instead of the actual module, bypassing all checks
    * on whether the module should be required normally or not.
@@ -278,7 +281,6 @@ export interface Jest {
     numRetries: number,
     options?: {logErrorsBeforeRetry?: boolean},
   ): Jest;
-
   /**
    * Exhausts tasks queued by `setImmediate()`.
    *


### PR DESCRIPTION
## Summary

Some clean up in the `Jest` interface to keep alphabetical order of members.

## Test plan

Green CI.
