### PR TITLE
feat(jest-core): Add newline after Json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-core]` Add newlines to Json output ([#13817](https://github.com/facebook/jest/pull/13817))
+
 ### Fixes
 
 - `[@jest/expect-utils]` `toMatchObject` diffs should include `Symbol` properties ([#13810](https://github.com/facebook/jest/pull/13810))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-core]` Add newlines to Json output ([#13817](https://github.com/facebook/jest/pull/13817))
+- `[jest-core]` Add newlines to JSON output ([#13817](https://github.com/facebook/jest/pull/13817))
 
 ### Fixes
 

--- a/e2e/__tests__/jsonReporter.test.ts
+++ b/e2e/__tests__/jsonReporter.test.ts
@@ -28,6 +28,8 @@ describe('JSON Reporter', () => {
     runJest('json-reporter', ['--json', `--outputFile=${outputFileName}`]);
     const testOutput = fs.readFileSync(outputFilePath, 'utf8');
 
+    expect(testOutput.endsWith('\n')).toBe(true);
+
     try {
       jsonResult = JSON.parse(testOutput);
     } catch (err: any) {
@@ -71,11 +73,15 @@ describe('JSON Reporter', () => {
   });
 
   it('outputs coverage report', () => {
-    const result = runJest('json-reporter', ['--json']);
+    const result = runJest('json-reporter', ['--json'], {
+      keepTrailingNewline: true,
+    });
     let jsonResult: FormattedTestResults;
 
     expect(result.stderr).toMatch(/1 failed, 1 skipped, 2 passed/);
     expect(result.exitCode).toBe(1);
+
+    expect(result.stdout.endsWith('\n')).toBe(true);
 
     try {
       jsonResult = JSON.parse(result.stdout);

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -20,6 +20,7 @@ import {normalizeIcons} from './Utils';
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 
 type RunJestOptions = {
+  keepTrailingNewline?: boolean; // keep final newline in output from stdout and stderr
   nodeOptions?: string;
   nodePath?: string;
   skipPkgJsonCheck?: boolean; // don't complain if can't find package.json
@@ -97,6 +98,7 @@ function spawnJest(
     cwd: dir,
     env,
     reject: false,
+    stripFinalNewline: !options.keepTrailingNewline,
     timeout: options.timeout || 0,
   };
 

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -106,12 +106,17 @@ const processResults = async (
       const cwd = tryRealpath(process.cwd());
       const filePath = path.resolve(cwd, outputFile);
 
-      fs.writeFileSync(filePath, JSON.stringify(formatTestResults(runResults)));
+      fs.writeFileSync(
+        filePath,
+        `${JSON.stringify(formatTestResults(runResults))}\n`,
+      );
       outputStream.write(
         `Test results written to: ${path.relative(cwd, filePath)}\n`,
       );
     } else {
-      process.stdout.write(JSON.stringify(formatTestResults(runResults)));
+      process.stdout.write(
+        `${JSON.stringify(formatTestResults(runResults))}\n`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
This pull request adds newline characters at the end of Json objects produced with `jest --json`.

This makes it trivial to separate multiple test runs when running `jest --json --watch`. With the current behavior, all result objects will be concatenated without separators, requiring a streaming or custom parser to separate the test runs.

It also makes the output conform to the Unix file specification, which dicates that lines in a text file should end with an `\n`.

Fixes #13816

## Test plan
All existing tests still pass.