### PR TITLE
fix: prevent double teardown on test environment error

### DIFF
--- a/e2e/__tests__/environmentTeardownError.test.ts
+++ b/e2e/__tests__/environmentTeardownError.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+// This test ensures that if a custom environment's teardown throws, Jest reports the real error, not an internal error.
+describe('Environment Teardown Error', () => {
+  it('reports the error thrown from teardown() in a custom environment', () => {
+    const {stderr, exitCode} = runJest('environment-teardown-error');
+    expect(exitCode).toBe(1);
+    expect(stderr).toMatch('teardown error from custom environment');
+    // Should NOT contain the internal error that was seen in the regression
+    expect(stderr).not.toMatch(
+      'The "object" argument must be of type object. Received null',
+    );
+  });
+});

--- a/e2e/environment-teardown-error/EnvironmentWithTeardownError.js
+++ b/e2e/environment-teardown-error/EnvironmentWithTeardownError.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const NodeEnvironment = require('jest-environment-node').default;
+
+class EnvironmentWithTeardownError extends NodeEnvironment {
+  async teardown() {
+    await super.teardown();
+    throw new Error('teardown error from custom environment');
+  }
+}
+
+module.exports = EnvironmentWithTeardownError;

--- a/e2e/environment-teardown-error/__tests__/environmentTeardownError.test.js
+++ b/e2e/environment-teardown-error/__tests__/environmentTeardownError.test.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('Environment must tear down with a correct error stack trace', () => {});

--- a/e2e/environment-teardown-error/package.json
+++ b/e2e/environment-teardown-error/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "<rootDir>/EnvironmentWithTeardownError.js"
+  }
+}

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -217,8 +217,11 @@ async function runTestInternal(
       );
       sourcemapSupport.resetRetrieveHandlers();
 
-      await environment.teardown();
-      isTornDown = true;
+      try {
+        await environment.teardown();
+      } finally {
+        isTornDown = true;
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- Resolves: #15730

This PR fixes a regression where errors thrown from a custom environment’s `teardown()` method were masked by an internal error, rather than being reported to the user. This led to confusing error messages and made debugging custom environments difficult.

- Ensures that `isTornDown` is always set in a `finally` block, even if `environment.teardown()` throws. This prevents double teardown and ensures the real error is surfaced.
- Adds a real end-to-end (e2e) test that:
  - Uses a custom environment that throws in `teardown()`
  - Asserts that Jest reports the actual error, not an internal or misleading one
  - Prevents future regressions of this kind

### Why

- The regression was reported in [#15730](https://github.com/jestjs/jest/issues/15730).
- Without this fix, users see a confusing internal error (`The "object" argument must be of type object. Received null`) instead of the real cause.
- The new e2e test ensures this scenario is covered in CI.

## Test plan

- The new e2e test fails on the old behavior and passes with this fix.
- The test runs a trivial test file using a custom environment that throws in `teardown()`, and asserts that the error is reported as expected.
- CI will now catch regressions of this kind.