### PR TITLE
feat(worker): add `start` method to worker farms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-worker]` Add `setup` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
+- `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-worker]` Add `setup` method to worker farms
+- `[jest-worker]` Add `setup` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-worker]` Add `setup` method to worker farms
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -140,7 +140,7 @@ Returns a `ReadableStream` where the standard output of all workers is piped. No
 
 Returns a `ReadableStream` where the standard error of all workers is piped. Note that the `silent` option of the child workers must be set to `true` to make it work. This is the default set by `jest-worker`, but keep it in mind when overriding options through `forkOptions`.
 
-#### `setup()`
+#### `start()`
 
 Starts up every worker and call their `setup` function, if it exists. Returns a `Promise` which resolves when all workers are running and have completed their `setup`.
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -140,11 +140,17 @@ Returns a `ReadableStream` where the standard output of all workers is piped. No
 
 Returns a `ReadableStream` where the standard error of all workers is piped. Note that the `silent` option of the child workers must be set to `true` to make it work. This is the default set by `jest-worker`, but keep it in mind when overriding options through `forkOptions`.
 
+#### `setup()`
+
+Starts up every worker and call their `setup` function, if it exists. Returns a `Promise` which resolves when all workers are running and have completed their `setup`.
+
+This is useful if you want to start up all your workers eagerly before they are used to call any other functions.
+
 #### `end()`
 
 Finishes the workers by killing all workers. No further calls can be done to the `Worker` instance.
 
-Returns a Promise that resolves with `{ forceExited: boolean }` once all workers are dead. If `forceExited` is `true`, at least one of the workers did not exit gracefully, which likely happened because it executed a leaky task that left handles open. This should be avoided, force exiting workers is a last resort to prevent creating lots of orphans.
+Returns a `Promise` that resolves with `{ forceExited: boolean }` once all workers are dead. If `forceExited` is `true`, at least one of the workers did not exit gracefully, which likely happened because it executed a leaky task that left handles open. This should be avoided, force exiting workers is a last resort to prevent creating lots of orphans.
 
 **Note:**
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -142,7 +142,7 @@ Returns a `ReadableStream` where the standard error of all workers is piped. Not
 
 #### `start()`
 
-Starts up every worker and call their `setup` function, if it exists. Returns a `Promise` which resolves when all workers are running and have completed their `setup`.
+Starts up every worker and calls their `setup` function, if it exists. Returns a `Promise` which resolves when all workers are running and have completed their `setup`.
 
 This is useful if you want to start up all your workers eagerly before they are used to call any other functions.
 

--- a/packages/jest-worker/__benchmarks__/test.js
+++ b/packages/jest-worker/__benchmarks__/test.js
@@ -87,11 +87,10 @@ function testJestWorker() {
 
     async function countToFinish() {
       if (++count === calls) {
-        farm.end();
         const endTime = performance.now();
 
         // Let all workers go down.
-        await sleep(2000);
+        await farm.end();
 
         resolve({
           globalTime: endTime - startTime - 2000,
@@ -110,7 +109,7 @@ function testJestWorker() {
     farm.getStderr().pipe(process.stderr);
 
     // Let all workers come up.
-    await sleep(2000);
+    await farm.setup();
 
     const startProcess = performance.now();
 

--- a/packages/jest-worker/__benchmarks__/test.js
+++ b/packages/jest-worker/__benchmarks__/test.js
@@ -109,7 +109,7 @@ function testJestWorker() {
     farm.getStderr().pipe(process.stderr);
 
     // Let all workers come up.
-    await farm.setup();
+    await farm.start();
 
     const startProcess = performance.now();
 

--- a/packages/jest-worker/__typetests__/jest-worker.test.ts
+++ b/packages/jest-worker/__typetests__/jest-worker.test.ts
@@ -88,6 +88,8 @@ expectError(typedWorkerFarm.runTestAsync());
 expectError(typedWorkerFarm.setup());
 expectError(typedWorkerFarm.teardown());
 
+expectType<Promise<void>>(typedWorkerFarm.start());
+
 expectError<Promise<void>>(typedWorkerFarm.end());
 expectType<Promise<{forceExited: boolean}>>(typedWorkerFarm.end());
 

--- a/packages/jest-worker/src/__tests__/index.test.ts
+++ b/packages/jest-worker/src/__tests__/index.test.ts
@@ -89,6 +89,7 @@ it('exposes the right API using passed worker', () => {
     getStdout: jest.fn(),
     getWorkers: jest.fn(),
     send: jest.fn(),
+    start: jest.fn(),
   }));
 
   const farm = new WorkerFarm('/tmp/baz.js', {

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -90,23 +90,24 @@ export default class BaseWorkerPool {
 
   async start(): Promise<void> {
     await Promise.all(
-      this._workers.map(
-        worker =>
-          new Promise<void>((resolve, reject) => {
-            worker.send(
-              [CHILD_MESSAGE_CALL_SETUP],
-              emptyMethod,
-              error => {
-                if (error) {
-                  reject(error);
-                } else {
-                  resolve();
-                }
-              },
-              emptyMethod,
-            );
-          }),
-      ),
+      this._workers.map(async worker => {
+        await worker.waitForWorkerReady();
+
+        await new Promise<void>((resolve, reject) => {
+          worker.send(
+            [CHILD_MESSAGE_CALL_SETUP],
+            emptyMethod,
+            error => {
+              if (error) {
+                reject(error);
+              } else {
+                resolve();
+              }
+            },
+            emptyMethod,
+          );
+        });
+      }),
     );
   }
 

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -88,7 +88,7 @@ export default class BaseWorkerPool {
     throw Error('Missing method createWorker in WorkerPool');
   }
 
-  async setup(): Promise<void> {
+  async start(): Promise<void> {
     await Promise.all(
       this._workers.map(
         worker =>

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -174,8 +174,8 @@ export class Worker {
     return this._workerPool.getStdout();
   }
 
-  async setup(): Promise<void> {
-    await this._workerPool.setup();
+  async start(): Promise<void> {
+    await this._workerPool.start();
   }
 
   async end(): Promise<PoolExitResult> {

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -174,6 +174,10 @@ export class Worker {
     return this._workerPool.getStdout();
   }
 
+  async setup(): Promise<void> {
+    await this._workerPool.setup();
+  }
+
   async end(): Promise<PoolExitResult> {
     if (this._ending) {
       throw new Error('Farm is ended, no more calls can be done to it');

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -36,6 +36,7 @@ export const CHILD_MESSAGE_INITIALIZE = 0;
 export const CHILD_MESSAGE_CALL = 1;
 export const CHILD_MESSAGE_END = 2;
 export const CHILD_MESSAGE_MEM_USAGE = 3;
+export const CHILD_MESSAGE_CALL_SETUP = 4;
 
 export const PARENT_MESSAGE_OK = 0;
 export const PARENT_MESSAGE_CLIENT_ERROR = 1;
@@ -61,6 +62,7 @@ export interface WorkerPoolInterface {
   getWorkers(): Array<WorkerInterface>;
   createWorker(options: WorkerOptions): WorkerInterface;
   send: WorkerCallback;
+  setup(): Promise<void>;
   end(): Promise<PoolExitResult>;
 }
 
@@ -223,11 +225,14 @@ export type ChildMessageEnd = [
 
 export type ChildMessageMemUsage = [type: typeof CHILD_MESSAGE_MEM_USAGE];
 
+export type ChildMessageCallSetup = [type: typeof CHILD_MESSAGE_CALL_SETUP];
+
 export type ChildMessage =
   | ChildMessageInitialize
   | ChildMessageCall
   | ChildMessageEnd
-  | ChildMessageMemUsage;
+  | ChildMessageMemUsage
+  | ChildMessageCallSetup;
 
 // Messages passed from the children to the parent.
 

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -62,7 +62,7 @@ export interface WorkerPoolInterface {
   getWorkers(): Array<WorkerInterface>;
   createWorker(options: WorkerOptions): WorkerInterface;
   send: WorkerCallback;
-  setup(): Promise<void>;
+  start(): Promise<void>;
   end(): Promise<PoolExitResult>;
 }
 

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -8,6 +8,7 @@
 import {isPromise} from 'jest-util';
 import {
   CHILD_MESSAGE_CALL,
+  CHILD_MESSAGE_CALL_SETUP,
   CHILD_MESSAGE_END,
   CHILD_MESSAGE_INITIALIZE,
   CHILD_MESSAGE_MEM_USAGE,
@@ -59,6 +60,28 @@ const messageListener: NodeJS.MessageListener = (request: any) => {
 
     case CHILD_MESSAGE_MEM_USAGE:
       reportMemoryUsage();
+      break;
+
+    case CHILD_MESSAGE_CALL_SETUP:
+      if (initialized) {
+        reportSuccess(void 0);
+      } else {
+        const main = require(file!);
+
+        initialized = true;
+
+        if (main.setup) {
+          execFunction(
+            main.setup,
+            main,
+            setupArgs,
+            reportSuccess,
+            reportInitializeError,
+          );
+        } else {
+          reportSuccess(void 0);
+        }
+      }
       break;
 
     default:

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -9,6 +9,7 @@ import {isMainThread, parentPort} from 'worker_threads';
 import {isPromise} from 'jest-util';
 import {
   CHILD_MESSAGE_CALL,
+  CHILD_MESSAGE_CALL_SETUP,
   CHILD_MESSAGE_END,
   CHILD_MESSAGE_INITIALIZE,
   CHILD_MESSAGE_MEM_USAGE,
@@ -61,6 +62,28 @@ const messageListener = (request: any) => {
 
     case CHILD_MESSAGE_MEM_USAGE:
       reportMemoryUsage();
+      break;
+
+    case CHILD_MESSAGE_CALL_SETUP:
+      if (initialized) {
+        reportSuccess(void 0);
+      } else {
+        const main = require(file!);
+
+        initialized = true;
+
+        if (main.setup) {
+          execFunction(
+            main.setup,
+            main,
+            setupArgs,
+            reportSuccess,
+            reportInitializeError,
+          );
+        } else {
+          reportSuccess(void 0);
+        }
+      }
       break;
 
     default:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When a worker farm is created, you synchronously get back a `Farm`. Then, once you call methods on it, it'll get a worker (by default via round-robin), and initialise it (calling an exported `setup` if it exists).

If you use workers in a server environment it's useful to initialise all workers as part of the server's startup, rather than taking a hit when actually invoking workers later.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Verified in a work project that initial hit when first invoking a worker is gone.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
