### PR TITLE
fix(resolve): remove faulty check for `node:` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[@jest/expect-utils]` `toMatchObject` should handle `Symbol` properties ([#13639](https://github.com/facebook/jest/pull/13639))
 - `[jest-mock]` Fix `mockReset` and `resetAllMocks` `undefined` return value([#13692](https://github.com/facebook/jest/pull/13692))
 - `[jest-resolve]` Add global paths to `require.resolve.paths` ([#13633](https://github.com/facebook/jest/pull/13633))
+- `[jest-resolve]` Correct node core module detection when using `node:` specifiers ([#13806](https://github.com/facebook/jest/pull/13806))
 - `[jest-runtime]` Support WASM files that import JS resources ([#13608](https://github.com/facebook/jest/pull/13608))
 - `[jest-runtime]` Use the `scriptTransformer` cache in `jest-runner` ([#13735](https://github.com/facebook/jest/pull/13735))
 - `[jest-runtime]` Enforce import assertions when importing JSON in ESM ([#12755](https://github.com/facebook/jest/pull/12755))

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:760:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:759:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;
@@ -71,7 +71,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:760:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/resolver.js:759:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -91,11 +91,11 @@ describe('isCoreModule', () => {
     expect(isCore).toBe(true);
   });
 
-  it('returns false if using `node:` URLs and `moduleName` is not a core module.', () => {
+  it('returns true if using `node:` URLs and `moduleName` is not a core module.', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('node:not-a-core-module');
-    expect(isCore).toBe(false);
+    expect(isCore).toBe(true);
   });
 });
 

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -456,9 +456,7 @@ export default class Resolver {
   isCoreModule(moduleName: string): boolean {
     return (
       this._options.hasCoreModules &&
-      (isBuiltinModule(moduleName) ||
-        (moduleName.startsWith('node:') &&
-          isBuiltinModule(moduleName.slice('node:'.length)))) &&
+      (isBuiltinModule(moduleName) || moduleName.startsWith('node:')) &&
       !this._isAliasModule(moduleName)
     );
   }

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1720,7 +1720,7 @@ export default class Runtime {
       return this._getMockedNativeModule();
     }
 
-    return require(moduleWithoutNodePrefix);
+    return require(moduleName);
   }
 
   private _importCoreModule(moduleName: string, context: VMContext) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is wrong - node itself throws:

```sh-session
$ node --eval 'require("node:foobar")'
node:internal/modules/cjs/loader:835
      throw new ERR_UNKNOWN_BUILTIN_MODULE(request);
      ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:foobar
    at new NodeError (node:internal/errors:387:5)
    at Function.Module._load (node:internal/modules/cjs/loader:835:13)
    at Module.require (node:internal/modules/cjs/loader:1067:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at [eval]:1:1
    at Script.runInThisContext (node:vm:129:12)
    at Object.runInThisContext (node:vm:313:38)
    at node:internal/process/execution:79:19
    at [eval]-wrapper:6:22
    at evalScript (node:internal/process/execution:78:60) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
