### PR TITLE
docs: example how to verify call arguments through asymmetric matchers

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1121,12 +1121,14 @@ test('registration applies correctly to orange La Croix', () => {
 });
 ```
 
-Note that you can use any asymmetric matchers to validate specific arguments, combining it with literal values:
+:::tip
 
-```
+You can also use asymmetric matchers instead of literal values:
+
+```js
 expect(func).toHaveBeenCalledWith(
   expect.anything(),
-  expect.any(MyClass1),
+  expect.any(MyClass),
   42,
   expect.objectContaining({
     name: expect.stringContaining('John')
@@ -1135,6 +1137,7 @@ expect(func).toHaveBeenCalledWith(
 );
 ```
 
+:::
 ### `.toHaveBeenLastCalledWith(arg1, arg2, ...)`
 
 Also under the alias: `.lastCalledWith(arg1, arg2, ...)`

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1121,6 +1121,20 @@ test('registration applies correctly to orange La Croix', () => {
 });
 ```
 
+Note that you can use any asymmetric matchers to validate specific arguments, combining it with literal values:
+
+```
+  expect(func).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.any(MyClass1),
+    42,
+    expect.objectContaining({
+      name: expect.stringContaining('John')
+    }),
+    false
+  );
+```
+
 ### `.toHaveBeenLastCalledWith(arg1, arg2, ...)`
 
 Also under the alias: `.lastCalledWith(arg1, arg2, ...)`

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1124,15 +1124,15 @@ test('registration applies correctly to orange La Croix', () => {
 Note that you can use any asymmetric matchers to validate specific arguments, combining it with literal values:
 
 ```
-  expect(func).toHaveBeenCalledWith(
-    expect.anything(),
-    expect.any(MyClass1),
-    42,
-    expect.objectContaining({
-      name: expect.stringContaining('John')
-    }),
-    false
-  );
+expect(func).toHaveBeenCalledWith(
+  expect.anything(),
+  expect.any(MyClass1),
+  42,
+  expect.objectContaining({
+    name: expect.stringContaining('John')
+  }),
+  false
+);
 ```
 
 ### `.toHaveBeenLastCalledWith(arg1, arg2, ...)`


### PR DESCRIPTION
Cross-reference from toHaveBeenCalledWith to asymmetric matchers like expect.anything() or expect.objectContaining() for better clarity

Fixes #11752

## Summary

Docs give an example of usage `expect.anything()` and other asymmetric matchers when defining that matchers. However, people who never used them, will not probably skim the doc page(which is - yes, for a reason - but long). Up to my experience with my colleagues, ~50% knows about using asymmetric matchers for arguments validation and start to use `expect(mockFn.mock.calls[0][1]).toEqual(someLiteral)` instead. 

So mentioning that for `toHaveBeenCalledWith` I also target people who have never used asymmetric matchers before. I know such developers, however I know nobody who never used `toHaveBeen...Called...()`.

Decided not to put the same block into `toHaveBeenLastCalledWith` and `toHaveBeenNthCalledWith` again.

## Test plan