### PR TITLE
docs: fix one of `mockFn.mockImplementation()` TS examples

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()

--- a/website/versioned_docs/version-28.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-28.x/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()

--- a/website/versioned_docs/version-29.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.0/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()

--- a/website/versioned_docs/version-29.1/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.1/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()

--- a/website/versioned_docs/version-29.2/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.2/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()

--- a/website/versioned_docs/version-29.3/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.3/MockFunctionAPI.md
@@ -163,6 +163,8 @@ mockFn(3); // 39
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest.fn((scalar: number) => 42 + scalar);
 
 mockFn(0); // 42
@@ -207,12 +209,13 @@ export class SomeClass {
 ```
 
 ```ts title="SomeClass.test.ts"
+import {jest} from '@jest/globals';
 import {SomeClass} from './SomeClass';
 
 jest.mock('./SomeClass'); // this happens automatically with automocking
 
 const mockMethod = jest.fn<(a: string, b: string) => void>();
-SomeClass.mockImplementation(() => {
+jest.mocked(SomeClass).mockImplementation(() => {
   return {
     method: mockMethod,
   };
@@ -239,6 +242,8 @@ mockFn((err, val) => console.log(val)); // false
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<(cb: (a: null, b: boolean) => void) => void>()
   .mockImplementationOnce(cb => cb(null, true))
@@ -315,6 +320,8 @@ mock(); // 43
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mock = jest.fn<() => number>();
 
 mock.mockReturnValue(42);
@@ -348,6 +355,8 @@ mockFn(); // 'default'
 ```
 
 ```ts tab
+import {jest} from '@jest/globals';
+
 const mockFn = jest
   .fn<() => string>()
   .mockReturnValue('default')
@@ -379,6 +388,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest.fn<() => Promise<number>>().mockResolvedValue(43);
 
@@ -412,6 +423,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()
@@ -447,6 +460,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<never>>()
@@ -479,6 +494,8 @@ test('async test', async () => {
 ```
 
 ```ts tab
+import {jest, test} from '@jest/globals';
+
 test('async test', async () => {
   const asyncMock = jest
     .fn<() => Promise<string>>()


### PR DESCRIPTION
## Summary

As it was noticed in https://github.com/facebook/jest/issues/13763#issuecomment-1384100254, one of `mockFn.mockImplementation()` TS examples is missing `jest.mocked()`. Because of that current example has a type error. This PR adds that missing `jest.mocked()`.

I also thought it would be good to add explicit `import {jest} from '@jest/globals'` to each of TS examples to make them copy-pastable. At first it felt like having more lines in TS tab could introduce some jumping, if a user would switch between the tabs. The preview shows that everything is smooth. So I think it is worth to add the explicit imports for completeness.

## Test plan

Deploy preview.