### PR TITLE
fix(jest-transformer): Ignoring writing cache errors on windows doesn't work

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -964,8 +964,7 @@ const cacheWriteErrorSafeToIgnore = (
   cachePath: string,
 ) =>
   process.platform === 'win32' &&
-  e.code === 'EPERM' &&
-  fs.existsSync(cachePath);
+  e.code === 'EPERM';
 
 const readCacheFile = (cachePath: string): string | null => {
   if (!fs.existsSync(cachePath)) {


### PR DESCRIPTION
## Summary

The issue #4444 is already open for 5 years but seems to be already fixed with https://github.com/facebook/jest/pull/4685
But the fix doesn't seem to work correctly.

The ScriptTransformer has already a check to ignore errors under windows on writing cache file. But in case that the file cannot be access because to process try to write/access the same file also fs.existsSync() will return false under windows! So, we should simply remove this check. This should not make the behavior worse on windows.


