### PR TITLE
fix: Avoid creating the word testfalse in the message on test timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 - `[jest-circus]` Send test case results for `todo` tests ([#13915](https://github.com/facebook/jest/pull/13915))
 - `[jest-circus]` Update message printed on test timeout ([#13830](https://github.com/facebook/jest/pull/13830))
-- `[jest-circus]` Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout ([#13954](https://github.com/facebook/jest/pull/13954))
+- `[jest-circus]` Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout AND updated timeouts test ([#13954](https://github.com/facebook/jest/pull/13954))
 - `[@jest/test-result]` Allow `TestResultsProcessor` type to return a Promise ([#13950](https://github.com/facebook/jest/pull/13950))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - `[jest-circus]` Send test case results for `todo` tests ([#13915](https://github.com/facebook/jest/pull/13915))
 - `[jest-circus]` Update message printed on test timeout ([#13830](https://github.com/facebook/jest/pull/13830))
+- `[jest-circus]` Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout ([#13954](https://github.com/facebook/jest/pull/13954))
 - `[@jest/test-result]` Allow `TestResultsProcessor` type to return a Promise ([#13950](https://github.com/facebook/jest/pull/13950))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -13,19 +13,6 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
-exports[`does not exceed the command line testTimeout 3`] = `
-"PASS __tests__/a-banana.js
-  ✓ banana"
-`;
-
-exports[`does not exceed the command line testTimeout 4`] = `
-"Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites."
-`;
-
 exports[`does not exceed the timeout 1`] = `
 "PASS __tests__/a-banana.js
   ✓ banana"

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -13,12 +13,38 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
+exports[`does not exceed the command line testTimeout 3`] = `
+"PASS __tests__/a-banana.js
+  ✓ banana"
+`;
+
+exports[`does not exceed the command line testTimeout 4`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
 exports[`does not exceed the timeout 1`] = `
 "PASS __tests__/a-banana.js
   ✓ banana"
 `;
 
 exports[`does not exceed the timeout 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`does not exceed the timeout parameter 1`] = `
+"PASS __tests__/a-banana.js
+  ✓ banana"
+`;
+
+exports[`does not exceed the timeout parameter 2`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total
@@ -35,6 +61,14 @@ Ran all test suites."
 `;
 
 exports[`exceeds the timeout 1`] = `
+"Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`exceeds the timeout parameter 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -30,9 +30,13 @@ test('exceeds the timeout', () => {
 
   const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
+  const regexToMatch =
+    process.env.JEST_JASMINE === '1'
+      ? /(Async callback was not invoked within the 20 ms timeout specified by jest\.setTimeout\.)/
+      : /(Exceeded timeout of 20 ms for a test\.)/;
 
   expect(rest).toMatch(/(jest\.setTimeout\(20\))/);
-  expect(rest).toMatch(/(Exceeded timeout of 20 ms for a test\.)/);
+  expect(rest).toMatch(regexToMatch);
   expect(summary).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });
@@ -77,7 +81,11 @@ test('exceeds the command line testTimeout', () => {
     '--testTimeout=200',
   ]);
   const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(/(Exceeded timeout of 200 ms for a test\.)/);
+  const regexToMatch =
+    process.env.JEST_JASMINE === '1'
+      ? /(Async callback was not invoked within the 200 ms timeout specified by jest\.setTimeout\.)/
+      : /(Exceeded timeout of 200 ms for a test\.)/;
+  expect(rest).toMatch(regexToMatch);
   expect(summary).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });
@@ -121,7 +129,11 @@ test('exceeds the timeout parameter', () => {
 
   const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(/(Exceeded timeout of 200 ms for a test\.)/);
+  const regexToMatch =
+    process.env.JEST_JASMINE === '1'
+      ? /(Async callback was not invoked within the 200 ms timeout specified by jest\.setTimeout\.)/
+      : /(Exceeded timeout of 200 ms for a test\.)/;
+  expect(rest).toMatch(regexToMatch);
   expect(summary).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });
@@ -160,10 +172,12 @@ test('exceeds the timeout specifying that `done` has not been called', () => {
 
   const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
+  const regexToMatch =
+    process.env.JEST_JASMINE === '1'
+      ? /(Async callback was not invoked within the 20 ms timeout specified by jest\.setTimeout\.)/
+      : /(Exceeded timeout of 20 ms for a test while waiting for `done\(\)` to be called\.)/;
   expect(rest).toMatch(/(jest\.setTimeout\(20\))/);
-  expect(rest).toMatch(
-    /(Exceeded timeout of 20 ms for a test while waiting for `done\(\)` to be called\.)/,
-  );
+  expect(rest).toMatch(regexToMatch);
   expect(summary).toMatchSnapshot();
   expect(exitCode).toBe(1);
 });

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -179,7 +179,7 @@ const _makeTimeoutMessage = (
   `Exceeded timeout of ${formatTime(timeout)} for a ${
     isHook ? 'hook' : 'test'
   }${
-    takesDoneCallback && ' while waiting for `done()` to be called'
+    takesDoneCallback ? ' while waiting for `done()` to be called' : ''
   }.\nAdd a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout.`;
 
 // Global values can be overwritten by mocks or tests. We'll capture


### PR DESCRIPTION
## Summary

Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout
Details in the issue #13844

## Test plan

Updated the timeouts test
