### PR TITLE
docs: clarify how to disable watch mode through CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -487,15 +487,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-25.x/CLI.md
+++ b/website/versioned_docs/version-25.x/CLI.md
@@ -413,15 +413,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-26.x/CLI.md
+++ b/website/versioned_docs/version-26.x/CLI.md
@@ -433,15 +433,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-27.x/CLI.md
+++ b/website/versioned_docs/version-27.x/CLI.md
@@ -437,15 +437,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-28.x/CLI.md
+++ b/website/versioned_docs/version-28.x/CLI.md
@@ -473,15 +473,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-29.0/CLI.md
+++ b/website/versioned_docs/version-29.0/CLI.md
@@ -467,15 +467,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-29.1/CLI.md
+++ b/website/versioned_docs/version-29.1/CLI.md
@@ -467,15 +467,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-29.2/CLI.md
+++ b/website/versioned_docs/version-29.2/CLI.md
@@ -487,15 +487,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-29.3/CLI.md
+++ b/website/versioned_docs/version-29.3/CLI.md
@@ -487,15 +487,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 

--- a/website/versioned_docs/version-29.4/CLI.md
+++ b/website/versioned_docs/version-29.4/CLI.md
@@ -487,15 +487,19 @@ Alias: `-v`. Print the version and exit.
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.
 
+:::tip
+
+Use `--no-watch` to explicitly disable the watch mode if it was enable using `--watch`. In most CI environments, this is automatically handled for you.
+
+:::
+
 ### `--watchAll`
 
 Watch files for changes and rerun all tests when something changes. If you want to re-run only the tests that depend on the changed files, use the `--watch` option.
 
-Use `--watchAll=false` to explicitly disable the watch mode.
-
 :::tip
 
-In most CI environments, this is automatically handled for you.
+Use `--no-watchAll` to explicitly disable the watch mode if it was enable using `--watchAll`. In most CI environments, this is automatically handled for you.
 
 :::
 


### PR DESCRIPTION
Resolves #13930

## Summary

Currently CLI documentation is missing clarification that `--watch` should be disabled through `--no-watch`, and `--watchAll` through `--no-watchAll`.

I though `--no-watch` and `--no-watchAll` are less verbose than `--watch=false` and `--watchAll=false`, but both would do the same job, of course.

## Test plan

Deploy preview