### PR TITLE
refactor(jest-mock): remove unused `specificReturnValues` property

### DIFF
--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -255,7 +255,6 @@ type MockFunctionState<T extends FunctionLike = UnknownFunction> = {
 type MockFunctionConfig = {
   mockImpl: Function | undefined;
   mockName: string;
-  specificReturnValues: Array<unknown>;
   specificMockImpls: Array<Function>;
 };
 
@@ -599,7 +598,6 @@ export class ModuleMocker {
       mockImpl: undefined,
       mockName: 'jest.fn()',
       specificMockImpls: [],
-      specificReturnValues: [],
     };
   }
 


### PR DESCRIPTION
## Summary

The `specificReturnValues` appears to be unused. Seems like any logic which was relying on it was removed in #8398.

## Test plan

Green CI.