### PR TITLE
chore: retry yarn install in e2e tests

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -8,7 +8,12 @@
 import * as path from 'path';
 import * as util from 'util';
 import dedent = require('dedent');
-import {ExecaSyncError, ExecaSyncReturnValue, sync as spawnSync} from 'execa';
+import {
+  ExecaSyncError,
+  SyncOptions as ExecaSyncOptions,
+  ExecaSyncReturnValue,
+  sync as spawnSync,
+} from 'execa';
 import * as fs from 'graceful-fs';
 import which = require('which');
 import type {Config} from '@jest/types';
@@ -19,7 +24,12 @@ export const run = (
   env?: Record<string, string>,
 ): ExecaSyncReturnValue => {
   const args = cmd.split(/\s/).slice(1);
-  const spawnOptions = {cwd, env, preferLocal: false, reject: false};
+  const spawnOptions: ExecaSyncOptions = {
+    cwd,
+    env,
+    preferLocal: false,
+    reject: false,
+  };
   const result = spawnSync(cmd.split(/\s/)[0], args, spawnOptions);
 
   if (result.exitCode !== 0) {
@@ -36,6 +46,9 @@ export const run = (
   return result;
 };
 
+const yarnInstallImmutable = 'yarn install --immutable';
+const yarnInstallNoImmutable = 'yarn install --no-immutable';
+
 export const runYarnInstall = (cwd: string, env?: Record<string, string>) => {
   const lockfilePath = path.resolve(cwd, 'yarn.lock');
   let exists = true;
@@ -46,11 +59,26 @@ export const runYarnInstall = (cwd: string, env?: Record<string, string>) => {
     fs.writeFileSync(lockfilePath, '');
   }
 
-  return run(
-    exists ? 'yarn install --immutable' : 'yarn install --no-immutable',
-    cwd,
-    env,
-  );
+  try {
+    return run(
+      exists ? yarnInstallImmutable : yarnInstallNoImmutable,
+      cwd,
+      env,
+    );
+  } catch (error) {
+    try {
+      // retry once in case of e.g. permission errors
+      return run(
+        fs.readFileSync(lockfilePath, 'utf8').trim().length > 0
+          ? yarnInstallImmutable
+          : yarnInstallNoImmutable,
+        cwd,
+        env,
+      );
+    } catch {
+      throw error;
+    }
+  }
 };
 
 export const linkJestPackage = (packageName: string, cwd: string) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Following up #13881. From what I can see, the errors are `permission denied` when renaming zip archives. A retry should be fine if `install` fails.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
