### PR TITLE
feat(@jest/expect): Expose type of actual to Matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Features
 
-- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#TBD)
-
 ### Fixes
+
+- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#TBD)
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#TBD)
+- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#13848)
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#13848)
+- `[expect, @jest/expect]` Provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions ([#13848](https://github.com/facebook/jest/pull/13848))
+- ```
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Fixes
 
 - `[expect, @jest/expect]` Provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions ([#13848](https://github.com/facebook/jest/pull/13848))
-- ```
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[@jest/expect]` provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions (#TBD)
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -19,6 +19,7 @@ import {
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 
 type M = Matchers<void>;
+type N = Matchers<void, string>;
 
 expectError(() => {
   type E = Matchers;

--- a/packages/expect/__typetests__/expectTyped.test.ts
+++ b/packages/expect/__typetests__/expectTyped.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {expectAssignable, expectError, expectType} from 'tsd-lite';
+import {Matchers, expect} from 'expect';
+
+declare module 'expect' {
+  interface Matchers<R, T> {
+    toTypedEqual(expected: T): void;
+  }
+}
+
+expectType<void>(expect(100).toTypedEqual(100));
+expectType<void>(expect(101).not.toTypedEqual(101));
+
+expectError(() => {
+  expect(100).toTypedEqual('three');
+});

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -143,7 +143,6 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
    * @internal
    */
   _unusedT(expected: T): R;
-
   /**
    * Ensures the last call to a mock function was provided specific args.
    */

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -134,7 +134,7 @@ type PromiseMatchers = {
   resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
 };
 
-export interface Matchers<R extends void | Promise<void>> {
+export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensures the last call to a mock function was provided specific args.
    */

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -97,9 +97,9 @@ export interface BaseExpect {
 }
 
 export type Expect = {
-  <T = unknown>(actual: T): Matchers<void> &
-    Inverse<Matchers<void>> &
-    PromiseMatchers;
+  <T = unknown>(actual: T): Matchers<void, T> &
+    Inverse<Matchers<void, T>> &
+    PromiseMatchers<T>;
 } & BaseExpect &
   AsymmetricMatchers &
   Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
@@ -121,19 +121,21 @@ export interface AsymmetricMatchers {
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }
 
-type PromiseMatchers = {
+type PromiseMatchers<T = unknown> = {
   /**
    * Unwraps the reason of a rejected promise so any other matcher can be chained.
    * If the promise is fulfilled the assertion fails.
    */
-  rejects: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  rejects: Matchers<Promise<void>, T> & Inverse<Matchers<Promise<void>, T>>;
   /**
    * Unwraps the value of a fulfilled promise so any other matcher can be chained.
    * If the promise is rejected the assertion fails.
    */
-  resolves: Matchers<Promise<void>> & Inverse<Matchers<Promise<void>>>;
+  resolves: Matchers<Promise<void>, T> & Inverse<Matchers<Promise<void>, T>>;
 };
 
+// @ts-expect-error unused variable T (can't use _T since users redeclare Matchers)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * Ensures the last call to a mock function was provided specific args.

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -134,9 +134,16 @@ type PromiseMatchers<T = unknown> = {
   resolves: Matchers<Promise<void>, T> & Inverse<Matchers<Promise<void>, T>>;
 };
 
-// @ts-expect-error unused variable T (can't use _T since users redeclare Matchers)
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface Matchers<R extends void | Promise<void>, T = unknown> {
+  /**
+   * T is a type param for the benefit of users who extend Matchers. It's
+   * intentionally unused and needs to be named T, not _T, for those users.
+   * This makes sure Typescript agrees.
+   *
+   * @internal
+   */
+  _unusedT(expected: T): R;
+
   /**
    * Ensures the last call to a mock function was provided specific args.
    */

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -138,7 +138,7 @@ export interface Matchers<R extends void | Promise<void>, T = unknown> {
   /**
    * T is a type param for the benefit of users who extend Matchers. It's
    * intentionally unused and needs to be named T, not _T, for those users.
-   * This makes sure Typescript agrees.
+   * This makes sure TypeScript agrees.
    *
    * @internal
    */

--- a/packages/jest-expect/__typetests__/jest-expect.test.ts
+++ b/packages/jest-expect/__typetests__/jest-expect.test.ts
@@ -29,3 +29,16 @@ expectError(() => {
 
 expectAssignable<typeof expect>(jestExpect);
 expectNotAssignable<typeof jestExpect>(expect);
+
+declare module 'expect' {
+  interface Matchers<R, T> {
+    toTypedEqual(expected: T): void;
+  }
+}
+
+expectType<void>(jestExpect(100).toTypedEqual(100));
+expectType<void>(jestExpect(101).not.toTypedEqual(101));
+
+expectError(() => {
+  jestExpect(100).toTypedEqual('three');
+});

--- a/packages/jest-expect/src/types.ts
+++ b/packages/jest-expect/src/types.ts
@@ -29,7 +29,7 @@ type Inverse<Matchers> = {
   not: Matchers;
 };
 
-type JestMatchers<R extends void | Promise<void>, T> = Matchers<R> &
+type JestMatchers<R extends void | Promise<void>, T> = Matchers<R, T> &
   SnapshotMatchers<R, T>;
 
 type PromiseMatchers<T = unknown> = {


### PR DESCRIPTION
## Summary

Matchers isn't as typed as some users would like (see #13334, #13812). For users who want to customize it by extending the `Matchers` interface, it's useful to have access to the type of `actual` (the argument of `expect`) so you can do, say,
```ts
interface Matchers<R, T> {
    toTypedEqual(expected: T): R
}
```
This commit exposes it. The first-party matchers still have the same types as before.

## Test Plan

typecheck