### PR TITLE
fix(tests): Fix test failures due to unflagged strip-types

### DIFF
--- a/e2e/__tests__/typescriptConfigFile.test.ts
+++ b/e2e/__tests__/typescriptConfigFile.test.ts
@@ -7,13 +7,11 @@
 
 import {tmpdir} from 'os';
 import * as path from 'path';
-import * as semver from 'semver';
 import {onNodeVersions} from '@jest/test-utils';
 import {cleanup, writeFiles} from '../Utils';
-import runJest, {getConfig} from '../runJest';
+import runJest, {getConfig, useNativeTypeScript} from '../runJest';
 
 const DIR = path.resolve(tmpdir(), 'typescript-config-file');
-const useNativeTypeScript = semver.satisfies(process.versions.node, '>=23.6.0');
 const importFileExtension = useNativeTypeScript ? '.ts' : '';
 
 beforeEach(() => cleanup(DIR));

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -12,11 +12,17 @@ import {stripVTControlCharacters as stripAnsi} from 'util';
 import dedent from 'dedent';
 import execa from 'execa';
 import * as fs from 'graceful-fs';
+import * as semver from 'semver';
 import {TestPathPatterns} from '@jest/pattern';
 import type {FormattedTestResults} from '@jest/test-result';
 import {normalizeIcons} from '@jest/test-utils';
 import type {Config} from '@jest/types';
 import {ErrorWithStack} from 'jest-util';
+
+export const useNativeTypeScript = semver.satisfies(
+  process.versions.node,
+  '^22.18.0 || >=23.6.0',
+);
 
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 


### PR DESCRIPTION
Update tests to handle `--experimental-strip-types` being unflagged by default in newer Node.js versions. See https://nodejs.org/en/blog/release/v22.18.0. This was causing test failures in CI similar to the following:

```
Expected substring: "jest.config.ts(2,25): error TS2322: Type 'string' is not assignable to type 'number'."
Received string:    "● Validation Error:·
  Option \"testTimeout\" must be of type:
    number
  but instead received:
    string·
  Example:
  {
    \"testTimeout\": 5000
  }·
  Configuration Documentation:
  https://jestjs.io/docs/configuration
"

    at Object.toMatch (e2e/__tests__/tsIntegration.test.ts:573:20)
```

and

```
    Expected substring: "PASS __tests__/mytest.alpha.js"
    Received string:    "Error: Jest: Failed to parse the TypeScript config file /tmp/typescript-config-file/alpha.config.ts
      Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/typescript-config-file/common' imported from /tmp/typescript-config-file/alpha.config.ts
        at readConfigFileAndSetRootDir (/home/runner/work/jest/jest/packages/jest-config/build/index.js:2269:13)
        at async readInitialOptions (/home/runner/work/jest/jest/packages/jest-config/build/index.js:1147:13)
        at async readConfig (/home/runner/work/jest/jest/packages/jest-config/build/index.js:918:7)
        at async Promise.all (index 0)
        at async readConfigs (/home/runner/work/jest/jest/packages/jest-config/build/index.js:1184:27)
        at async runCLI (/home/runner/work/jest/jest/packages/jest-core/build/index.js:1393:7)
        at async Object.run (/home/runner/work/jest/jest/packages/jest-cli/build/index.js:656:9)"

      102 |   );
      103 |
    > 104 |   expect(stderr).toContain('PASS __tests__/mytest.alpha.js');
          |                  ^
      105 |   expect(stderr).toContain('PASS __tests__/mytest.beta.js');
      106 |   expect(stderr).toContain('PASS __tests__/mytest.common.js');
      107 |   expect(stderr.replace('PASS __tests__/mytest.common.js', '')).toContain(

      at Object.toContain (e2e/__tests__/typescriptConfigFile.test.ts:104:18)
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
