### PR TITLE
fix(jest-matcher-utils): compare value of inherited getter on test failure (#10167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-environment-jsdom, jest-environment-node]` Fix assignment of `customExportConditions` via `testEnvironmentOptions` when custom env subclass defines a default value ([#13989](https://github.com/facebook/jest/pull/13989))
+- `[jest-matcher-utils]` Fix copying value of inherited getters ([#14007](https://github.com/facebook/jest/pull/14007))
 
 ### Chore & Maintenance
 

--- a/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
@@ -43,7 +43,7 @@ test('convert accessor descriptor into value descriptor', () => {
   });
 });
 
-test('should not skips non-enumerables', () => {
+test('should not skip non-enumerables', () => {
   const obj = {};
   Object.defineProperty(obj, 'foo', {enumerable: false, value: 'bar'});
 
@@ -64,6 +64,18 @@ test('copies symbols', () => {
   const obj = {[symbol]: 42};
 
   expect(deepCyclicCopyReplaceable(obj)[symbol]).toBe(42);
+});
+
+test('copies value of inherited getters', () => {
+  class Foo {
+    #foo = 42;
+    get foo() {
+      return this.#foo;
+    }
+  }
+  const obj = new Foo();
+
+  expect(deepCyclicCopyReplaceable(obj).foo).toBe(42);
 });
 
 test('copies arrays as array objects', () => {

--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -57,9 +57,11 @@ export default function deepCyclicCopyReplaceable<T>(
 
 function deepCyclicCopyObject<T>(object: T, cycles: WeakMap<any, unknown>): T {
   const newObject = Object.create(Object.getPrototypeOf(object));
-  const descriptors: {
-    [x: string]: PropertyDescriptor;
-  } = Object.getOwnPropertyDescriptors(object);
+  let descriptors: Record<string, PropertyDescriptor> = {};
+  let obj = object;
+  do {
+    descriptors = Object.assign({}, Object.getOwnPropertyDescriptors(obj), descriptors)
+  } while ( (obj = Object.getPrototypeOf( obj )) && obj !== Object.getPrototypeOf({}) );
 
   cycles.set(object, newObject);
 

--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -60,8 +60,15 @@ function deepCyclicCopyObject<T>(object: T, cycles: WeakMap<any, unknown>): T {
   let descriptors: Record<string, PropertyDescriptor> = {};
   let obj = object;
   do {
-    descriptors = Object.assign({}, Object.getOwnPropertyDescriptors(obj), descriptors)
-  } while ( (obj = Object.getPrototypeOf( obj )) && obj !== Object.getPrototypeOf({}) );
+    descriptors = Object.assign(
+      {},
+      Object.getOwnPropertyDescriptors(obj),
+      descriptors,
+    );
+  } while (
+    (obj = Object.getPrototypeOf(obj)) &&
+    obj !== Object.getPrototypeOf({})
+  );
 
   cycles.set(object, newObject);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Inherited getters were not enumerated by `deepCyclicCopyObject` causing getters not being replaced with value and the test code to call those getters later on the copied object. If the non-replaced getter depended on other non-copied value, e.g. a private class field the calling code could end up in error while trying to show comparison of the expected and received value on test failures.
Fixes #10167

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
See more detailed analysis under the issue: https://github.com/facebook/jest/issues/10167#issuecomment-1468142256

## Test plan
Added a new test case `'copies value of inherited getters'` which is failing without the fix but passes after.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
