### PR TITLE
docs: clean up `expect.extend` documentation

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -203,40 +203,7 @@ expect.extend({
 });
 ```
 
-:::note
-
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
-
-```ts title="toBeWithinRange.ts"
-expect.extend({
-  toBeWithinRange(received: number, floor: number, ceiling: number) {
-    // ...
-  },
-});
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeWithinRange(a: number, b: number): R;
-    }
-  }
-}
-```
-
-If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
-
-```ts
-interface CustomMatchers<R = unknown> {
-  toBeWithinRange(floor: number, ceiling: number): R;
-}
-declare global {
-  namespace jest {
-    interface Expect extends CustomMatchers {}
-    interface Matchers<R> extends CustomMatchers<R> {}
-    interface InverseAsymmetricMatchers extends CustomMatchers {}
-  }
-}
-export {};
-```
+:::
 
 #### Async Matchers
 

--- a/website/versioned_docs/version-29.1/ExpectAPI.md
+++ b/website/versioned_docs/version-29.1/ExpectAPI.md
@@ -203,40 +203,7 @@ expect.extend({
 });
 ```
 
-:::note
-
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
-
-```ts title="toBeWithinRange.ts"
-expect.extend({
-  toBeWithinRange(received: number, floor: number, ceiling: number) {
-    // ...
-  },
-});
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeWithinRange(a: number, b: number): R;
-    }
-  }
-}
-```
-
-If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
-
-```ts
-interface CustomMatchers<R = unknown> {
-  toBeWithinRange(floor: number, ceiling: number): R;
-}
-declare global {
-  namespace jest {
-    interface Expect extends CustomMatchers {}
-    interface Matchers<R> extends CustomMatchers<R> {}
-    interface InverseAsymmetricMatchers extends CustomMatchers {}
-  }
-}
-export {};
-```
+:::
 
 #### Async Matchers
 

--- a/website/versioned_docs/version-29.2/ExpectAPI.md
+++ b/website/versioned_docs/version-29.2/ExpectAPI.md
@@ -203,40 +203,7 @@ expect.extend({
 });
 ```
 
-:::note
-
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
-
-```ts title="toBeWithinRange.ts"
-expect.extend({
-  toBeWithinRange(received: number, floor: number, ceiling: number) {
-    // ...
-  },
-});
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeWithinRange(a: number, b: number): R;
-    }
-  }
-}
-```
-
-If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
-
-```ts
-interface CustomMatchers<R = unknown> {
-  toBeWithinRange(floor: number, ceiling: number): R;
-}
-declare global {
-  namespace jest {
-    interface Expect extends CustomMatchers {}
-    interface Matchers<R> extends CustomMatchers<R> {}
-    interface InverseAsymmetricMatchers extends CustomMatchers {}
-  }
-}
-export {};
-```
+:::
 
 #### Async Matchers
 

--- a/website/versioned_docs/version-29.3/ExpectAPI.md
+++ b/website/versioned_docs/version-29.3/ExpectAPI.md
@@ -203,40 +203,7 @@ expect.extend({
 });
 ```
 
-:::note
-
-In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher in the imported module like this:
-
-```ts title="toBeWithinRange.ts"
-expect.extend({
-  toBeWithinRange(received: number, floor: number, ceiling: number) {
-    // ...
-  },
-});
-declare global {
-  namespace jest {
-    interface Matchers<R> {
-      toBeWithinRange(a: number, b: number): R;
-    }
-  }
-}
-```
-
-If you want to move the typings to a separate file (e.g. `types/jest/index.d.ts`), you may need to an export, e.g.:
-
-```ts
-interface CustomMatchers<R = unknown> {
-  toBeWithinRange(floor: number, ceiling: number): R;
-}
-declare global {
-  namespace jest {
-    interface Expect extends CustomMatchers {}
-    interface Matchers<R> extends CustomMatchers<R> {}
-    interface InverseAsymmetricMatchers extends CustomMatchers {}
-  }
-}
-export {};
-```
+:::
 
 #### Async Matchers
 


### PR DESCRIPTION
## Summary

Just noticed that instructions of declaring additional matchers with `expect.extend` got duplicated somehow. For example, the note on adding an empty `export {}` is present just above.

Also note that this additional note is hijacking the closing `:::` of the `:::tip` above. Also the note does not have closing `:::`. Seems like a copy-paste mistake.

## Test plan

Deploy preview.