### PR TITLE
fix(snapshot-utils): Handle Windows line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Features
 
-- `[jest-leak-detector]` Configurable GC aggressiveness regarding to V8 heap snapshot generation ([#15793](https://github.com/jestjs/jest/pull/15793/)) 
+- `[jest-leak-detector]` Configurable GC aggressiveness regarding to V8 heap snapshot generation ([#15793](https://github.com/jestjs/jest/pull/15793/))
 - `[jest-runtime]` Reduce redundant ReferenceError messages
 - `[jest-core]` Include test modules that failed to load when --onlyFailures is active
 

--- a/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
@@ -176,7 +176,9 @@ test('getSnapshotData() throws for deprecated snapshot guide link', () => {
 
   expect(() => getSnapshotData(filename, update)).toThrow(
     `${chalk.red(
-      `${chalk.red.bold('Outdated guide link')}: The snapshot guide link is outdated.` +
+      `${chalk.red.bold(
+        'Outdated guide link',
+      )}: The snapshot guide link is outdated.` +
         'Please update all snapshots while upgrading of Jest',
     )}\n\nExpected: ${SNAPSHOT_GUIDE_LINK}\n` +
       `Received: ${deprecatedGuideLink}`,

--- a/packages/jest-snapshot-utils/src/utils.ts
+++ b/packages/jest-snapshot-utils/src/utils.ts
@@ -77,7 +77,9 @@ const validateSnapshotHeader = (snapshotContents: string) => {
     return new Error(
       // eslint-disable-next-line prefer-template
       chalk.red(
-        `${chalk.red.bold('Outdated guide link')}: The snapshot guide link is outdated.` +
+        `${chalk.red.bold(
+          'Outdated guide link',
+        )}: The snapshot guide link is outdated.` +
           'Please update all snapshots while upgrading of Jest',
       ) +
         '\n\n' +


### PR DESCRIPTION
Fixes #15799.

## Summary

Handle Windows line endings when checking snapshot headers after changes made in #15787.

## Test plan

Updated unit tests.
