### PR TITLE
docs: add `testEnvironmentOptions` configuration examples

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1908,9 +1908,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -1100,7 +1100,36 @@ beforeAll(() => {
 
 Default: `{}`
 
-Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example, you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
+Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
+
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 ### `testFailureExitCode` \[number]
 

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -1104,31 +1104,14 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
 
-```js tab
-/** @type {import('jest').Config} */
-const config = {
+```js
+module.exports = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     html: '<html lang="zh-cmn-Hant"></html>',
     userAgent: 'Agent/007',
   },
 };
-
-module.exports = config;
-```
-
-```ts tab
-import type {Config} from 'jest';
-
-const config: Config = {
-  testEnvironment: 'jsdom',
-  testEnvironmentOptions: {
-    html: '<html lang="zh-cmn-Hant"></html>',
-    userAgent: 'Agent/007',
-  },
-};
-
-export default config;
 ```
 
 ### `testFailureExitCode` \[number]

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -1186,7 +1186,36 @@ beforeAll(() => {
 
 Default: `{}`
 
-Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example, you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
+Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
+
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 ### `testFailureExitCode` \[number]
 

--- a/website/versioned_docs/version-26.x/Configuration.md
+++ b/website/versioned_docs/version-26.x/Configuration.md
@@ -1190,31 +1190,14 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
 
-```js tab
-/** @type {import('jest').Config} */
-const config = {
+```js
+module.exports = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     html: '<html lang="zh-cmn-Hant"></html>',
     userAgent: 'Agent/007',
   },
 };
-
-module.exports = config;
-```
-
-```ts tab
-import type {Config} from 'jest';
-
-const config: Config = {
-  testEnvironment: 'jsdom',
-  testEnvironmentOptions: {
-    html: '<html lang="zh-cmn-Hant"></html>',
-    userAgent: 'Agent/007',
-  },
-};
-
-export default config;
 ```
 
 ### `testFailureExitCode` \[number]

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -1260,31 +1260,14 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
 
-```js tab
-/** @type {import('jest').Config} */
-const config = {
+```js
+module.exports = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     html: '<html lang="zh-cmn-Hant"></html>',
     userAgent: 'Agent/007',
   },
 };
-
-module.exports = config;
-```
-
-```ts tab
-import type {Config} from 'jest';
-
-const config: Config = {
-  testEnvironment: 'jsdom',
-  testEnvironmentOptions: {
-    html: '<html lang="zh-cmn-Hant"></html>',
-    userAgent: 'Agent/007',
-  },
-};
-
-export default config;
 ```
 
 ### `testFailureExitCode` \[number]

--- a/website/versioned_docs/version-27.x/Configuration.md
+++ b/website/versioned_docs/version-27.x/Configuration.md
@@ -1256,7 +1256,36 @@ beforeAll(() => {
 
 Default: `{}`
 
-Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example, you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", userAgent: "Agent/007"}`.
+Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
+
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 ### `testFailureExitCode` \[number]
 

--- a/website/versioned_docs/version-28.x/Configuration.md
+++ b/website/versioned_docs/version-28.x/Configuration.md
@@ -1393,9 +1393,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-28.x/Configuration.md
+++ b/website/versioned_docs/version-28.x/Configuration.md
@@ -1408,29 +1408,13 @@ module.exports = {
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
 
-```js tab
-/** @type {import('jest').Config} */
-const config = {
+```js
+module.exports = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     customExportConditions: ['react-native'],
   },
 };
-
-module.exports = config;
-```
-
-```ts tab
-import type {Config} from 'jest';
-
-const config: Config = {
-  testEnvironment: 'jsdom',
-  testEnvironmentOptions: {
-    customExportConditions: ['react-native'],
-  },
-};
-
-export default config;
 ```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:

--- a/website/versioned_docs/version-28.x/Configuration.md
+++ b/website/versioned_docs/version-28.x/Configuration.md
@@ -1395,9 +1395,8 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
 
-```js tab
-/** @type {import('jest').Config} */
-const config = {
+```js
+module.exports = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
     html: '<html lang="zh-cmn-Hant"></html>',
@@ -1405,23 +1404,6 @@ const config = {
     userAgent: 'Agent/007',
   },
 };
-
-module.exports = config;
-```
-
-```ts tab
-import type {Config} from 'jest';
-
-const config: Config = {
-  testEnvironment: 'jsdom',
-  testEnvironmentOptions: {
-    html: '<html lang="zh-cmn-Hant"></html>',
-    url: 'https://jestjs.io/',
-    userAgent: 'Agent/007',
-  },
-};
-
-export default config;
 ```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.

--- a/website/versioned_docs/version-29.0/Configuration.md
+++ b/website/versioned_docs/version-29.0/Configuration.md
@@ -1867,9 +1867,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-29.1/Configuration.md
+++ b/website/versioned_docs/version-29.1/Configuration.md
@@ -1867,9 +1867,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-29.2/Configuration.md
+++ b/website/versioned_docs/version-29.2/Configuration.md
@@ -1873,9 +1873,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-29.3/Configuration.md
+++ b/website/versioned_docs/version-29.3/Configuration.md
@@ -1873,9 +1873,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-29.4/Configuration.md
+++ b/website/versioned_docs/version-29.4/Configuration.md
@@ -1873,9 +1873,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 

--- a/website/versioned_docs/version-29.5/Configuration.md
+++ b/website/versioned_docs/version-29.5/Configuration.md
@@ -1908,9 +1908,63 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment.
 
-For example, in `jest-environment-jsdom`, you can override options given to [`jsdom`](https://github.com/jsdom/jsdom) such as `{html: "<html lang="zh-cmn-Hant"></html>", url: 'https://jestjs.io/', userAgent: "Agent/007"}`.
+For example, you can override options passed to [`jsdom`](https://github.com/jsdom/jsdom):
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    html: '<html lang="zh-cmn-Hant"></html>',
+    url: 'https://jestjs.io/',
+    userAgent: 'Agent/007',
+  },
+};
+
+export default config;
+```
 
 Both `jest-environment-jsdom` and `jest-environment-node` allow specifying `customExportConditions`, which allow you to control which versions of a library are loaded from `exports` in `package.json`. `jest-environment-jsdom` defaults to `['browser']`. `jest-environment-node` defaults to `['node', 'node-addons']`.
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: ['react-native'],
+  },
+};
+
+export default config;
+```
 
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 


### PR DESCRIPTION
From https://github.com/facebook/jest/pull/13989#issuecomment-1458655780
And partly https://github.com/facebook/jest/issues/9430#issuecomment-1452053720

## Summary

Perhaps it would be useful to add `testEnvironmentOptions` configuration examples?

## Test plan

Deploy preview.
