### PR TITLE
chore: tweak wording when using conflicting CLI arguments

### DIFF
--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -15,8 +15,7 @@ export function check(argv: Config.Argv): true {
     Object.prototype.hasOwnProperty.call(argv, 'maxWorkers')
   ) {
     throw new Error(
-      'Both --runInBand and --maxWorkers were specified, but these two ' +
-        'options do not make sense together. Which is it?',
+      'Both --runInBand and --maxWorkers were specified, only one is allowed.',
     );
   }
 
@@ -28,17 +27,16 @@ export function check(argv: Config.Argv): true {
   ]) {
     if (argv[key] && argv.watchAll) {
       throw new Error(
-        `Both --${key} and --watchAll were specified, but these two ` +
-          'options do not make sense together. Try the --watch option which ' +
-          'reruns only tests related to changed files.',
+        `Both --${key} and --watchAll were specified, but cannot be used ` +
+          'together. Try the --watch option which reruns only tests ' +
+          'related to changed files.',
       );
     }
   }
 
   if (argv.onlyFailures && argv.watchAll) {
     throw new Error(
-      'Both --onlyFailures and --watchAll were specified, but these two ' +
-        'options do not make sense together.',
+      'Both --onlyFailures and --watchAll were specified, only one is allowed.',
     );
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

How would I do this without knowing the version to change to? If instructions are in something like contributing, then consider linking to that in the PR template so theDX is much better for such a trivial PR.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the middle of debugging engineers don't want focus broken, unnecessarily sassy cli output is funny but plainly distracting.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

It's just text, you don't even need to accept the PR or my words, it's just clearer to open a PR than an issue.