### PR TITLE
chore: use `glob` to select files in `buildTs` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "execa": "^5.0.0",
     "find-process": "^1.4.1",
     "glob": "^8.0.0",
-    "globby": "^11.0.1",
     "graceful-fs": "^4.2.9",
     "isbinaryfile": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",

--- a/scripts/buildTs.mjs
+++ b/scripts/buildTs.mjs
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
 import execa from 'execa';
-import globby from 'globby';
+import glob from 'glob';
 import fs from 'graceful-fs';
 import pLimit from 'p-limit';
 import stripJsonComments from 'strip-json-comments';
@@ -125,12 +125,13 @@ try {
   await Promise.all(
     packagesWithTs.map(({packageDir, pkg}) =>
       mutex(async () => {
-        const buildDir = path.resolve(packageDir, 'build/**/*.d.ts');
-
-        const globbed = await globby([buildDir]);
+        const matched = await glob.sync('build/**/*.d.ts', {
+          absolute: true,
+          cwd: packageDir,
+        });
 
         const files = await Promise.all(
-          globbed.map(file =>
+          matched.map(file =>
             Promise.all([file, fs.promises.readFile(file, 'utf8')]),
           ),
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2819,7 +2819,6 @@ __metadata:
     execa: ^5.0.0
     find-process: ^1.4.1
     glob: ^8.0.0
-    globby: ^11.0.1
     graceful-fs: ^4.2.9
     isbinaryfile: ^5.0.0
     istanbul-lib-coverage: ^3.0.0


### PR DESCRIPTION
## Summary

Just like other scripts in this repo, the `buildTs` script could use `glob` to select files. This change makes it possible to remove one dev dependency. Less efforts to maintain the repo (;

## Test plan

Green CI.
