### PR TITLE
feat(jest-core): Add performance markers around significant lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## main
 
 ### Features
-- `[@jest/core]` Instrument significant lifecycle events with [`performance.mark()`](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#performancemarkname-options) ([#13859]((https://github.com/facebook/jest/pull/13859)))
+
+- `[@jest/core]` Instrument significant lifecycle events with [`performance.mark()`](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#performancemarkname-options) ([#13859](https://github.com/facebook/jest/pull/13859))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## main
 
 ### Features
+- `[@jest/core]` Instrument significant lifecycle events with [`performance.mark()`](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#performancemarkname-options) ([#13859]((https://github.com/facebook/jest/pull/13859)))
 
-### Fixes
+- ### Fixes
 
 - `[expect, @jest/expect]` Provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions ([#13848](https://github.com/facebook/jest/pull/13848))
 - `[jest-circus]` Added explicit mention of test failing because `done()` is not being called in error message ([#13847](https://github.com/facebook/jest/pull/13847))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 - `[@jest/core]` Instrument significant lifecycle events with [`performance.mark()`](https://nodejs.org/docs/latest-v16.x/api/perf_hooks.html#performancemarkname-options) ([#13859]((https://github.com/facebook/jest/pull/13859)))
 
-- ### Fixes
+### Fixes
 
 - `[expect, @jest/expect]` Provide type of `actual` as a generic argument to `Matchers` to allow better-typed extensions ([#13848](https://github.com/facebook/jest/pull/13848))
 - `[jest-circus]` Added explicit mention of test failing because `done()` is not being called in error message ([#13847](https://github.com/facebook/jest/pull/13847))

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {performance} from 'perf_hooks';
 import chalk = require('chalk');
 import exit = require('exit');
 import * as fs from 'graceful-fs';
@@ -41,6 +42,7 @@ export async function runCLI(
   results: AggregatedResult;
   globalConfig: Config.GlobalConfig;
 }> {
+  performance.mark('jest/runCLI:start');
   let results: AggregatedResult | undefined;
 
   // If we output a JSON object, we can't write anything to stdout, since
@@ -133,6 +135,7 @@ export async function runCLI(
     console.error(message);
   }
 
+  performance.mark('jest/runCLI:end');
   return {globalConfig, results};
 }
 
@@ -173,6 +176,12 @@ const _run10000 = async (
   // Queries to hg/git can take a while, so we need to start the process
   // as soon as possible, so by the time we need the result it's already there.
   const changedFilesPromise = getChangedFilesPromise(globalConfig, configs);
+  if (changedFilesPromise) {
+    performance.mark('jest/getChangedFiles:start');
+    changedFilesPromise.finally(() => {
+      performance.mark('jest/getChangedFiles:end');
+    });
+  }
 
   // Filter may need to do an HTTP call or something similar to setup.
   // We will wait on an async response from this before using the filter.
@@ -204,11 +213,13 @@ const _run10000 = async (
     };
   }
 
+  performance.mark('jest/buildContextsAndHasteMaps:start');
   const {contexts, hasteMapInstances} = await buildContextsAndHasteMaps(
     configs,
     globalConfig,
     outputStream,
   );
+  performance.mark('jest/buildContextsAndHasteMaps:end');
 
   globalConfig.watch || globalConfig.watchAll
     ? await runWatch(

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import {performance} from 'perf_hooks';
 import chalk = require('chalk');
 import exit = require('exit');
 import * as fs from 'graceful-fs';
@@ -179,6 +180,7 @@ export default async function runJest({
 
   const searchSources = contexts.map(context => new SearchSource(context));
 
+  performance.mark('jest/getTestPaths:start');
   const testRunData: TestRunData = await Promise.all(
     contexts.map(async (context, index) => {
       const searchSource = searchSources[index];
@@ -195,6 +197,7 @@ export default async function runJest({
       return {context, matches};
     }),
   );
+  performance.mark('jest/getTestPaths:end');
 
   if (globalConfig.shard) {
     if (typeof sequencer.shard !== 'function') {
@@ -260,7 +263,9 @@ export default async function runJest({
   }
 
   if (hasTests) {
+    performance.mark('jest/globalSetup:start');
     await runGlobalHook({allTests, globalConfig, moduleName: 'globalSetup'});
+    performance.mark('jest/globalSetup:end');
   }
 
   if (changedFilesPromise) {
@@ -289,14 +294,24 @@ export default async function runJest({
     ...testSchedulerContext,
   });
 
+  // @ts-expect-error - second arg is unsupported (but harmless) in Node 14
+  performance.mark('jest/scheduleAndRun:start', {
+    detail: {numTests: allTests.length},
+  });
   const results = await scheduler.scheduleTests(allTests, testWatcher);
+  performance.mark('jest/scheduleAndRun:start');
 
+  performance.mark('jest/cacheResults:start');
   sequencer.cacheResults(allTests, results);
+  performance.mark('jest/cacheResults:end');
 
   if (hasTests) {
+    performance.mark('jest/globalTeardown:start');
     await runGlobalHook({allTests, globalConfig, moduleName: 'globalTeardown'});
+    performance.mark('jest/globalTeardown:end');
   }
 
+  performance.mark('jest/processResults:start');
   await processResults(results, {
     collectHandles,
     json: globalConfig.json,
@@ -305,4 +320,5 @@ export default async function runJest({
     outputStream,
     testResultsProcessor: globalConfig.testResultsProcessor,
   });
+  performance.mark('jest/processResults:end');
 }


### PR DESCRIPTION
## Summary

I'd like to upstream some of the work we've been doing over in Metro to improve startup times (particularly with an overhaul of `jest-haste-map` that started by [forking it](https://github.com/facebook/metro/pull/812)), and possibly carve out some time to optimise other areas of Jest startup. A first step (especially to get some buy-in at Meta!) is instrumentation - this PR is a stab at adding some key markers via the standard global `performance` API.

I'm not wedded to this implementation - open to bikeshedding about labels, abstraction, or if there's a pre-existing Jest instrumentation pattern I'd missed, but I'm particularly looking for *some* way to time the startup independently of running tests.

## Test plan

Running Jest programmatically in a thin wrapper allows performance data to be gathered:

```js
'use strict';

const {performance} = require('perf_hooks');

if (process.env.NODE_ENV == null) {
  process.env.NODE_ENV = 'test';
}

require('jest-cli')
  .run()
  .then(() => {
    console.log(performance.getEntries());
  });
```

```
[
  PerformanceMark {
    name: 'jest/runCLI:start',
    entryType: 'mark',
    startTime: 179.9593139886856,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/buildContextsAndHasteMaps:start',
    entryType: 'mark',
    startTime: 269.55708903074265,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/buildContextsAndHasteMaps:end',
    entryType: 'mark',
    startTime: 1525.8082609772682,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/getTestRunData:start',
    entryType: 'mark',
    startTime: 1535.9708949923515,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/getTestRunData:end',
    entryType: 'mark',
    startTime: 2911.5280399918556,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/globalSetup:start',
    entryType: 'mark',
    startTime: 2928.4168980121613,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/globalSetup:end',
    entryType: 'mark',
    startTime: 2928.6306880116463,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/scheduleAndRun:start',
    entryType: 'mark',
    startTime: 2938.5601339936256,
    duration: 0,
    detail: { numTests: 1 }
  },
  PerformanceMark {
    name: 'jest/scheduleAndRun:start',
    entryType: 'mark',
    startTime: 5480.210482001305,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/cacheResults:start',
    entryType: 'mark',
    startTime: 5480.292959034443,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/cacheResults:end',
    entryType: 'mark',
    startTime: 5480.848489999771,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/globalTeardown:start',
    entryType: 'mark',
    startTime: 5480.870894014835,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/globalTeardown:end',
    entryType: 'mark',
    startTime: 5480.897032022476,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/processResults:start',
    entryType: 'mark',
    startTime: 5480.90157699585,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/processResults:end',
    entryType: 'mark',
    startTime: 5481.04110699892,
    duration: 0,
    detail: null
  },
  PerformanceMark {
    name: 'jest/runCLI:end',
    entryType: 'mark',
    startTime: 5481.130716025829,
    duration: 0,
    detail: null
  }
]
```
