### PR TITLE
fix(jest-mock): do not restore mocks when `jest.resetAllMocks()` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-mock]` Clear mock state when `jest.restoreAllMocks()` is called ([#13867](https://github.com/facebook/jest/pull/13867))
+- `[jest-mock]` Do not restore mocks when `jest.resetAllMocks()` is called ([#13866](https://github.com/facebook/jest/pull/13866))
 
 ### Chore & Maintenance
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1380,8 +1380,8 @@ describe('moduleMocker', () => {
     });
 
     it('supports resetting all spies', () => {
-      const methodOneReturn = 0;
-      const methodTwoReturn = 0;
+      const methodOneReturn = 10;
+      const methodTwoReturn = 20;
       const obj = {
         methodOne() {
           return methodOneReturn;
@@ -1391,14 +1391,14 @@ describe('moduleMocker', () => {
         },
       };
 
-      moduleMocker.spyOn(obj, 'methodOne').mockReturnValue(10);
-      moduleMocker.spyOn(obj, 'methodTwo').mockReturnValue(20);
+      moduleMocker.spyOn(obj, 'methodOne').mockReturnValue(100);
+      moduleMocker.spyOn(obj, 'methodTwo').mockReturnValue(200);
 
       // Return values are mocked.
-      expect(methodOneReturn).toBe(0);
-      expect(methodTwoReturn).toBe(0);
-      expect(obj.methodOne()).toBe(10);
-      expect(obj.methodTwo()).toBe(20);
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne()).toBe(100);
+      expect(obj.methodTwo()).toBe(200);
 
       expect(moduleMocker.isMockFunction(obj.methodOne)).toBe(true);
       expect(moduleMocker.isMockFunction(obj.methodTwo)).toBe(true);
@@ -1410,10 +1410,10 @@ describe('moduleMocker', () => {
       expect(moduleMocker.isMockFunction(obj.methodTwo)).toBe(true);
 
       // After resetting all mocks, the methods return the original return value.
-      expect(methodOneReturn).toBe(0);
-      expect(methodTwoReturn).toBe(0);
-      expect(obj.methodOne()).toBe(0);
-      expect(obj.methodTwo()).toBe(0);
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne()).toBe(10);
+      expect(obj.methodTwo()).toBe(20);
     });
 
     it('supports restoring a spy', () => {
@@ -1623,6 +1623,59 @@ describe('moduleMocker', () => {
       );
     });
 
+    it('supports resetting a spy', () => {
+      const methodOneReturn = 0;
+      const obj = {
+        get methodOne() {
+          return methodOneReturn;
+        },
+      };
+
+      const spy1 = moduleMocker
+        .spyOn(obj, 'methodOne', 'get')
+        .mockReturnValue(10);
+
+      // Return value is mocked.
+      expect(methodOneReturn).toBe(0);
+      expect(obj.methodOne).toBe(10);
+
+      spy1.mockReset();
+
+      // After resetting the spy, the method returns the original return value.
+      expect(methodOneReturn).toBe(0);
+      expect(obj.methodOne).toBe(0);
+    });
+
+    it('supports resetting all spies', () => {
+      const methodOneReturn = 10;
+      const methodTwoReturn = 20;
+      const obj = {
+        get methodOne() {
+          return methodOneReturn;
+        },
+        get methodTwo() {
+          return methodTwoReturn;
+        },
+      };
+
+      moduleMocker.spyOn(obj, 'methodOne', 'get').mockReturnValue(100);
+      moduleMocker.spyOn(obj, 'methodTwo', 'get').mockReturnValue(200);
+
+      // Return values are mocked.
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne).toBe(100);
+      expect(obj.methodTwo).toBe(200);
+
+      moduleMocker.resetAllMocks();
+
+      // After resetting all mocks, the methods return the original return value.
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne).toBe(10);
+      expect(obj.methodTwo).toBe(20);
+    });
+
     it('supports restoring a spy', () => {
       let methodOneCalls = 0;
       const obj = {
@@ -1753,6 +1806,61 @@ describe('moduleMocker', () => {
       obj.property = true;
       expect(spy).not.toHaveBeenCalled();
       expect(obj.property).toBe(true);
+    });
+
+    it('supports resetting a spy on the prototype chain', () => {
+      const methodOneReturn = 0;
+      const prototype = {
+        get methodOne() {
+          return methodOneReturn;
+        },
+      };
+      const obj = Object.create(prototype, {});
+
+      const spy1 = moduleMocker
+        .spyOn(obj, 'methodOne', 'get')
+        .mockReturnValue(10);
+
+      // Return value is mocked.
+      expect(methodOneReturn).toBe(0);
+      expect(obj.methodOne).toBe(10);
+
+      spy1.mockReset();
+
+      // After resetting the spy, the method returns the original return value.
+      expect(methodOneReturn).toBe(0);
+      expect(obj.methodOne).toBe(0);
+    });
+
+    it('supports resetting all spies on the prototype chain', () => {
+      const methodOneReturn = 10;
+      const methodTwoReturn = 20;
+      const prototype = {
+        get methodOne() {
+          return methodOneReturn;
+        },
+        get methodTwo() {
+          return methodTwoReturn;
+        },
+      };
+      const obj = Object.create(prototype, {});
+
+      moduleMocker.spyOn(obj, 'methodOne', 'get').mockReturnValue(100);
+      moduleMocker.spyOn(obj, 'methodTwo', 'get').mockReturnValue(200);
+
+      // Return values are mocked.
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne).toBe(100);
+      expect(obj.methodTwo).toBe(200);
+
+      moduleMocker.resetAllMocks();
+
+      // After resetting all mocks, the methods return the original return value.
+      expect(methodOneReturn).toBe(10);
+      expect(methodTwoReturn).toBe(20);
+      expect(obj.methodOne).toBe(10);
+      expect(obj.methodTwo).toBe(20);
     });
 
     it('supports restoring a spy on the prototype chain', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1440,13 +1440,14 @@ export class ModuleMocker {
   }
 
   resetAllMocks(): void {
-    this.clearAllMocks();
+    this._mockState = new WeakMap();
     this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.reset?.());
   }
 
   restoreAllMocks(): void {
-    this.resetAllMocks();
+    this._mockState = new WeakMap();
+    this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.restore());
     this._spyState = new Set();
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -787,7 +787,7 @@ export class ModuleMocker {
       };
 
       f.mockRestore = () => {
-        f.mockClear().mockReset();
+        f.mockReset();
 
         if (spyState != null) {
           spyState.restore();

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -787,7 +787,8 @@ export class ModuleMocker {
       };
 
       f.mockRestore = () => {
-        f.mockReset();
+        f.mockClear();
+        this._mockConfigRegistry.delete(f);
 
         if (spyState != null) {
           spyState.restore();
@@ -1447,7 +1448,8 @@ export class ModuleMocker {
   }
 
   restoreAllMocks(): void {
-    this.resetAllMocks();
+    this.clearAllMocks();
+    this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.restore());
     this._spyState = new Set();
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -787,7 +787,7 @@ export class ModuleMocker {
       };
 
       f.mockRestore = () => {
-        f.mockReset();
+        f.mockClear();
 
         if (spyState != null) {
           spyState.restore();
@@ -1439,12 +1439,13 @@ export class ModuleMocker {
   }
 
   resetAllMocks(): void {
-    this._mockConfigRegistry = new WeakMap();
     this._mockState = new WeakMap();
+    this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.reset?.());
   }
 
   restoreAllMocks(): void {
+    this._mockState = new WeakMap();
     this._spyState.forEach(spyState => spyState.restore());
     this._spyState = new Set();
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1301,7 +1301,12 @@ export class ModuleMocker {
         {type: 'function'},
         {
           reset: () => {
-            // TODO
+            (descriptor![accessType] as Mock).mockImplementation(function (
+              this: unknown,
+            ) {
+              // @ts-expect-error - wrong context
+              return original.apply(this, arguments);
+            });
           },
           restore: () => {
             // @ts-expect-error: mock is assignable

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -787,8 +787,7 @@ export class ModuleMocker {
       };
 
       f.mockRestore = () => {
-        f.mockClear();
-        this._mockConfigRegistry.delete(f);
+        f.mockClear().mockReset();
 
         if (spyState != null) {
           spyState.restore();

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1122,7 +1122,7 @@ export class ModuleMocker {
     mock: Mock<UnknownFunction>,
     original: T,
   ) {
-    mock.mockImplementation(function (this: unknown) {
+    mock.mockImplementation?.(function (this: unknown) {
       return original.apply(this, arguments);
     });
   }
@@ -1440,14 +1440,13 @@ export class ModuleMocker {
   }
 
   resetAllMocks(): void {
-    this._mockState = new WeakMap();
+    this.clearAllMocks();
     this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.reset?.());
   }
 
   restoreAllMocks(): void {
-    this._mockState = new WeakMap();
-    this._mockConfigRegistry = new WeakMap();
+    this.resetAllMocks();
     this._spyState.forEach(spyState => spyState.restore());
     this._spyState = new Set();
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -791,6 +791,7 @@ export class ModuleMocker {
 
         if (spyState != null) {
           spyState.restore();
+          this._spyState.delete(spyState);
         }
       };
 
@@ -1122,7 +1123,7 @@ export class ModuleMocker {
     mock: Mock<UnknownFunction>,
     original: T,
   ) {
-    mock.mockImplementation?.(function (this: unknown) {
+    mock.mockImplementation(function (this: unknown) {
       return original.apply(this, arguments);
     });
   }

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -788,6 +788,7 @@ export class ModuleMocker {
 
       f.mockRestore = () => {
         f.mockClear();
+        this._mockConfigRegistry.delete(f);
 
         if (spyState != null) {
           spyState.restore();

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1440,13 +1440,13 @@ export class ModuleMocker {
   }
 
   resetAllMocks(): void {
-    this._mockState = new WeakMap();
+    this.clearAllMocks();
     this._mockConfigRegistry = new WeakMap();
     this._spyState.forEach(spyState => spyState.reset?.());
   }
 
   restoreAllMocks(): void {
-    this._mockState = new WeakMap();
+    this.resetAllMocks();
     this._spyState.forEach(spyState => spyState.restore());
     this._spyState = new Set();
   }


### PR DESCRIPTION
Fixes #13808

## Summary

As it is described in the issue, currently calling `jest.resetAllMocks()` is restoring mocks instead of resetting them. Trying to fix this.

## Test plan

Unit tests added.