### PR TITLE
refactor(resolve): use `resolve.exports` for `imports`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `[jest-config, jest-worker]` Use `os.availableParallelism` if available to calculate number of workers to spawn ([#13738](https://github.com/facebook/jest/pull/13738))
 - `[@jest/globals, jest-mock]` Add `jest.replaceProperty()` that replaces property value ([#13496](https://github.com/facebook/jest/pull/13496))
 - `[jest-haste-map]` ignore Sapling vcs directories (`.sl/`) ([#13674](https://github.com/facebook/jest/pull/13674))
-- `[jest-resolve]` Support subpath imports ([#13705](https://github.com/facebook/jest/pull/13705), [#13723](https://github.com/facebook/jest/pull/13723))
+- `[jest-resolve]` Support subpath imports ([#13705](https://github.com/facebook/jest/pull/13705), [#13723](https://github.com/facebook/jest/pull/13723)), [#13777](https://github.com/facebook/jest/pull/13777))
 - `[jest-runtime]` Add `jest.isolateModulesAsync` for scoped module initialization of asynchronous functions ([#13680](https://github.com/facebook/jest/pull/13680))
 - `[jest-runtime]` Add `jest.isEnvironmentTornDown` function ([#13698](https://github.com/facebook/jest/pull/13698))
 - `[jest-test-result]` Added `skipped` and `focused` status to `FormattedTestResult` ([#13700](https://github.com/facebook/jest/pull/13700))

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -24,8 +24,7 @@
     "jest-util": "workspace:^",
     "jest-validate": "workspace:^",
     "resolve": "^1.20.0",
-    "resolve.exports": "^1.1.1",
-    "resolve.imports": "^2.0.3",
+    "resolve.exports": "^2.0.0",
     "slash": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -397,14 +397,7 @@ describe('findNodeModule', () => {
           basedir: path.resolve(importsRoot, './foo-import/index.js'),
           conditions: [],
         });
-      }).toThrow(
-        expect.objectContaining({
-          code: 'ERR_PACKAGE_IMPORT_NOT_DEFINED',
-          message: expect.stringMatching(
-            /^Package import specifier "#something-else" is not defined in package/,
-          ),
-        }),
-      );
+      }).toThrow('Missing "#something-else" specifier in "foo-import" package');
     });
   });
 });

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -153,10 +153,10 @@ function getPathInModule(
     if (resolved) {
       const target = resolved[0];
       return target.startsWith('.')
-        // internal relative filepath
-        ? pathResolve(dirname(closestPackageJson), target)
-        // this is an external module, re-resolve it
-        : defaultResolver(target, options);
+        ? // internal relative filepath
+          pathResolve(dirname(closestPackageJson), target)
+        : // this is an external module, re-resolve it
+          defaultResolver(target, options);
     }
 
     if (pkg.imports) {
@@ -240,11 +240,10 @@ function createResolveOptions(
       {browser: false, require: true};
 }
 
-function createImportsResolveOptions(conditions: Array<string> | undefined): resolve.Options {
-  return {
-    unsafe: true,
-    conditions: conditions || ['node', 'require']
-  };
+function createImportsResolveOptions(
+  conditions = ['node', 'require'],
+): resolve.Options {
+  return {conditions, unsafe: true};
 }
 
 // if it's a relative import or an absolute path, imports/exports are ignored

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -8,11 +8,7 @@
 import {dirname, isAbsolute, resolve as pathResolve} from 'path';
 import pnpResolver from 'jest-pnp-resolver';
 import {SyncOpts as UpstreamResolveOptions, sync as resolveSync} from 'resolve';
-import {
-  Options as ResolveExportsOptions,
-  resolve as resolveExports,
-} from 'resolve.exports';
-import {resolve as resolveImports} from 'resolve.imports';
+import * as resolve from 'resolve.exports';
 import {
   findClosestPackageJson,
   isDirectory,
@@ -148,28 +144,26 @@ function getPathInModule(
 
     const pkg = readPackageCached(closestPackageJson);
 
-    const resolved = resolveImports(
-      {
-        base: options.basedir,
-        content: pkg,
-        path: dirname(closestPackageJson),
-      },
-      path,
+    const resolved = resolve.imports(
+      pkg,
+      path as resolve.Imports.Entry,
       createImportsResolveOptions(options.conditions),
     );
 
-    if (!resolved) {
+    if (resolved) {
+      const target = resolved[0];
+      return target.startsWith('.')
+        // internal relative filepath
+        ? pathResolve(dirname(closestPackageJson), target)
+        // this is an external module, re-resolve it
+        : defaultResolver(target, options);
+    }
+
+    if (pkg.imports) {
       throw new Error(
         '`imports` exists, but no results - this is a bug in Jest. Please report an issue',
       );
     }
-
-    if (resolved.startsWith('.')) {
-      return pathResolve(dirname(closestPackageJson), resolved);
-    }
-
-    // this is an external module, re-resolve it
-    return defaultResolver(resolved, options);
   }
 
   const segments = path.split('/');
@@ -186,22 +180,22 @@ function getPathInModule(
     if (closestPackageJson) {
       const pkg = readPackageCached(closestPackageJson);
 
-      if (pkg.name === moduleName && pkg.exports) {
-        const subpath = segments.join('/') || '.';
-
-        const resolved = resolveExports(
+      if (pkg.name === moduleName) {
+        const resolved = resolve.exports(
           pkg,
-          subpath,
+          (segments.join('/') || '.') as resolve.Exports.Entry,
           createResolveOptions(options.conditions),
         );
 
-        if (!resolved) {
+        if (resolved) {
+          return pathResolve(dirname(closestPackageJson), resolved[0]);
+        }
+
+        if (pkg.exports) {
           throw new Error(
             '`exports` exists, but no results - this is a bug in Jest. Please report an issue',
           );
         }
-
-        return pathResolve(dirname(closestPackageJson), resolved);
       }
     }
 
@@ -216,22 +210,20 @@ function getPathInModule(
     if (packageJsonPath && isFile(packageJsonPath)) {
       const pkg = readPackageCached(packageJsonPath);
 
+      const resolved = resolve.exports(
+        pkg,
+        (segments.join('/') || '.') as resolve.Exports.Entry,
+        createResolveOptions(options.conditions),
+      );
+
+      if (resolved) {
+        return pathResolve(dirname(packageJsonPath), resolved[0]);
+      }
+
       if (pkg.exports) {
-        const subpath = segments.join('/') || '.';
-
-        const resolved = resolveExports(
-          pkg,
-          subpath,
-          createResolveOptions(options.conditions),
+        throw new Error(
+          '`exports` exists, but no results - this is a bug in Jest. Please report an issue',
         );
-
-        if (!resolved) {
-          throw new Error(
-            '`exports` exists, but no results - this is a bug in Jest. Please report an issue',
-          );
-        }
-
-        return pathResolve(dirname(packageJsonPath), resolved);
       }
     }
   }
@@ -241,18 +233,17 @@ function getPathInModule(
 
 function createResolveOptions(
   conditions: Array<string> | undefined,
-): ResolveExportsOptions {
+): resolve.Options {
   return conditions
     ? {conditions, unsafe: true}
     : // no conditions were passed - let's assume this is Jest internal and it should be `require`
       {browser: false, require: true};
 }
 
-function createImportsResolveOptions(conditions: Array<string> | undefined) {
+function createImportsResolveOptions(conditions: Array<string> | undefined): resolve.Options {
   return {
-    conditions: conditions
-      ? [...conditions, 'default']
-      : ['node', 'require', 'default'],
+    unsafe: true,
+    conditions: conditions || ['node', 'require']
   };
 }
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -147,7 +147,7 @@ function getPathInModule(
     const resolved = resolve.imports(
       pkg,
       path as resolve.Imports.Entry,
-      createImportsResolveOptions(options.conditions),
+      createResolveOptions(options.conditions),
     );
 
     if (resolved) {
@@ -238,12 +238,6 @@ function createResolveOptions(
     ? {conditions, unsafe: true}
     : // no conditions were passed - let's assume this is Jest internal and it should be `require`
       {browser: false, require: true};
-}
-
-function createImportsResolveOptions(
-  conditions = ['node', 'require'],
-): resolve.Options {
-  return {conditions, unsafe: true};
 }
 
 // if it's a relative import or an absolute path, imports/exports are ignored

--- a/yarn.lock
+++ b/yarn.lock
@@ -12895,8 +12895,7 @@ __metadata:
     jest-util: "workspace:^"
     jest-validate: "workspace:^"
     resolve: ^1.20.0
-    resolve.exports: ^1.1.1
-    resolve.imports: ^2.0.3
+    resolve.exports: ^2.0.0
     slash: ^3.0.0
     tsd-lite: ^0.6.0
   languageName: unknown
@@ -16415,13 +16414,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pattern-key-compare@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "pattern-key-compare@npm:2.0.0"
-  checksum: cded15070cddbc5ef7b97c1b91371bcf59ff931f8afe383d2323f935891e6c4517bd76154f5edc2b1ab53c6fbeeb0711b9db43af592064482d0a9ccf03dd507c
-  languageName: node
-  linkType: hard
-
 "pend@npm:~1.2.0":
   version: 1.2.0
   resolution: "pend@npm:1.2.0"
@@ -18359,19 +18351,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "resolve.exports@npm:1.1.1"
-  checksum: 485aa10082eb388a569d696e17ad7b16f4186efc97dd34eadd029d95b811f21ffee13b1b733198bb4584dbb3cb296aa6f141835221fb7613b9606b84f1386655
-  languageName: node
-  linkType: hard
-
-"resolve.imports@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "resolve.imports@npm:2.0.3"
-  dependencies:
-    pattern-key-compare: ^2.0.0
-  checksum: 155ae4a32ccc1da7ad12b88f6c748dd1e038092838e537de1066248c32a197b42489810da6070bb2bd0dd954e8abbe841b09282c0806c5493b2e49e8f7e29632
+"resolve.exports@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "resolve.exports@npm:2.0.0"
+  checksum: d8bee3b0cc0a0ae6c8323710983505bc6a3a2574f718e96f01e048a0f0af035941434b386cc9efc7eededc5e1199726185c306ec6f6a1aa55d5fbad926fd0634
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Update [`resolve.exports`](https://github.com/lukeed/resolve.exports) to the `2.0` release, which now supports the `"imports"` map and correctly supports subpath patterns, array'd & nullable entries.

* Related: #13723
* Related: https://github.com/lukeed/resolve.exports/issues/14

## Test plan

Reran the CI pipeline locally:

```sh
$ yarn build
$ yarn test-ci-partial:parallel
```
