### PR TITLE
docs: add a note on difference between `toEqual` and `toStrictEqual`

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -646,6 +646,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -746,13 +752,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-25.x/ExpectAPI.md
+++ b/website/versioned_docs/version-25.x/ExpectAPI.md
@@ -1198,7 +1198,17 @@ describe('the La Croix cans on my desk', () => {
 });
 ```
 
-> Note: `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+:::tip
+
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
+`.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+
+:::
 
 If differences between properties do not help you to understand why a test fails, especially if the report is large, then you might move the comparison into the `expect` function. For example, use `equals` method of `Buffer` class to assert whether or not buffers contain the same content:
 
@@ -1296,13 +1306,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-25.x/UsingMatchers.md
+++ b/website/versioned_docs/version-25.x/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-26.x/ExpectAPI.md
+++ b/website/versioned_docs/version-26.x/ExpectAPI.md
@@ -1198,7 +1198,17 @@ describe('the La Croix cans on my desk', () => {
 });
 ```
 
-> Note: `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+:::tip
+
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
+`.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+
+:::
 
 If differences between properties do not help you to understand why a test fails, especially if the report is large, then you might move the comparison into the `expect` function. For example, use `equals` method of `Buffer` class to assert whether or not buffers contain the same content:
 
@@ -1296,13 +1306,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-26.x/UsingMatchers.md
+++ b/website/versioned_docs/version-26.x/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-27.x/ExpectAPI.md
+++ b/website/versioned_docs/version-27.x/ExpectAPI.md
@@ -1213,7 +1213,17 @@ describe('the La Croix cans on my desk', () => {
 });
 ```
 
-> Note: `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+:::tip
+
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
+`.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
+
+:::
 
 If differences between properties do not help you to understand why a test fails, especially if the report is large, then you might move the comparison into the `expect` function. For example, use `equals` method of `Buffer` class to assert whether or not buffers contain the same content:
 
@@ -1311,13 +1321,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-27.x/UsingMatchers.md
+++ b/website/versioned_docs/version-27.x/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-28.x/ExpectAPI.md
+++ b/website/versioned_docs/version-28.x/ExpectAPI.md
@@ -1246,6 +1246,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -1346,13 +1352,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-28.x/UsingMatchers.md
+++ b/website/versioned_docs/version-28.x/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-29.0/ExpectAPI.md
+++ b/website/versioned_docs/version-29.0/ExpectAPI.md
@@ -1345,6 +1345,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -1445,13 +1451,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-29.0/UsingMatchers.md
+++ b/website/versioned_docs/version-29.0/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-29.1/ExpectAPI.md
+++ b/website/versioned_docs/version-29.1/ExpectAPI.md
@@ -1345,6 +1345,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -1445,13 +1451,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-29.1/UsingMatchers.md
+++ b/website/versioned_docs/version-29.1/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-29.2/ExpectAPI.md
+++ b/website/versioned_docs/version-29.2/ExpectAPI.md
@@ -1345,6 +1345,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -1445,13 +1451,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-29.2/UsingMatchers.md
+++ b/website/versioned_docs/version-29.2/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-29.3/ExpectAPI.md
+++ b/website/versioned_docs/version-29.3/ExpectAPI.md
@@ -1345,6 +1345,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -1445,13 +1451,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-29.3/UsingMatchers.md
+++ b/website/versioned_docs/version-29.3/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 

--- a/website/versioned_docs/version-29.4/ExpectAPI.md
+++ b/website/versioned_docs/version-29.4/ExpectAPI.md
@@ -646,6 +646,12 @@ describe('the La Croix cans on my desk', () => {
 
 :::tip
 
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use [`.toStrictEqual`](#tostrictequalvalue) instead.
+
+:::
+
+:::info
+
 `.toEqual` won't perform a _deep equality_ check for two errors. Only the `message` property of an Error is considered for equality. It is recommended to use the `.toThrow` matcher for testing against errors.
 
 :::
@@ -746,13 +752,14 @@ Check out the section on [Inline Snapshots](SnapshotTesting.md#inline-snapshots)
 
 ### `.toStrictEqual(value)`
 
-Use `.toStrictEqual` to test that objects have the same types as well as structure.
+Use `.toStrictEqual` to test that objects have the same structure and type.
 
 Differences from `.toEqual`:
 
-- Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
-- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
-- Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
+- keys with `undefined` properties are checked, e.g. `{a: undefined, b: 2}` will not equal `{b: 2}`;
+- `undefined` items are taken into account, e.g. `[2]` will not equal `[2, undefined]`;
+- array sparseness is checked, e.g. `[, 1]` will not equal `[undefined, 1]`;
+- object types are checked, e.g. a class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js
 class LaCroix {

--- a/website/versioned_docs/version-29.4/UsingMatchers.md
+++ b/website/versioned_docs/version-29.4/UsingMatchers.md
@@ -17,7 +17,7 @@ test('two plus two is four', () => {
 
 In this code, `expect(2 + 2)` returns an "expectation" object. You typically won't do much with these expectation objects except call matchers on them. In this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing matchers so that it can print out nice error messages for you.
 
-`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual` or `toStrictEqual` instead:
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an object, use `toEqual`:
 
 ```js
 test('object assignment', () => {
@@ -31,7 +31,7 @@ test('object assignment', () => {
 
 :::tip
 
-Using `toStrictEqual` is preferred over using `toEqual`. `toEqual` simply ignores `undefined` values, whereas `toStrictEqual` takes them into account.
+`toEqual` ignores object keys with `undefined` properties, `undefined` array items, array sparseness, or object type mismatch. To take these into account use `toStrictEqual` instead.
 
 :::
 


### PR DESCRIPTION
Closes #13885

## Summary

Current documentation of `toEqual` matcher does not mention `toStrictEqual`. I added a note and tweak few details in the explanation of the differences between these two matchers.

## Test plan

Deploy preview.