### PR TITLE
Include symbol keys when diffing objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/expect-utils]` `toMatchObject` diffs should include `Symbol` properties ([#13810](https://github.com/facebook/jest/pull/13810))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -43,6 +43,17 @@ const hasPropertyInObject = (object: object, key: string | symbol): boolean => {
   );
 };
 
+// Retrieves an object's keys for evaluation by getObjectSubset.  This evaluates
+// the prototype chain for string keys but not for symbols.  (Otherwise, it
+// could find values such as a Set or Map's Symbol.toStringTag, with unexpected
+// results.)
+//
+// Compare with subsetEquality's use of Reflect.ownKeys.
+const getObjectKeys = (object: object) => [
+  ...Object.keys(object),
+  ...Object.getOwnPropertySymbols(object),
+];
+
 export const getPath = (
   object: Record<string, any>,
   propertyPath: string | Array<string>,
@@ -131,7 +142,7 @@ export const getObjectSubset = (
     const trimmed: any = {};
     seenReferences.set(object, trimmed);
 
-    Object.keys(object)
+    getObjectKeys(object)
       .filter(key => hasPropertyInObject(subset, key))
       .forEach(key => {
         trimmed[key] = seenReferences.has(object[key])
@@ -144,7 +155,7 @@ export const getObjectSubset = (
             );
       });
 
-    if (Object.keys(trimmed).length > 0) {
+    if (getObjectKeys(trimmed).length > 0) {
       return trimmed;
     }
   }

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -4140,13 +4140,13 @@ exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObjec
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "c", Symbol(jest): Any<String>}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected  - 2</>
+<g>- Expected  - 1</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "c",</>
-<g>-   Symbol(jest): Any<String>,</>
 <r>+   "a": "b",</>
+<d>    Symbol(jest): Any<String>,</>
 <d>  }</>
 `;
 


### PR DESCRIPTION
## Summary

As a result of #13639, `expect.toMatchObject` can now compare symbol keys.  However, the diffs that it generates if a symbol key doesn't match are misleading.

**Note**: In inspecting the code, I wonder if `getObjectSubset` should use the same logic as `subsetEquality` - i.e., if `subsetEquality` does not evaluate an object's inherited string keys when determining equality, then `getObjectSubset` should not evaluate an object's inherited string keys for reporting on inequality? To put it another way - #13639 appears to change `subsetEquality` from considering an object's inherited string keys to not considering inherited string keys, and I'm not sure if that was intentional in a SemVer-minor change.  For now, I've preserved the previous behavior, but let me know if this should change.

## Test plan

See examples from #13809.