### PR TITLE
feat(jest-message-util): add support for AggregateError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - `[jest-changed-files]` Support Sapling ([#13941](https://github.com/facebook/jest/pull/13941))
 - `[jest-cli, jest-config, @jest/core, jest-haste-map, @jest/reporters, jest-runner, jest-runtime, @jest/types]` Add `workerThreads` configuration option to allow using [worker threads](https://nodejs.org/dist/latest/docs/api/worker_threads.html) for parallelization ([#13939](https://github.com/facebook/jest/pull/13939))
-- `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 - `[jest-message-util]` Add support for [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946))
+- `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-cli, jest-config, @jest/core, jest-haste-map, @jest/reporters, jest-runner, jest-runtime, @jest/types]` Add `workerThreads` configuration option to allow using [worker threads](https://nodejs.org/dist/latest/docs/api/worker_threads.html) for parallelization ([#13939](https://github.com/facebook/jest/pull/13939))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
+- `[jest-message-util]` Add support for [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[jest-changed-files]` Support Sapling ([#13941](https://github.com/facebook/jest/pull/13941))
 - `[jest-cli, jest-config, @jest/core, jest-haste-map, @jest/reporters, jest-runner, jest-runtime, @jest/types]` Add `workerThreads` configuration option to allow using [worker threads](https://nodejs.org/dist/latest/docs/api/worker_threads.html) for parallelization ([#13939](https://github.com/facebook/jest/pull/13939))
-- `[jest-message-util]` Add support for [AggregateErrors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946))
+- `[jest-message-util]` Add support for [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -127,3 +127,22 @@ exports[`should return the error cause if there is one 1`] = `
 
 "
 `;
+
+exports[`should return the inner errors of an AggregateError 1`] = `
+"  <bold>● </intensity>Test suite failed to run
+
+    AggregateError:
+
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:439:22)</intensity>
+
+    Errors contained in AggregateError:
+     Err 1
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:440:7)</intensity>
+
+     Err 2
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:441:7)</intensity>
+
+"
+`;

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -71,6 +71,25 @@ exports[`no stack 1`] = `
 "
 `;
 
+exports[`on node >=15.0.0 should return the inner errors of an AggregateError 1`] = `
+"  <bold>● </intensity>Test suite failed to run
+
+    AggregateError:
+
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:441:24)</intensity>
+
+    Errors contained in AggregateError:
+     Err 1
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:442:9)</intensity>
+
+     Err 2
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:443:9)</intensity>
+
+"
+`;
+
 exports[`retains message in babel code frame error 1`] = `
 "<bold><red>  <bold>● </intensity><bold>Babel test</color></intensity>
 
@@ -118,31 +137,12 @@ exports[`should return the error cause if there is one 1`] = `
 
     Test exception
 
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:418:17)</intensity>
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:419:17)</intensity>
 
     Cause:
      Cause Error
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:421:17)</intensity>
-
-"
-`;
-
-exports[`should return the inner errors of an AggregateError 1`] = `
-"  <bold>● </intensity>Test suite failed to run
-
-    AggregateError:
-
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:439:22)</intensity>
-
-    Errors contained in AggregateError:
-     Err 1
-
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:440:7)</intensity>
-
-     Err 2
-
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:441:7)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:422:17)</intensity>
 
 "
 `;

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -435,7 +435,7 @@ it('should return the error cause if there is one', () => {
 it('should return the inner errors of an AggregateError', () => {
   // TODO remove this if when the lowest supported Node version is 15.0.0
   // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
-  if (AggregateError) {
+  if (typeof AggregateError !== 'undefined') {
     const aggError = new AggregateError([
       new Error('Err 1'),
       new Error('Err 2'),

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,6 +9,7 @@
 import {readFileSync} from 'graceful-fs';
 import slash = require('slash');
 import tempy = require('tempy');
+import {onNodeVersions} from '@jest/test-utils';
 import {
   formatExecError,
   formatResultsErrors,
@@ -432,24 +433,26 @@ it('should return the error cause if there is one', () => {
   expect(message).toMatchSnapshot();
 });
 
-it('should return the inner errors of an AggregateError', () => {
-  // TODO remove this if when the lowest supported Node version is 15.0.0
-  // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
-  if (AggregateError) {
-    const aggError = new AggregateError([
-      new Error('Err 1'),
-      new Error('Err 2'),
-    ]);
-    const message = formatExecError(
-      aggError,
-      {
-        rootDir: '',
-        testMatch: [],
-      },
-      {
-        noStackTrace: false,
-      },
-    );
-    expect(message).toMatchSnapshot();
-  }
+// TODO remove this wrapper when the lowest supported Node version is v16
+onNodeVersions('>=15.0.0', () => {
+  it('should return the inner errors of an AggregateError', () => {
+    // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
+    if (AggregateError) {
+      const aggError = new AggregateError([
+        new Error('Err 1'),
+        new Error('Err 2'),
+      ]);
+      const message = formatExecError(
+        aggError,
+        {
+          rootDir: '',
+          testMatch: [],
+        },
+        {
+          noStackTrace: false,
+        },
+      );
+      expect(message).toMatchSnapshot();
+    }
+  });
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -431,3 +431,25 @@ it('should return the error cause if there is one', () => {
   );
   expect(message).toMatchSnapshot();
 });
+
+it('should return the inner errors of an AggregateError', () => {
+  // TODO remove this if when the lowest supported Node version is 15.0.0
+  // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
+  if (AggregateError) {
+    const aggError = new AggregateError([
+      new Error('Err 1'),
+      new Error('Err 2'),
+    ]);
+    const message = formatExecError(
+      aggError,
+      {
+        rootDir: '',
+        testMatch: [],
+      },
+      {
+        noStackTrace: false,
+      },
+    );
+    expect(message).toMatchSnapshot();
+  }
+});

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -435,7 +435,7 @@ it('should return the error cause if there is one', () => {
 it('should return the inner errors of an AggregateError', () => {
   // TODO remove this if when the lowest supported Node version is 15.0.0
   // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
-  if (typeof AggregateError !== 'undefined') {
+  if (AggregateError) {
     const aggError = new AggregateError([
       new Error('Err 1'),
       new Error('Err 2'),

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -137,6 +137,7 @@ export const formatExecError = (
 
   let message, stack;
   let cause = '';
+  const subErrors = [];
 
   if (typeof error === 'string' || !error) {
     error || (error = 'EMPTY ERROR');
@@ -170,6 +171,20 @@ export const formatExecError = (
           true,
         );
         cause += `${prefix}${formatted}`;
+      }
+    }
+    if ('errors' in error && Array.isArray(error.errors)) {
+      for (const subError of error.errors) {
+        subErrors.push(
+          formatExecError(
+            subError,
+            config,
+            options,
+            testPath,
+            reuseMessage,
+            true,
+          ),
+        );
       }
     }
   }
@@ -210,8 +225,14 @@ export const formatExecError = (
     messageToUse = `${EXEC_ERROR_MESSAGE}\n\n${message}`;
   }
   const title = noTitle ? '' : `${TITLE_INDENT + TITLE_BULLET}`;
+  const subErrorStr =
+    subErrors.length > 0
+      ? indentAllLines(
+          `\n\nErrors contained in AggregateError:\n${subErrors.join('\n')}`,
+        )
+      : '';
 
-  return `${title + messageToUse + stack + cause}\n`;
+  return `${title + messageToUse + stack + cause + subErrorStr}\n`;
 };
 
 const removeInternalStackEntries = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR adds support for printing the errors contained in an [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError).

Example output:
```
      ● Test suite failed to run
    
        AggregateError:
    
          at Object.<anonymous> (packages/jest-message-util/src/__tests__/messages.test.ts:439:22)
    
        Errors contained in AggregateError:
         Err 1
    
              at Object.<anonymous> (packages/jest-message-util/src/__tests__/messages.test.ts:440:7)
    
         Err 2
    
              at Object.<anonymous> (packages/jest-message-util/src/__tests__/messages.test.ts:441:7)

```

## Test plan

I've added a single unit test that uses snapshots.
