### PR TITLE
feat(jest-snapshot): add support to cts and mts typescript files to inline snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-message-util]` Add support for [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946) & [#13947](https://github.com/facebook/jest/pull/13947))
 - `[jest-message-util]` Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in `test` and `it` ([#13935](https://github.com/facebook/jest/pull/13935) & [#13966](https://github.com/facebook/jest/pull/13966))
 - `[jest-reporters]` Add `summaryThreshold` option to summary reporter to allow overriding the internal threshold that is used to print the summary of all failed tests when the number of test suites surpasses it ([#13895](https://github.com/facebook/jest/pull/13895))
+- `[jest-snapshot]` Add support to `cts` and `mts` TypeScript files to inline snapshots ([#13975](https://github.com/facebook/jest/pull/13975))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -81,7 +81,7 @@ const saveSnapshotsForFile = (
   // TypeScript projects may not have a babel config; make sure they can be parsed anyway.
   const presets = [require.resolve('babel-preset-current-node-syntax')];
   const plugins: Array<PluginItem> = [];
-  if (/\.tsx?$/.test(sourceFilePath)) {
+  if (/\.[cm]?tsx?$/.test(sourceFilePath)) {
     plugins.push([
       require.resolve('@babel/plugin-syntax-typescript'),
       {isTSX: sourceFilePath.endsWith('x')},

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -81,7 +81,7 @@ const saveSnapshotsForFile = (
   // TypeScript projects may not have a babel config; make sure they can be parsed anyway.
   const presets = [require.resolve('babel-preset-current-node-syntax')];
   const plugins: Array<PluginItem> = [];
-  if (/\.[cm]?tsx?$/.test(sourceFilePath)) {
+  if (/\.([cm]?ts|tsx)$/.test(sourceFilePath)) {
     plugins.push([
       require.resolve('@babel/plugin-syntax-typescript'),
       {isTSX: sourceFilePath.endsWith('x')},

--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -167,7 +167,7 @@ const a: [Foo, Foo] = [{ foo: 'one' },            { foo: 'two' }];
 expect(a).toMatchInlineSnapshot(\`[{ foo: 'one' }, { foo: 'two' }]\`);
 `.trim()}\n`,
     );
-  }
+  },
 );
 
 test('saveInlineSnapshots() can handle tsx without prettier', () => {

--- a/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/InlineSnapshots.test.ts
@@ -132,40 +132,43 @@ expect(a).toMatchInlineSnapshot(\`[1, 2]\`);
   );
 });
 
-test('saveInlineSnapshots() can handle typescript without prettier', () => {
-  const filename = path.join(dir, 'my.test.ts');
-  fs.writeFileSync(
-    filename,
-    `${`
+test.each([['ts'], ['cts'], ['mts']])(
+  'saveInlineSnapshots() can handle typescript without prettier - %s extension',
+  extension => {
+    const filename = path.join(dir, `my.test.${extension}`);
+    fs.writeFileSync(
+      filename,
+      `${`
 interface Foo {
   foo: string
 }
 const a: [Foo, Foo] = [{ foo: 'one' },            { foo: 'two' }];
 expect(a).toMatchInlineSnapshot();
 `.trim()}\n`,
-  );
+    );
 
-  saveInlineSnapshots(
-    [
-      {
-        frame: {column: 11, file: filename, line: 5} as Frame,
-        snapshot: "[{ foo: 'one' }, { foo: 'two' }]",
-      },
-    ],
-    dir,
-    null,
-  );
+    saveInlineSnapshots(
+      [
+        {
+          frame: {column: 11, file: filename, line: 5} as Frame,
+          snapshot: "[{ foo: 'one' }, { foo: 'two' }]",
+        },
+      ],
+      dir,
+      null,
+    );
 
-  expect(fs.readFileSync(filename, 'utf8')).toBe(
-    `${`
+    expect(fs.readFileSync(filename, 'utf8')).toBe(
+      `${`
 interface Foo {
   foo: string
 }
 const a: [Foo, Foo] = [{ foo: 'one' },            { foo: 'two' }];
 expect(a).toMatchInlineSnapshot(\`[{ foo: 'one' }, { foo: 'two' }]\`);
 `.trim()}\n`,
-  );
-});
+    );
+  }
+);
 
 test('saveInlineSnapshots() can handle tsx without prettier', () => {
   const filename = path.join(dir, 'my.test.tsx');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently if a inline snapshot is added to a cts or mts file, a parser error is thrown due to missing typescript plugin.
Add the typescript plugin for these file extensions.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added cts and mts file extension to test suite.