### PR TITLE
docs: add documentation of the `jest.deepUnmock()` method

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -364,6 +364,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -286,6 +286,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -290,6 +290,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -290,6 +290,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-28.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.x/JestObjectAPI.md
@@ -290,6 +290,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-29.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.0/JestObjectAPI.md
@@ -332,6 +332,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-29.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.1/JestObjectAPI.md
@@ -364,6 +364,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-29.2/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.2/JestObjectAPI.md
@@ -364,6 +364,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.

--- a/website/versioned_docs/version-29.3/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.3/JestObjectAPI.md
@@ -364,6 +364,12 @@ The most common use of this API is for specifying the module a given test intend
 
 Returns the `jest` object for chaining.
 
+### `jest.deepUnmock(moduleName)`
+
+Indicates that the module system should never return a mocked version of the specified module and its dependencies.
+
+Returns the `jest` object for chaining.
+
 ### `jest.doMock(moduleName, factory, options)`
 
 When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use this method if you want to explicitly avoid this behavior.


### PR DESCRIPTION
## Summary

The `jest.deepUnmock()` method was added long time ago (see #1188), but for some reason wasn’t documented.

## Test plan

Deploy preview.
