### PR TITLE
fix(@jest/test-result): allow `TestResultsProcessor` type to return a Promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - `[jest-circus]` Send test case results for `todo` tests ([#13915](https://github.com/facebook/jest/pull/13915))
 - `[jest-circus]` Update message printed on test timeout ([#13830](https://github.com/facebook/jest/pull/13830))
+- `[@jest/test-result]` Allow `TestResultsProcessor` type to return a Promise ([#13950](https://github.com/facebook/jest/pull/13950))
 
 ### Chore & Maintenance
 

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -77,7 +77,7 @@ export type AggregatedResult = AggregatedResultWithoutCoverage & {
 
 export type TestResultsProcessor = (
   results: AggregatedResult,
-) => AggregatedResult;
+) => AggregatedResult | Promise<AggregatedResult>;
 
 export type Suite = {
   title: string;


### PR DESCRIPTION
Following up #13343

## Summary

The above mentioned PR implemented async `testResultsProcessor`s, but `TestResultsProcessor` was not reworked to allow the function return a Promise.

## Test plan

Green CI.