### PR TITLE
chore(jest-snapshot): Remove hard dependency on `jest-haste-map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Chore & Maintenance
 
-- `[jest-snapshot]` Remove dependency on `jest-haste-map` ([#13977](https://github.com/facebook/jest/pull/13977)) 
+- `[jest-snapshot]` Remove dependency on `jest-haste-map` ([#13977](https://github.com/facebook/jest/pull/13977))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Chore & Maintenance
 
+- `[jest-snapshot]` Remove dependency on `jest-haste-map` ([#13977](https://github.com/facebook/jest/pull/13977)) 
+
 ### Performance
 
 ## 29.4.3

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -34,7 +34,6 @@
     "graceful-fs": "^4.2.9",
     "jest-diff": "workspace:^",
     "jest-get-type": "workspace:^",
-    "jest-haste-map": "workspace:^",
     "jest-matcher-utils": "workspace:^",
     "jest-message-util": "workspace:^",
     "jest-util": "workspace:^",

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -8,7 +8,6 @@
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import type {MatcherFunctionWithContext} from 'expect';
-import type {IHasteFS} from 'jest-haste-map';
 import {
   BOLD_WEIGHT,
   EXPECTED_COLOR,
@@ -31,7 +30,7 @@ import {
   printReceived,
   printSnapshotAndReceived,
 } from './printSnapshot';
-import type {Context, MatchSnapshotConfig} from './types';
+import type {Context, FileSystem, MatchSnapshotConfig} from './types';
 import {deepMerge, escapeBacktickString, serialize} from './utils';
 
 export {addSerializer, getSerializers} from './plugins';
@@ -110,11 +109,11 @@ function stripAddedIndentation(inlineSnapshot: string) {
   return inlineSnapshot;
 }
 
-const fileExists = (filePath: string, hasteFS: IHasteFS): boolean =>
-  hasteFS.exists(filePath) || fs.existsSync(filePath);
+const fileExists = (filePath: string, fileSystem: FileSystem): boolean =>
+  fileSystem.exists(filePath) || fs.existsSync(filePath);
 
 export const cleanup = (
-  hasteFS: IHasteFS,
+  fileSystem: FileSystem,
   update: Config.SnapshotUpdateState,
   snapshotResolver: SnapshotResolver,
   testPathIgnorePatterns?: Config.ProjectConfig['testPathIgnorePatterns'],
@@ -123,7 +122,7 @@ export const cleanup = (
   filesRemovedList: Array<string>;
 } => {
   const pattern = `\\.${EXTENSION}$`;
-  const files = hasteFS.matchFiles(pattern);
+  const files = fileSystem.matchFiles(pattern);
   let testIgnorePatternsRegex: RegExp | null = null;
   if (testPathIgnorePatterns && testPathIgnorePatterns.length > 0) {
     testIgnorePatternsRegex = new RegExp(testPathIgnorePatterns.join('|'));
@@ -137,7 +136,7 @@ export const cleanup = (
       return false;
     }
 
-    if (!fileExists(testPath, hasteFS)) {
+    if (!fileExists(testPath, fileSystem)) {
       if (update === 'all') {
         fs.unlinkSync(snapshotFile);
       }

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -13,7 +13,7 @@ export interface Context extends MatcherContext {
   snapshotState: SnapshotState;
 }
 
-// This is typically implemented by ``jest-haste-map`'s `HasteFS`, but we
+// This is typically implemented by `jest-haste-map`'s `HasteFS`, but we
 // partially reproduce the interface here to avoid a dependency.
 
 export interface FileSystem {

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -13,6 +13,14 @@ export interface Context extends MatcherContext {
   snapshotState: SnapshotState;
 }
 
+// This is typically implemented by ``jest-haste-map`'s `HasteFS`, but we
+// partially reproduce the interface here to avoid a dependency.
+
+export interface FileSystem {
+  exists(path: string): boolean;
+  matchFiles(pattern: RegExp | string): Array<string>;
+}
+
 export type MatchSnapshotConfig = {
   context: Context;
   hint?: string;

--- a/packages/jest-snapshot/tsconfig.json
+++ b/packages/jest-snapshot/tsconfig.json
@@ -11,7 +11,6 @@
     {"path": "../expect-utils"},
     {"path": "../jest-diff"},
     {"path": "../jest-get-type"},
-    {"path": "../jest-haste-map"},
     {"path": "../jest-matcher-utils"},
     {"path": "../jest-message-util"},
     {"path": "../jest-transform"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -13116,7 +13116,6 @@ __metadata:
     graceful-fs: ^4.2.9
     jest-diff: "workspace:^"
     jest-get-type: "workspace:^"
-    jest-haste-map: "workspace:^"
     jest-matcher-utils: "workspace:^"
     jest-message-util: "workspace:^"
     jest-util: "workspace:^"


### PR DESCRIPTION
## Summary

`jest-snapshot` lists `jest-haste-map` as a `dependency`, because it references a `jest-haste-map` interface in its public API (for `cleanup`). `jest-haste-map` has a [complex dependency tree](https://npmgraph.js.org/?q=jest-haste-map), including a native addon `fsevents`.

Consumers of `jest-snapshot` as a standalone package (like `metro`, ahem 😅) could be spared some of this by `jest-snapshot` specifying its own interface, decoupling it from `jest-haste-map`.

## Test plan

Tests and build pass. The new interface is intentionally a subset of `IHasteFS` so that this change isn't breaking.