### PR TITLE
jest-environment-jsdom: stop setting document to null on teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[jest-circus]` Send test case results for `todo` tests ([#13915](https://github.com/facebook/jest/pull/13915))
 - `[jest-circus]` Update message printed on test timeout ([#13830](https://github.com/facebook/jest/pull/13830))
 - `[jest-circus]` Avoid creating the word "testfalse" when `takesDoneCallback` is `false` in the message printed on test timeout AND updated timeouts test ([#13954](https://github.com/facebook/jest/pull/13954))
+- `[jest-environment-jsdom]` Stop setting `document` to `null` on teardown ([#13972](https://github.com/facebook/jest/pull/13972))
 - `[@jest/test-result]` Allow `TestResultsProcessor` type to return a Promise ([#13950](https://github.com/facebook/jest/pull/13950))
 
 ### Chore & Maintenance

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.ts
@@ -84,7 +84,7 @@ describe('JSDomEnvironment', () => {
 
   /**
    * When used in conjunction with Custom Elements (part of the WebComponents standard)
-   * setting the global.document to null too early is problematic because:
+   * setting the `global` and `global.document` to null too early is problematic because:
    *
    * CustomElement's disconnectedCallback method is called when a custom element
    * is removed from the DOM. The disconnectedCallback could need the document
@@ -94,7 +94,7 @@ describe('JSDomEnvironment', () => {
    * The custom element will be removed from the DOM at this point, therefore disconnectedCallback
    * will be called, so please make sure the global.document is still available at this point.
    */
-  it('should not set the global.document to null too early', () => {
+  it('should call CE disconnectedCallback with valid globals on teardown', () => {
     const env = new JSDomEnvironment(
       {
         globalConfig: makeGlobalConfig(),
@@ -103,12 +103,46 @@ describe('JSDomEnvironment', () => {
       {console, docblockPragmas: {}, testPath: __filename},
     );
 
-    const originalCloseFn = env.global.close.bind(env.global);
-    env.global.close = () => {
-      originalCloseFn();
-      expect(env.global.document).not.toBeNull();
-    };
+    let hasDisconnected = false;
+    let documentWhenDisconnected = null;
 
-    return env.teardown();
+    // define a custom element
+    const {HTMLElement} = env.global;
+    class MyCustomElement extends HTMLElement {
+      disconnectedCallback() {
+        hasDisconnected = true;
+        documentWhenDisconnected = env.global.document;
+      }
+    }
+
+    // append an instance of the custom element
+    env.global.customElements.define('my-custom-element', MyCustomElement);
+    const instance = env.global.document.createElement('my-custom-element');
+    env.global.document.body.appendChild(instance);
+
+    // teardown will disconnect the custom elements
+    env.teardown();
+
+    expect(hasDisconnected).toBe(true);
+    expect(documentWhenDisconnected).not.toBeNull();
+  });
+
+  it('should not fire load event after the environment was teared down', async () => {
+    const env = new JSDomEnvironment(
+      {
+        globalConfig: makeGlobalConfig(),
+        projectConfig: makeProjectConfig(),
+      },
+      {console, docblockPragmas: {}, testPath: __filename},
+    );
+
+    const loadHandler = jest.fn();
+    env.global.document.addEventListener('load', loadHandler);
+    env.teardown();
+
+    // The `load` event is fired in microtasks, wait until the microtask queue is reliably flushed
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(loadHandler).not.toHaveBeenCalled();
   });
 });

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -160,13 +160,6 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
         this.global.removeEventListener('error', this.errorEventListener);
       }
       this.global.close();
-
-      // Dispose "document" to prevent "load" event from triggering.
-
-      // Note that this.global.close() will trigger the CustomElement::disconnectedCallback
-      // Do not reset the document before CustomElement disconnectedCallback function has finished running,
-      // document should be accessible within disconnectedCallback.
-      Object.defineProperty(this.global, 'document', {value: null});
     }
     this.errorEventListener = null;
     // @ts-expect-error: this.global not allowed to be `null`


### PR DESCRIPTION
Removes redundant bit of code that sets `global.document` to `null` when `jest-environment-jsdom` is tearing down.

This change is unblocking JSDOM upgrade in #13825. Actually #13825 already makes the same change, my PR is only adding some unit tests and reasoning around this.

The "set `document` to `null`" code was originally added in #5955, to prevent a document `load` event handler to be fired after the document shuts down. But it turns out, and my testing confirms that, that `window.close()` already solves this, because in JSDOM `window.close()` will remove all event listeners from both `window` and `document`.

JSDOM didn't always do that correctly, there is a bugfix PR from 2016 that fixed that: https://github.com/jsdom/jsdom/pull/1479 But Jest's #5955 is from 2018, two years later, so I'm wondering which version of JSDOM was it using at the time.

`JSDOMEnvironment`'s `teardown` method already calls `this.global.close()`, and that's all that needs to be done. I added a new unit test to verify that the `load` handler is indeed not being called after `env.teardown()`/`window.close()`.

Another related PR was #11871, fixing a bug where `document` was being set to `null` _before_ calling `window.close()`. `window.close()` removes all elements from the document, and when there are custom elements, their `disconnectedCallback` methods are called. Synchronously. At the time when `disconnectedCallback` was called, `document` was already `null` which was bad and broke things. So #11871 changed the order of the statements: set `document` to `null` only after `window.close`.

I added a unit test also for this. Replacing the original test, which was testing that `document` is not yet `null` when `window.close()` is called, i.e., was testing implementation internals, my new test is testing the real thing: whether a custom element's `disconnectedCallback` is really called during `env.teardown()`, and whether it's seeing a valid `window` and `document`.