### PR TITLE
fix: Fix user override of customExportConditions in custom env subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-environment-jsdom, jest-environment-node]` Fix assignment of `customExportConditions` via `testEnvironmentOptions` when custom env subclass defines a default value ([#13989](https://github.com/facebook/jest/pull/13989))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/e2e/resolve-conditions/__tests__/custom-env-conditions-method-override.test.mjs
+++ b/e2e/resolve-conditions/__tests__/custom-env-conditions-method-override.test.mjs
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment <rootDir>/custom-env-conditions-method-override.js
+ */
+
+import {fn} from 'fake-dual-dep';
+
+test('returns correct message', () => {
+  expect(fn()).toBe('hello from deno');
+});

--- a/e2e/resolve-conditions/__tests__/custom-env-override-export-conditions.test.mjs
+++ b/e2e/resolve-conditions/__tests__/custom-env-override-export-conditions.test.mjs
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment <rootDir>/custom-env.js
+ * @jest-environment-options {"customExportConditions": ["react-native"]}
+ */
+
+import {fn} from 'fake-dual-dep';
+
+test('returns correct message', () => {
+  expect(fn()).toBe('hello from react-native');
+});

--- a/e2e/resolve-conditions/__tests__/custom-env.test.mjs
+++ b/e2e/resolve-conditions/__tests__/custom-env.test.mjs
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment <rootDir>/custom-env.js
+ */
+
+import {fn} from 'fake-dual-dep';
+
+test('returns correct message', () => {
+  expect(fn()).toBe('hello from deno');
+});

--- a/e2e/resolve-conditions/custom-env-conditions-method-override.js
+++ b/e2e/resolve-conditions/custom-env-conditions-method-override.js
@@ -9,7 +9,7 @@
 
 const NodeEnv = require('jest-environment-node').TestEnvironment;
 
-module.exports = class DenoEnvWithConditions extends NodeEnv {
+module.exports = class CustomEnvWithConditions extends NodeEnv {
   exportConditions() {
     return ['deno'];
   }

--- a/e2e/resolve-conditions/custom-env.js
+++ b/e2e/resolve-conditions/custom-env.js
@@ -3,12 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @jest-environment <rootDir>/deno-env.js
  */
 
-import {fn} from 'fake-dual-dep';
+'use strict';
 
-test('returns correct message', () => {
-  expect(fn()).toBe('hello from deno');
-});
+const NodeEnv = require('jest-environment-node').TestEnvironment;
+
+module.exports = class CustomEnvWithConditions extends NodeEnv {
+  customExportConditions = ['deno'];
+};

--- a/e2e/resolve-conditions/node_modules/fake-dual-dep/package.json
+++ b/e2e/resolve-conditions/node_modules/fake-dual-dep/package.json
@@ -6,6 +6,7 @@
       "deno": "./deno.mjs",
       "node": "./node.mjs",
       "browser": "./browser.mjs",
+      "react-native": "./react-native.js",
       "special": "./special.mjs"
     }
   }

--- a/e2e/resolve-conditions/node_modules/fake-dual-dep/react-native.js
+++ b/e2e/resolve-conditions/node_modules/fake-dual-dep/react-native.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports.fn = function fn() {
+  return 'hello from react-native';
+}

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -38,6 +38,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
   private errorEventListener: ((event: Event & {error: Error}) => void) | null;
   moduleMocker: ModuleMocker | null;
   customExportConditions = ['browser'];
+  private _configuredExportConditions?: Array<string>;
 
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
     const {projectConfig} = config;
@@ -119,7 +120,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
         Array.isArray(customExportConditions) &&
         customExportConditions.every(isString)
       ) {
-        this.customExportConditions = customExportConditions;
+        this._configuredExportConditions = customExportConditions;
       } else {
         throw new Error(
           'Custom export conditions specified but they are not an array of strings',
@@ -170,7 +171,7 @@ export default class JSDOMEnvironment implements JestEnvironment<number> {
   }
 
   exportConditions(): Array<string> {
-    return this.customExportConditions;
+    return this._configuredExportConditions ?? this.customExportConditions;
   }
 
   getVmContext(): Context | null {

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -64,6 +64,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   global: Global.Global;
   moduleMocker: ModuleMocker | null;
   customExportConditions = ['node', 'node-addons'];
+  private _configuredExportConditions?: Array<string>;
 
   // while `context` is unused, it should always be passed
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext) {
@@ -147,7 +148,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
         Array.isArray(customExportConditions) &&
         customExportConditions.every(isString)
       ) {
-        this.customExportConditions = customExportConditions;
+        this._configuredExportConditions = customExportConditions;
       } else {
         throw new Error(
           'Custom export conditions specified but they are not an array of strings',
@@ -201,7 +202,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   }
 
   exportConditions(): Array<string> {
-    return this.customExportConditions;
+    return this._configuredExportConditions ?? this.customExportConditions;
   }
 
   getVmContext(): Context | null {


### PR DESCRIPTION
## Summary

Adjusts behaviour in `jest-environment-jsdom` and `jest-environment-node` (no breaking changes).

With `customExportConditions` exposed as a public property on each env class, and as previously tested in [`deno.test.mjs`](https://github.com/facebook/jest/blob/67aa05cfe1bbab5e61833fa5e40fbf2ce7045b38/e2e/resolve-conditions/__tests__/deno.test.mjs#LL12C3-L12C3), subclasses can override `"exports"` conditions in two ways:

<img width="457" alt="image" src="https://user-images.githubusercontent.com/2547783/224019266-0f1f7bf3-fc36-4056-a62b-75690295f26f.png">

Previously, both overriding the property or reimplementing `exportConditions()` would mean that when a user attempted to override this in Jest config, this was **ignored**.

```js
{
  testEnvironment: 'react-native/jest/react-native-env', // (via preset: 'react-native')
  testEnvironmentOptions: {
    customExportConditions: ['test', 'react-native'],
  },
}
```

These changes make sure this behaviour works for the property assignment case — and is covered by tests. We plan to make this load-bearing in the React Native Jest preset for 0.72.

Changes:

- Updates `jest-environment-jsdom`, `jest-environment-node` to use the `customExportConditions` property as a _default_, which will be overridden if set in `config.projectConfig.testEnvironmentOptions`.
- Renames `deno.test.mjs`/`deno-env.js` to `custom-env` (more generic).
- Adds `custom-env-override-conditions.test.mjs` with new test case (tests via `@jest-environment-options` doc comment).

## Test plan

```
yarn jest e2e/__tests__/resolveConditions.test.ts
```

✅ Updated tests pass
