### PR TITLE
docs: fix link in Jest Object API page

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-25.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-25.x/JestObjectAPI.md
@@ -125,7 +125,7 @@ This is how `genMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](MockFunctions.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-26.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.x/JestObjectAPI.md
@@ -129,7 +129,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](MockFunctions.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-27.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-27.x/JestObjectAPI.md
@@ -129,7 +129,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-28.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-28.x/JestObjectAPI.md
@@ -129,7 +129,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.0/JestObjectAPI.md
@@ -153,7 +153,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.1/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.1/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.2/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.2/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.3/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.3/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.4/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 

--- a/website/versioned_docs/version-29.5/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.5/JestObjectAPI.md
@@ -174,7 +174,7 @@ This is how `createMockFromModule` will mock the following data types:
 
 #### `Function`
 
-Creates a new [mock function](mock-functions). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
+Creates a new [mock function](MockFunctionAPI.md). The new function has no formal parameters and when called will return `undefined`. This functionality also applies to `async` functions.
 
 #### `Class`
 


### PR DESCRIPTION
## Summary

I think it would be better to point to Mock Function API from Jest Object API page. Just like here:

https://github.com/facebook/jest/blob/39f3beda6b396665bebffab94e8d7c45be30454c/docs/JestObjectAPI.md?plain=1#L595

## Test plan

Deploy preview.
