### PR TITLE
refactor(jest-message-util): delete needless 'if' in AggregateError test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `[jest-changed-files]` Support Sapling ([#13941](https://github.com/facebook/jest/pull/13941))
 - `[jest-cli, jest-config, @jest/core, jest-haste-map, @jest/reporters, jest-runner, jest-runtime, @jest/types]` Add `workerThreads` configuration option to allow using [worker threads](https://nodejs.org/dist/latest/docs/api/worker_threads.html) for parallelization ([#13939](https://github.com/facebook/jest/pull/13939))
 - `[@jest/create-cache-key-function]` Allow passing `length` argument to `createCacheKey()` function and set its default value to `16` on Windows ([#13827](https://github.com/facebook/jest/pull/13827))
-- `[jest-message-util]` Add support for [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946))
+- `[jest-message-util]` Add support for [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946) & [#13947](https://github.com/facebook/jest/pull/13947))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -76,16 +76,16 @@ exports[`on node >=15.0.0 should return the inner errors of an AggregateError 1`
 
     AggregateError:
 
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:441:24)</intensity>
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:440:22)</intensity>
 
     Errors contained in AggregateError:
      Err 1
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:442:9)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:441:7)</intensity>
 
      Err 2
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:443:9)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:442:7)</intensity>
 
 "
 `;

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -437,22 +437,20 @@ it('should return the error cause if there is one', () => {
 onNodeVersions('>=15.0.0', () => {
   it('should return the inner errors of an AggregateError', () => {
     // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
-    if (AggregateError) {
-      const aggError = new AggregateError([
-        new Error('Err 1'),
-        new Error('Err 2'),
-      ]);
-      const message = formatExecError(
-        aggError,
-        {
-          rootDir: '',
-          testMatch: [],
-        },
-        {
-          noStackTrace: false,
-        },
-      );
-      expect(message).toMatchSnapshot();
-    }
+    const aggError = new AggregateError([
+      new Error('Err 1'),
+      new Error('Err 2'),
+    ]);
+    const message = formatExecError(
+      aggError,
+      {
+        rootDir: '',
+        testMatch: [],
+      },
+      {
+        noStackTrace: false,
+      },
+    );
+    expect(message).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is a small improvement for my last PR. There is an if in the test which was meant to check if AggregateError is available. This is not needed anymore because we are checking for the Node version explicitly.

 I'll add a changelog update if the tests for Node 14 work.


## Test plan

This whole PR is an update do a test. 😃 
