### PR TITLE
feat(Programmatic API): Add programmatic API

### DIFF
--- a/packages/jest-core/src/__tests__/runCore.test.ts
+++ b/packages/jest-core/src/__tests__/runCore.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {tmpdir} from 'os';
+import {resolve} from 'path';
+import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
+import {runCore} from '../';
+import runJest from '../runJest';
+
+jest.mock('jest-runtime', () => ({
+  createHasteMap: () => ({
+    build: jest.fn(),
+  }),
+}));
+jest.mock('../lib/createContext', () => jest.fn());
+jest.mock('../runJest', () =>
+  jest.fn(({onComplete}) => {
+    onComplete({results: {success: true}});
+  }),
+);
+
+describe(runCore, () => {
+  it('should run once and provide the result', async () => {
+    const actualResult = await runCore(makeGlobalConfig(), [
+      makeProjectConfig({
+        cacheDirectory: resolve(tmpdir(), 'jest_runCore_test'),
+      }),
+    ]);
+    expect(jest.mocked(runJest)).toHaveBeenCalled();
+    expect(actualResult).toEqual({results: {success: true}});
+  });
+});

--- a/packages/jest-core/src/index.ts
+++ b/packages/jest-core/src/index.ts
@@ -7,5 +7,6 @@
 
 export {default as SearchSource} from './SearchSource';
 export {createTestScheduler} from './TestScheduler';
-export {runCLI} from './cli';
+export {runCLI, runCore} from './cli';
 export {default as getVersion} from './version';
+export {readConfigs, readInitialOptions} from 'jest-config';

--- a/packages/jest/src/index.ts
+++ b/packages/jest/src/index.ts
@@ -12,6 +12,9 @@ export {
   createTestScheduler,
   getVersion,
   runCLI,
+  readConfigs,
+  readInitialOptions,
+  runCore,
 } from '@jest/core';
 
 export {run} from 'jest-cli';


### PR DESCRIPTION
## Summary

This pull request adds a documented programmatic API to run Jest. It can be used to run Jest either in watch mode or as a one-off, and can be called both internally by `runCLI` and externally.

The new `run` function takes the following parameters:

- `globalConfig`: The global configuration to use for this run. It can be obtained using `readConfigs` (imported from 'jest-config').
- `configs`: The project configurations to run. It can be obtained using `readConfigs` (imported from 'jest-config').
- `warnForDeprecations` (optional): Whether or not to warn for deprecation messages when globalConfig.watch or globalConfig.watchAll is true. If not provided, it defaults to `undefined`.
- `outputStream` (optional): The stream to write output to. If not provided, it defaults to `process.stdout`.

## Motivation

This change adds a documented programmatic API to run Jest, which makes it easier for users to programmatically run Jest in their own scripts. The API can be used to run Jest either in watch mode or as a one-off, and can be called both internally by `runCLI` and externally.

## Test plan

To test this change, I ran the following commands:

```
```

I also tested the new `run` function by running the following code in my own project:

```ts
import { run, readConfigs } from 'jest';
const { globalConfig, configs } = await readConfigs(process.argv, [process.cwd()]);
// change globalConfig or configs as you see fit
const results = await run(globalConfig, configs);
console.log(results);
