### PR TITLE
refactor(babel-jest): replace `chalk` w/ `picocolors`

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -24,8 +24,8 @@
     "@types/babel__core": "^7.20.5",
     "babel-plugin-istanbul": "^7.0.0",
     "babel-preset-jest": "workspace:*",
-    "chalk": "^4.1.2",
     "graceful-fs": "^4.2.11",
+    "picocolors": "^1.1.1",
     "slash": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -13,8 +13,8 @@ import {
   transformSync as babelTransform,
   transformAsync as babelTransformAsync,
 } from '@babel/core';
-import chalk from 'chalk';
 import * as fs from 'graceful-fs';
+import picocolors from 'picocolors';
 import slash from 'slash';
 import type {
   TransformOptions as JestTransformOptions,
@@ -38,9 +38,9 @@ function assertLoadedBabelConfig(
 ): asserts babelConfig {
   if (!babelConfig) {
     throw new Error(
-      `babel-jest: Babel ignores ${chalk.bold(
+      `babel-jest: Babel ignores ${picocolors.bold(
         slash(path.relative(cwd, filename)),
-      )} - make sure to include the file in Jest's ${chalk.bold(
+      )} - make sure to include the file in Jest's ${picocolors.bold(
         'transformIgnorePatterns',
       )} as well.`,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -7606,8 +7606,8 @@ __metadata:
     "@types/graceful-fs": "npm:^4.1.9"
     babel-plugin-istanbul: "npm:^7.0.0"
     babel-preset-jest: "workspace:*"
-    chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
+    picocolors: "npm:^1.1.1"
     slash: "npm:^3.0.0"
   peerDependencies:
     "@babel/core": ^7.11.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Part of #15189.

Since Babel has already switched from `chalk` to `picocolors` (see https://github.com/babel/babel/pull/16359), it definitely makes sense to do the same thing to `babel-jest` as well. After we evaluate this, we can do similar migrations to other Jest packages as well.

cc @SimenB since you did give a go (https://github.com/jestjs/jest/issues/15189#issuecomment-2227849811 https://github.com/jestjs/jest/issues/15189#issuecomment-2230927738).

Also cc @cpojer 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<img width="538" height="159" alt="image" src="https://github.com/user-attachments/assets/bfadd755-e4f0-41bb-a343-42fe05e9de08" />

All tests passed on my machine locally.