### PR TITLE
jest-environment-jsdom: Bump JSDOM to 21.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-environment-jsdom]` Bump `JSDOM` to 21.1.0. `JSDOM`'s API had no breaking changes. ([]())
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -24,7 +24,7 @@
     "@types/node": "*",
     "jest-mock": "workspace:^",
     "jest-util": "workspace:^",
-    "jsdom": "^20.0.0"
+    "jsdom": "^21.0.0"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12705,7 +12705,7 @@ __metadata:
     "@types/node": "*"
     jest-mock: "workspace:^"
     jest-util: "workspace:^"
-    jsdom: ^20.0.0
+    jsdom: ^21.0.0
   peerDependencies:
     canvas: ^2.5.0
   peerDependenciesMeta:
@@ -13414,9 +13414,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^20.0.0":
-  version: 20.0.3
-  resolution: "jsdom@npm:20.0.3"
+"jsdom@npm:^21.0.0":
+  version: 21.1.0
+  resolution: "jsdom@npm:21.1.0"
   dependencies:
     abab: ^2.0.6
     acorn: ^8.8.1
@@ -13449,7 +13449,7 @@ __metadata:
   peerDependenciesMeta:
     canvas:
       optional: true
-  checksum: 6e2ae21db397133a061b270c26d2dbc0b9051733ea3b896a7ece78d79f475ff0974f766a413c1198a79c793159119169f2335ddb23150348fbfdcfa6f3105536
+  checksum: 2c89c72a6f399184ffc8de30bbdd86283086dbd72bb3a40667102d3f12af141c7517ffb78150a3bb6883a654e8c7d0266c3328d1c387a2b9a1fd0729dc537954
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


## Summary

[JSDOM changelog](https://github.com/jsdom/jsdom/blob/master/Changelog.md#2100)

They didn't change any library API. Only bug fixes (backwards incompatible in nature) and features for their DOM implementation. [Perf improvements seem significant](https://github.com/mui/material-ui/pull/35972) so this is worth the upgrade in my opinion

[Types update is pending review](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64121).

## Test plan

- [ ] Test with override in dom-testing-library (will need to upgrade to Jest 29 first)
