### PR TITLE
docs: update `transformIgnorePatterns` example for React Native

### DIFF
--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -143,9 +143,7 @@ By default the `jest-react-native` preset only processes the project's own sourc
 
 ```json
 {
-  "transformIgnorePatterns": [
-    "node_modules/(?!(react-native|my-project|react-native-button)/)"
-  ]
+  "transformIgnorePatterns": ["node_modules/(?!((@)?react-native|my-project)/)"]
 }
 ```
 

--- a/website/versioned_docs/version-29.4/TutorialReactNative.md
+++ b/website/versioned_docs/version-29.4/TutorialReactNative.md
@@ -143,9 +143,7 @@ By default the `jest-react-native` preset only processes the project's own sourc
 
 ```json
 {
-  "transformIgnorePatterns": [
-    "node_modules/(?!(react-native|my-project|react-native-button)/)"
-  ]
+  "transformIgnorePatterns": ["node_modules/(?!((@)?react-native|my-project)/)"]
 }
 ```
 

--- a/website/versioned_docs/version-29.5/TutorialReactNative.md
+++ b/website/versioned_docs/version-29.5/TutorialReactNative.md
@@ -143,9 +143,7 @@ By default the `jest-react-native` preset only processes the project's own sourc
 
 ```json
 {
-  "transformIgnorePatterns": [
-    "node_modules/(?!(react-native|my-project|react-native-button)/)"
-  ]
+  "transformIgnorePatterns": ["node_modules/(?!((@)?react-native|my-project)/)"]
 }
 ```
 

--- a/website/versioned_docs/version-29.6/TutorialReactNative.md
+++ b/website/versioned_docs/version-29.6/TutorialReactNative.md
@@ -143,9 +143,7 @@ By default the `jest-react-native` preset only processes the project's own sourc
 
 ```json
 {
-  "transformIgnorePatterns": [
-    "node_modules/(?!(react-native|my-project|react-native-button)/)"
-  ]
+  "transformIgnorePatterns": ["node_modules/(?!((@)?react-native|my-project)/)"]
 }
 ```
 

--- a/website/versioned_docs/version-29.7/TutorialReactNative.md
+++ b/website/versioned_docs/version-29.7/TutorialReactNative.md
@@ -143,9 +143,7 @@ By default the `jest-react-native` preset only processes the project's own sourc
 
 ```json
 {
-  "transformIgnorePatterns": [
-    "node_modules/(?!(react-native|my-project|react-native-button)/)"
-  ]
+  "transformIgnorePatterns": ["node_modules/(?!((@)?react-native|my-project)/)"]
 }
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Since then, React Native introduced a new scope for packages: `@react-native`, let's make sure to include it in the example to avoid issues.

I also took the liberty to remove `react-native-button` from the example, because this is not a package that is used anymore, but also because most people were copy-pasting this example without changing anything out of it. See search on GitHub for that string: https://github.com/search?q=node_modules%2F%28%3F%21%28react-native%7Cmy-project%7Creact-native-button%29%2F%29&type=code. I thought it could be confusing to read and it seems to imply that it needs to be there.