### PR TITLE
fix: correct overeager hoisting in `babel-plugin-jest-hoist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- `[babel-plugin-jest-hoist]` Fix unwanted hoisting of nested `jest` usages ([#13952](https://github.com/facebook/jest/pull/13952))
 - `[jest-circus]` Send test case results for `todo` tests ([#13915](https://github.com/facebook/jest/pull/13915))
 - `[jest-circus]` Update message printed on test timeout ([#13830](https://github.com/facebook/jest/pull/13830))
 - `[jest-circus]` Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout AND updated timeouts test ([#13954](https://github.com/facebook/jest/pull/13954))

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -230,3 +230,59 @@ function _getJestObj() {
 }
 
 `;
+
+exports[`babel-plugin-jest-hoist 11. jest.spyOn call on the imported module: 11. jest.spyOn call on the imported module 1`] = `
+
+jest.mock('some-module', () => {
+  const module = jest.requireActual('some-module');
+  jest.spyOn(module, 'add');
+  return module;
+});
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  const module = jest.requireActual('some-module');
+  _getJestObj().spyOn(module, 'add');
+  return module;
+});
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel-plugin-jest-hoist 12. jest.spyOn call in class constructor: 12. jest.spyOn call in class constructor 1`] = `
+
+jest.mock('some-module', () => {
+  const Actual = jest.requireActual('some-module');
+  return class Mocked extends Actual {
+    constructor() {
+      super();
+      jest.spyOn(module, 'add');
+    }
+  };
+});
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('some-module', () => {
+  const Actual = jest.requireActual('some-module');
+  return class Mocked extends Actual {
+    constructor() {
+      super();
+      _getJestObj().spyOn(module, 'add');
+    }
+  };
+});
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -262,7 +262,7 @@ jest.mock('some-module', () => {
   return class Mocked extends Actual {
     constructor() {
       super();
-      jest.spyOn(module, 'add');
+      jest.spyOn(this, 'add');
     }
   };
 });
@@ -275,7 +275,7 @@ _getJestObj().mock('some-module', () => {
   return class Mocked extends Actual {
     constructor() {
       super();
-      _getJestObj().spyOn(module, 'add');
+      _getJestObj().spyOn(this, 'add');
     }
   };
 });

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -151,6 +151,32 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
+    'jest.spyOn call on the imported module': {
+      code: formatResult(`
+        jest.mock('some-module', () => {
+          const module = jest.requireActual('some-module');
+          jest.spyOn(module, 'add');
+          return module;
+        });
+      `),
+      formatResult,
+      snapshot: true,
+    },
+    'jest.spyOn call in class constructor': {
+      code: formatResult(`
+        jest.mock('some-module', () => {
+          const Actual = jest.requireActual('some-module');
+          return class Mocked extends Actual {
+            constructor() {
+              super();
+              jest.spyOn(module, 'add');
+            }
+          };
+        });
+      `),
+      formatResult,
+      snapshot: true,
+    },
   },
   /* eslint-enable */
 });

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -169,7 +169,7 @@ pluginTester({
           return class Mocked extends Actual {
             constructor() {
               super();
-              jest.spyOn(module, 'add');
+              jest.spyOn(this, 'add');
             }
           };
         });

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -32,6 +32,7 @@ const JEST_GLOBALS_MODULE_NAME = '@jest/globals';
 const JEST_GLOBALS_MODULE_JEST_EXPORT_NAME = 'jest';
 
 const hoistedVariables = new WeakSet<VariableDeclarator>();
+const hoistedJestGetters = new WeakSet<CallExpression>();
 const hoistedJestExpressions = new WeakSet<Expression>();
 
 // We allow `jest`, `expect`, `require`, all default Node.js globals and all
@@ -255,9 +256,12 @@ const isJestObject = (
   return false;
 };
 
-const extractJestObjExprIfHoistable = (
-  expr: NodePath,
-): NodePath<Expression> | null => {
+type JestObjInfo = {
+  hoist: boolean;
+  path: NodePath<Expression>;
+};
+
+const extractJestObjExprIfHoistable = (expr: NodePath): JestObjInfo | null => {
   if (!expr.isCallExpression()) {
     return null;
   }
@@ -276,7 +280,7 @@ const extractJestObjExprIfHoistable = (
   const jestObjExpr = isJestObject(object)
     ? object
     : // The Jest object could be returned from another call since the functions are all chainable.
-      extractJestObjExprIfHoistable(object);
+      extractJestObjExprIfHoistable(object)?.path;
   if (!jestObjExpr) {
     return null;
   }
@@ -284,23 +288,26 @@ const extractJestObjExprIfHoistable = (
   // Important: Call the function check last
   // It might throw an error to display to the user,
   // which should only happen if we're already sure it's a call on the Jest object.
-  let functionLooksHoistableOrInHoistable = FUNCTIONS[propertyName]?.(args);
-
+  const functionIsHoistable = FUNCTIONS[propertyName]?.(args) ?? false;
+  let functionHasHoistableScope = functionIsHoistable;
   for (
     let path: NodePath<Node> | null = expr;
-    path && !functionLooksHoistableOrInHoistable;
+    path && !functionHasHoistableScope;
     path = path.parentPath
   ) {
-    functionLooksHoistableOrInHoistable = hoistedJestExpressions.has(
+    functionHasHoistableScope = hoistedJestExpressions.has(
       // @ts-expect-error: it's ok if path.node is not an Expression, .has will
       // just return false.
       path.node,
     );
   }
 
-  if (functionLooksHoistableOrInHoistable) {
+  if (functionHasHoistableScope) {
     hoistedJestExpressions.add(expr.node);
-    return jestObjExpr;
+    return {
+      hoist: functionIsHoistable,
+      path: jestObjExpr,
+    };
   }
 
   return null;
@@ -334,21 +341,23 @@ export default function jestHoist(): PluginObj<{
     },
     visitor: {
       ExpressionStatement(exprStmt) {
-        const jestObjExpr = extractJestObjExprIfHoistable(
+        const jestObjInfo = extractJestObjExprIfHoistable(
           exprStmt.get('expression'),
         );
-        if (jestObjExpr) {
-          jestObjExpr.replaceWith(
-            callExpression(this.declareJestObjGetterIdentifier(), []),
+        if (jestObjInfo) {
+          const jestCallExpr = callExpression(
+            this.declareJestObjGetterIdentifier(),
+            [],
           );
+          jestObjInfo.path.replaceWith(jestCallExpr);
+          if (jestObjInfo.hoist) {
+            hoistedJestGetters.add(jestCallExpr);
+          }
         }
       },
     },
     // in `post` to make sure we come after an import transform and can unshift above the `require`s
     post({path: program}) {
-      // eslint-disable-next-line @typescript-eslint/no-this-alias
-      const self = this;
-
       visitBlock(program);
       program.traverse({BlockStatement: visitBlock});
 
@@ -368,13 +377,7 @@ export default function jestHoist(): PluginObj<{
         varsHoistPoint.remove();
 
         function visitCallExpr(callExpr: NodePath<CallExpression>) {
-          const {
-            node: {callee},
-          } = callExpr;
-          if (
-            isIdentifier(callee) &&
-            callee.name === self.jestObjGetterIdentifier?.name
-          ) {
+          if (hoistedJestGetters.has(callExpr.node)) {
             const mockStmt = callExpr.getStatementParent();
 
             if (mockStmt) {


### PR DESCRIPTION
Unit test with a snapshot that demonstrates a bug, a regression introduced in #13188.

If I call `jest.spyOn`, or something else from the `jest` namespace, inside a `jest.mock` factory, it will get hoisted to the top of the block. But sometimes the hosting is bad. I'm providing two examples:

```js
jest.mock('some-module', () => {
  const module = jest.requireActual('some-module');
  jest.spyOn(module, 'add');
  return module;
});
```
will be transformed to:
```js
_getJestObj().mock('some-module', () => {
  _getJestObj().spyOn(module, 'add');
  const module = jest.requireActual('some-module');
  return module;
});
```
where the `jest.spyOn` call will be moved to a place where the `module` variable isn't defined yet.

Second example is a class constructor where the call is moved before `super`:
```js
jest.mock('some-module', () => {
  const Actual = jest.requireActual('some-module');
  return class Mocked extends Actual {
    constructor() {
      super();
      jest.spyOn(module, 'add');
    }
  };
});
```
is turned into:
```js
_getJestObj().mock('some-module', () => {
  const Actual = jest.requireActual('some-module');
  return class Mocked extends Actual {
    constructor() {
      _getJestObj().spyOn(module, 'add');
      super();
    }
  };
});
```
where instantiating the `Mocked` class will always fail with:
```
Must call super constructor in derived class before accessing 'this'
```

FYI @nicolo-ribaudo: before #13188 the `jest.spyOn` calls weren't touched, they were not transformed to `_getJestObj().spyOn` and not hoisted.

I think we want to hoist only `jest.mock` calls, not any other `jest.*` ones?
