### PR TITLE
refactor(jest-runtime): do not call `resetAllMock()` during `teardown`

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1338,7 +1338,6 @@ export default class Runtime {
 
   teardown(): void {
     this.restoreAllMocks();
-    this.resetAllMocks();
     this.resetModules();
 
     this._internalModuleRegistry.clear();


### PR DESCRIPTION
## Summary

There is no need to call `resetAllMocks()` _after_ `restoreAllMocks()`, because it does nothing (as one can see below, logic in `jest-mock`):

https://github.com/facebook/jest/blob/d8e29382c9cb83f6f7a712c9dc2835b69a81e5f5/packages/jest-mock/src/index.ts#L1446-L1457

`restoreAllMocks()` already cleared mocks and their registry. The `spyState` will also be empty.

## Test plan

Green CI.
