### PR TITLE
fix(jest-resolve): Remove redundant `realpath` call

### DIFF
--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -108,11 +108,11 @@ const defaultResolver: SyncResolver = (path, options) => {
 
   const pathToResolve = getPathInModule(path, resolveOptions);
 
+  // resolveSync dereferences symlinks to ensure we don't create a separate
+  // module instance depending on how it was referenced.
   const result = resolveSync(pathToResolve, resolveOptions);
 
-  // Dereference symlinks to ensure we don't create a separate
-  // module instance depending on how it was referenced.
-  return realpathSync(result);
+  return result;
 };
 
 export default defaultResolver;


### PR DESCRIPTION
## Summary

Removes a redundant call to `realpathCached`. `resolve` already calls `realpath` due to `preserveSymlinks: false` so the subsequent `realpathCached` call was redundant. 

In test suites resolving a lot of files, `realpathCache` can become a real hotpath. Since resolving files is done during test-setup, it's important that resolving modules is as fast as possible. So even if we know we'll hit the cache, we should avoid calling at all if we know for certain it's just hitting the cache. Since these calls are right next to each other I don't see the danger of accidentally not resolving symlinks.



## Test plan

- [x] CI (same test failures on master)
- [x] Patch works on internal test suite
