### PR TITLE
Fix destruction of builtin node globals

### DIFF
--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -87,4 +87,8 @@ describe('NodeEnvironment', () => {
   test('TextEncoder references the same global Uint8Array constructor', () => {
     expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array);
   });
+
+  test('dispatch event', () => {
+    new EventTarget().dispatchEvent(new Event('foo'));
+  });
 });

--- a/packages/jest-environment-node/src/__tests__/node_environment_2.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment_2.test.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('NodeEnvironment 2', () => {
+  test('dispatch event', () => {
+    new EventTarget().dispatchEvent(new Event('foo'));
+  });
+});

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -102,6 +102,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
       Object.getOwnPropertyNames(global) as GlobalProperties,
     );
     for (const [nodeGlobalsKey, descriptor] of nodeGlobals) {
+      protectProperties(globalThis[nodeGlobalsKey]);
       if (!contextGlobals.has(nodeGlobalsKey)) {
         if (descriptor.configurable) {
           Object.defineProperty(global, nodeGlobalsKey, {


### PR DESCRIPTION
## Summary

Fixes #15632 that was introduced in #15215.

The PR to mitigate memory leaks accidentally deleted some of the builtin node globals.

This PR fixes it by protecting all of them from deletion.

## Test plan

New tests were added that rely on the reproduction project from #15632.

Looks like [one CI test](https://github.com/jestjs/jest/actions/runs/15304251183/job/43052792869?pr=15636) (`e2e/__tests__/circusConcurrent.test.ts`) fails, but from the output it seems to be flaky?

I see [previous builds](https://github.com/jestjs/jest/actions/runs/15303724309/job/43050948914?pr=15634) where it fails several times but succeeds on the last (3rd) attempt.
