### PR TITLE
feat(jest-message-util): improve detection of error causes

### DIFF
--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -152,7 +152,15 @@ export const formatExecError = (
       const prefix = '\n\nCause:\n';
       if (typeof error.cause === 'string' || typeof error.cause === 'number') {
         cause += `${prefix}${error.cause}`;
-      } else if (types.isNativeError(error.cause)) {
+      } else if (
+        types.isNativeError(error.cause) ||
+        error.cause instanceof Error
+      ) {
+        /* `isNativeError` is used, because the error might come from another realm.
+         `instanceof Error` is used because `isNativeError` does return `false` for some
+         things that are `instanceof Error` like the errors provided in
+         [verror](https://www.npmjs.com/package/verror) or [axios](https://axios-http.com).
+        */
         const formatted = formatExecError(
           error.cause,
           config,


### PR DESCRIPTION
## Summary

This is a small improvement to my last PR.  The check if the cause of an error is an `Error` is now done both using `isNativeError` and `instanceof Error`.  I'm doing this, because Errors provided by popular libraries like axios or verror return `false` when checked with `isNativeError`. I've added this explanation to the code.