### PR TITLE
docs: clean up Getting Started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -126,7 +126,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started. Alternatively you can use [vitest](https://github.com/vitest-dev/vitest).
+Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
 
 ### Using Parcel
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-25.x/GettingStarted.md
+++ b/website/versioned_docs/version-25.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-26.x/GettingStarted.md
+++ b/website/versioned_docs/version-26.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-27.x/GettingStarted.md
+++ b/website/versioned_docs/version-27.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-28.x/GettingStarted.md
+++ b/website/versioned_docs/version-28.x/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.0/GettingStarted.md
+++ b/website/versioned_docs/version-29.0/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -126,7 +126,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started. Alternatively you can use [vitest](https://github.com/vitest-dev/vitest).
+Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
 
 ### Using Parcel
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.1/GettingStarted.md
+++ b/website/versioned_docs/version-29.1/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -126,7 +126,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started. Alternatively you can use [vitest](https://github.com/vitest-dev/vitest).
+Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
 
 ### Using Parcel
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.2/GettingStarted.md
+++ b/website/versioned_docs/version-29.2/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -126,7 +126,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started. Alternatively you can use [vitest](https://github.com/vitest-dev/vitest).
+Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
 
 ### Using Parcel
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.3/GettingStarted.md
+++ b/website/versioned_docs/version-29.3/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -87,7 +87,7 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
 <details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
+  // set to something else. This can help to determine what presets or plugins
   // to include in the configuration.
   const isTest = api.env('test');
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -126,7 +126,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started. Alternatively you can use [vitest](https://github.com/vitest-dev/vitest).
+Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
 
 ### Using Parcel
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -87,18 +87,16 @@ module.exports = {
 };
 ```
 
-The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
+_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-:::tip
+<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
-  // set to something else. This can help to determine what presets or plugins 
-  // to include in the configuration.
   const isTest = api.env('test');
+  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -106,11 +104,9 @@ module.exports = api => {
 };
 ```
 
-:::
+:::note
 
-:::info
-
-If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
+`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -119,6 +115,8 @@ module.exports = {
 ```
 
 :::
+
+</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -87,16 +87,18 @@ module.exports = {
 };
 ```
 
-_The ideal configuration for Babel will depend on your project._ See [Babel's docs](https://babeljs.io/docs/en/) for more details.
+The ideal configuration will depend on your project. See [Babel's documentation](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+:::tip
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+You can use [Config Function API](https://babeljs.io/docs/en/config-files#config-function-api) to make your Babel config Jest aware:
 
 ```javascript title="babel.config.js"
 module.exports = api => {
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
+  // to include in the configuration.
   const isTest = api.env('test');
-  // You can use isTest to determine what presets and plugins to use.
 
   return {
     // ...
@@ -104,9 +106,11 @@ module.exports = api => {
 };
 ```
 
-:::note
+:::
 
-`babel-jest` is automatically installed when installing Jest and will automatically transform files if a babel configuration exists in your project. To avoid this behavior, you can explicitly reset the `transform` configuration option:
+:::info
+
+If a Babel configuration exists in your project, by default `babel-jest` will be used to transform files. To avoid this behavior, you should explicitly set the [`transform`](Configuration.md#transform-objectltstring-pathtotransformer--pathtotransformer-objectgt) configuration option:
 
 ```javascript title="jest.config.js"
 module.exports = {
@@ -115,8 +119,6 @@ module.exports = {
 ```
 
 :::
-
-</details>
 
 ### Using webpack
 

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -95,8 +95,8 @@ You can use [Config Function API](https://babeljs.io/docs/en/config-files#config
 
 ```javascript title="babel.config.js"
 module.exports = api => {
-  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already
-  // set to something else. This can help to determine what presets or plugins
+  // Jest will set `process.env.NODE_ENV` to `'test'`, if it is not already 
+  // set to something else. This can help to determine what presets or plugins 
   // to include in the configuration.
   const isTest = api.env('test');
 


### PR DESCRIPTION
## Summary

Just an idea – what if `details` element in the Getting Started page would be replaced with admonition? For my eye, it looks somewhat cleaner.

## Test plan

Deploy preview