### PR TITLE
Not the good promise state ?

### DIFF
--- a/website/versioned_docs/version-29.4/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.4/TestingAsyncCode.md
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a rejected promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {


### PR DESCRIPTION
I might be wrong, but at line 62,
"a <b>fulfilled</b> promise would not fail the test.", instead of "fulfilled" shouldn't it be "rejected". Because we are talking about a promise that will fail the test. If the promise is fulfilled, it means our code run smoothly, so our test must be right ?

I'm still a learner, I might interpret it wrongly.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
