### PR TITLE
test: Cleanup after verify-old-ts

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -54,6 +54,8 @@ jobs:
         run: yarn verify-old-ts
       - name: typecheck examples
         run: yarn typecheck:examples
+      - name: typecheck debug
+        run: yarn tsc --version
       - name: typecheck tests
         run: yarn typecheck:tests
       - name: run ESLint with type info

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,14 +46,6 @@ jobs:
         run: yarn --immutable
       - name: build
         run: yarn build
-      - name: ts integration
-        run: yarn test-ts --selectProjects ts-integration
-      - name: type tests
-        run: yarn test-ts --selectProjects type-tests
-      - name: verify TypeScript@4.3 compatibility
-        run: yarn verify-old-ts
-      - name: typecheck examples
-        run: yarn typecheck:examples
       - name: typecheck debug
         run: yarn tsc --version
       - name: typecheck tests

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -46,8 +46,14 @@ jobs:
         run: yarn --immutable
       - name: build
         run: yarn build
-      - name: typecheck debug
-        run: yarn tsc --version
+      - name: ts integration
+        run: yarn test-ts --selectProjects ts-integration
+      - name: type tests
+        run: yarn test-ts --selectProjects type-tests
+      - name: verify TypeScript@4.3 compatibility
+        run: yarn verify-old-ts
+      - name: typecheck examples
+        run: yarn typecheck:examples
       - name: typecheck tests
         run: yarn typecheck:tests
       - name: run ESLint with type info

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -139,6 +139,7 @@ function typeTests() {
     execa.sync('yarn', ['test-types'], {cwd, stdio: 'inherit'});
   } finally {
     execa.sync('git', ['checkout', 'yarn.lock'], {cwd});
+    execa.sync('yarn', ['install'], {cwd});
   }
 
   function verifyInstalledTsdTypescript() {


### PR DESCRIPTION
This PR is based on before https://github.com/facebook/jest/pull/14028 showing that we don't need to split workflows.
