### PR TITLE
fix(jest-mock): spyOn should support `0` key in objects (#14077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-mock]` Tweak typings to allow `jest.replaceProperty()` replace methods ([#14008](https://github.com/facebook/jest/pull/14008))
 - `[jest-snapshot]` Fix a potential bug when not using prettier and improve performance ([#14036](https://github.com/facebook/jest/pull/14036))
 - `[@jest/transform]` Do not instrument `.json` modules ([#14048](https://github.com/facebook/jest/pull/14048))
+- `[jest-mock]` Fix `jest.spyOn()` to correctly handle `0` as a method/property name ([#14082](https://github.com/facebook/jest/pull/14082))
 
 ### Chore & Maintenance
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1309,6 +1309,15 @@ describe('moduleMocker', () => {
         moduleMocker.spyOn(null, 'method');
       }).toThrow('spyOn could not find an object to spy on for method');
       expect(() => {
+        moduleMocker.spyOn({} as Record<string, any>, '');
+      }).toThrow('No property name supplied');
+      expect(() => {
+        moduleMocker.spyOn({} as Record<number, any>, NaN);
+      }).toThrow('No property name supplied');
+      expect(() => {
+        moduleMocker.spyOn({}, undefined);
+      }).toThrow('No property name supplied');
+      expect(() => {
         moduleMocker.spyOn({}, 'method');
       }).toThrow(
         "Cannot spy on the method property because it is not a function; undefined given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
@@ -1318,6 +1327,19 @@ describe('moduleMocker', () => {
       }).toThrow(
         "Cannot spy on the method property because it is not a function; number given instead. If you are trying to mock a property, use `jest.replaceProperty(object, 'method', value)` instead.",
       );
+    });
+
+    it('should not throw when spying on a method named `0`', () => {
+      let haveBeenCalled = false;
+      const obj = {
+        0: () => {
+          haveBeenCalled = true;
+        },
+      };
+      const spy = moduleMocker.spyOn(obj, 0);
+      obj[0].call(null);
+      expect(haveBeenCalled).toBe(true);
+      expect(spy).toHaveBeenCalled();
     });
 
     it('supports clearing a spy', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1168,7 +1168,7 @@ export class ModuleMocker {
       );
     }
 
-    if (!methodKey) {
+    if (!methodKey && !Number.isFinite(methodKey)) {
       throw new Error('No property name supplied');
     }
 


### PR DESCRIPTION
## Summary

`jest.spyOn` previously throwed when applied to a method that is referenced by `0` key of the target module/object, thus being incompatible with design patterns, that rely on Enum indices, and Array-like objects. 

See [#14077](https://github.com/facebook/jest/issues/14077)

## Test plan

```
enum IndexedKeys {
    A,
    B,
    C
}

const DynamicDispatchObject:Record<IndexedKeys,CallableFunction>={
    [IndexedKeys.A]:()=>{},
    [IndexedKeys.B]:()=>{},
    [IndexedKeys.C]:()=>{}
}

// Doesn't throw anymore, works as intended
const spiedFunction = jest.spyOn(DynamicDispatchObject, IndexedKeys.A);
```
