### PR TITLE
feat(jest-worker): support passing a URL as path to worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - `[jest-runtime, @jest/transform]` Allow V8 coverage provider to collect coverage from files which were not loaded explicitly ([#13974](https://github.com/facebook/jest/pull/13974))
 - `[jest-snapshot]` Add support to `cts` and `mts` TypeScript files to inline snapshots ([#13975](https://github.com/facebook/jest/pull/13975))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
-- `[jest-worker]` Support passing a URL as path to worker
+- `[jest-worker]` Support passing a URL as path to worker ([#13982](https://github.com/facebook/jest/pull/13982))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-runtime, @jest/transform]` Allow V8 coverage provider to collect coverage from files which were not loaded explicitly ([#13974](https://github.com/facebook/jest/pull/13974))
 - `[jest-snapshot]` Add support to `cts` and `mts` TypeScript files to inline snapshots ([#13975](https://github.com/facebook/jest/pull/13975))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
+- `[jest-worker]` Support passing a URL as path to worker
 
 ### Fixes
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -49,9 +49,9 @@ To use `worker_threads` instead of default `child_process` you have to pass `ena
 
 The `Worker` export is a constructor that is initialized by passing the worker path, plus an options object.
 
-### `workerPath: string` (required)
+### `workerPath: string | URL` (required)
 
-Node module name or absolute path of the file to be loaded in the child processes. Use `require.resolve` to transform a relative path into an absolute one.
+Node module name or absolute path or file URL of the file to be loaded in the child processes. You can use `require.resolve` to transform a relative path into an absolute one.
 
 ### `options: Object` (optional)
 

--- a/packages/jest-worker/src/__tests__/index.test.ts
+++ b/packages/jest-worker/src/__tests__/index.test.ts
@@ -73,9 +73,7 @@ it('makes a non-existing relative worker throw', () => {
 });
 
 it('supports URLs', () => {
-  const absoluteWorkerPath = '/tmp/baz.js';
-
-  const workerPathUrl = pathToFileURL(absoluteWorkerPath);
+  const workerPathUrl = pathToFileURL(__filename);
 
   // eslint-disable-next-line no-new
   new WorkerFarm(workerPathUrl, {exposedMethods: ['foo', 'bar']});
@@ -83,16 +81,8 @@ it('supports URLs', () => {
   new WorkerFarm(workerPathUrl.href, {exposedMethods: ['foo', 'bar']});
 
   expect(WorkerPool).toHaveBeenCalledTimes(2);
-  expect(WorkerPool).toHaveBeenNthCalledWith(
-    1,
-    absoluteWorkerPath,
-    expect.anything(),
-  );
-  expect(WorkerPool).toHaveBeenNthCalledWith(
-    2,
-    absoluteWorkerPath,
-    expect.anything(),
-  );
+  expect(WorkerPool).toHaveBeenNthCalledWith(1, __filename, expect.anything());
+  expect(WorkerPool).toHaveBeenNthCalledWith(2, __filename, expect.anything());
 });
 
 it('exposes the right API using default working', () => {

--- a/packages/jest-worker/src/__tests__/index.test.ts
+++ b/packages/jest-worker/src/__tests__/index.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {pathToFileURL} from 'url';
 import type {JestWorkerFarm, Worker, WorkerFarmOptions} from '../';
 import type FarmClass from '../Farm';
 import type WorkerPoolClass from '../WorkerPool';
@@ -69,6 +70,29 @@ it('makes a non-existing relative worker throw', () => {
     // eslint-disable-next-line no-new
     new WorkerFarm('./relative/worker-module.js');
   }).toThrow("'workerPath' must be absolute");
+});
+
+it('supports URLs', () => {
+  const absoluteWorkerPath = '/tmp/baz.js';
+
+  const workerPathUrl = pathToFileURL(absoluteWorkerPath);
+
+  // eslint-disable-next-line no-new
+  new WorkerFarm(workerPathUrl, {exposedMethods: ['foo', 'bar']});
+  // eslint-disable-next-line no-new
+  new WorkerFarm(workerPathUrl.href, {exposedMethods: ['foo', 'bar']});
+
+  expect(WorkerPool).toHaveBeenCalledTimes(2);
+  expect(WorkerPool).toHaveBeenNthCalledWith(
+    1,
+    absoluteWorkerPath,
+    expect.anything(),
+  );
+  expect(WorkerPool).toHaveBeenNthCalledWith(
+    2,
+    absoluteWorkerPath,
+    expect.anything(),
+  );
 });
 
 it('exposes the right API using default working', () => {

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -11,6 +11,7 @@ import {
   cpus,
 } from 'os';
 import {isAbsolute} from 'path';
+import {fileURLToPath} from 'url';
 import Farm from './Farm';
 import WorkerPool from './WorkerPool';
 import type {
@@ -95,11 +96,17 @@ export class Worker {
   private readonly _options: WorkerFarmOptions;
   private readonly _workerPool: WorkerPoolInterface;
 
-  constructor(workerPath: string, options?: WorkerFarmOptions) {
+  constructor(workerPath: string | URL, options?: WorkerFarmOptions) {
     this._options = {...options};
     this._ending = false;
 
-    if (!isAbsolute(workerPath)) {
+    if (typeof workerPath !== 'string') {
+      workerPath = workerPath.href;
+    }
+
+    if (workerPath.startsWith('file:')) {
+      workerPath = fileURLToPath(workerPath);
+    } else if (!isAbsolute(workerPath)) {
       throw new Error(`'workerPath' must be absolute, got '${workerPath}'`);
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Since `fs` APIs and `import()` supports it, it makes sense for `jest-worker` to do so as well.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Unit test added.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
