### PR TITLE
chore: do not use built version of circus in unit test

### DIFF
--- a/packages/jest-circus/src/__mocks__/testUtils.ts
+++ b/packages/jest-circus/src/__mocks__/testUtils.ts
@@ -11,13 +11,9 @@ import * as path from 'path';
 import {ExecaSyncReturnValue, sync as spawnSync} from 'execa';
 import * as fs from 'graceful-fs';
 
-const CIRCUS_PATH = require.resolve('../../build').replace(/\\/g, '\\\\');
-const CIRCUS_RUN_PATH = require
-  .resolve('../../build/run')
-  .replace(/\\/g, '\\\\');
-const CIRCUS_STATE_PATH = require
-  .resolve('../../build/state')
-  .replace(/\\/g, '\\\\');
+const CIRCUS_PATH = require.resolve('../').replace(/\\/g, '\\\\');
+const CIRCUS_RUN_PATH = require.resolve('../run').replace(/\\/g, '\\\\');
+const CIRCUS_STATE_PATH = require.resolve('../state').replace(/\\/g, '\\\\');
 const TEST_EVENT_HANDLER_PATH = require
   .resolve('./testEventHandler')
   .replace(/\\/g, '\\\\');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When bundling (#12348), these files don't exist in `build`. And we use `@babel/register` anyways, so using TS here is fine.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
