### PR TITLE
docs: fix wrong filename in config example

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1643,7 +1643,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.0/Configuration.md
+++ b/website/versioned_docs/version-29.0/Configuration.md
@@ -1608,7 +1608,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.1/Configuration.md
+++ b/website/versioned_docs/version-29.1/Configuration.md
@@ -1608,7 +1608,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.2/Configuration.md
+++ b/website/versioned_docs/version-29.2/Configuration.md
@@ -1608,7 +1608,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.3/Configuration.md
+++ b/website/versioned_docs/version-29.3/Configuration.md
@@ -1608,7 +1608,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.4/Configuration.md
+++ b/website/versioned_docs/version-29.4/Configuration.md
@@ -1608,7 +1608,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.5/Configuration.md
+++ b/website/versioned_docs/version-29.5/Configuration.md
@@ -1643,7 +1643,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  setupFilesAfterEnv: ['<rootDir>/setup-matchers.js'],
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.js'],
 };
 
 export default config;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

In the [configuration docs](https://jestjs.io/docs/configuration#setupfilesafterenv-array) the example where a setup-jest.js file is imported has a different filename in JS and TS. The JS one is correct, while the TS one isn't. This PR changes the TS one so it is consistent with the filename used elsewhere.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Before:
![image](https://github.com/jestjs/jest/assets/31799931/d498cc5f-d5e8-4ff4-be12-7b8b05a2279a)

After:
![image](https://github.com/jestjs/jest/assets/31799931/e694ceb9-0938-4142-8087-7fa8fe497c75)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
