### PR TITLE
Update babel-plugin-istanbul to 7.0.1

### DIFF
--- a/e2e/coverage-transform-instrumented/package.json
+++ b/e2e/coverage-transform-instrumented/package.json
@@ -25,6 +25,6 @@
   "dependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "babel-plugin-istanbul": "^7.0.0"
+    "babel-plugin-istanbul": "^7.0.1"
   }
 }

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@jest/transform": "workspace:*",
     "@types/babel__core": "^7.20.5",
-    "babel-plugin-istanbul": "^7.0.0",
+    "babel-plugin-istanbul": "^7.0.1",
     "babel-preset-jest": "workspace:*",
     "chalk": "^4.1.2",
     "graceful-fs": "^4.2.11",

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -22,7 +22,7 @@
     "@babel/core": "^7.27.4",
     "@jest/types": "workspace:*",
     "@jridgewell/trace-mapping": "^0.3.25",
-    "babel-plugin-istanbul": "^7.0.0",
+    "babel-plugin-istanbul": "^7.0.1",
     "chalk": "^4.1.2",
     "convert-source-map": "^2.0.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4191,7 +4191,7 @@ __metadata:
     "@types/graceful-fs": "npm:^4.1.9"
     "@types/micromatch": "npm:^4.0.9"
     "@types/write-file-atomic": "npm:^4.0.3"
-    babel-plugin-istanbul: "npm:^7.0.0"
+    babel-plugin-istanbul: "npm:^7.0.1"
     chalk: "npm:^4.1.2"
     convert-source-map: "npm:^2.0.0"
     dedent: "npm:^1.6.0"
@@ -7605,7 +7605,7 @@ __metadata:
     "@jest/transform": "workspace:*"
     "@types/babel__core": "npm:^7.20.5"
     "@types/graceful-fs": "npm:^4.1.9"
-    babel-plugin-istanbul: "npm:^7.0.0"
+    babel-plugin-istanbul: "npm:^7.0.1"
     babel-preset-jest: "workspace:*"
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
@@ -7637,16 +7637,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-istanbul@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "babel-plugin-istanbul@npm:7.0.0"
+"babel-plugin-istanbul@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "babel-plugin-istanbul@npm:7.0.1"
   dependencies:
     "@babel/helper-plugin-utils": "npm:^7.0.0"
     "@istanbuljs/load-nyc-config": "npm:^1.0.0"
     "@istanbuljs/schema": "npm:^0.1.3"
     istanbul-lib-instrument: "npm:^6.0.2"
     test-exclude: "npm:^6.0.0"
-  checksum: 10/4df567f29161c7f50737ed1884c7f08203f4d0cb1684c499fca374fcf5059396eacb02f8f727bf7a82bbf3e50b9f4a24bcb026a1678f63940d8f0f78546e3774
+  checksum: 10/fe9f865f975aaa7a033de9ccb2b63fdcca7817266c5e98d3e02ac7ffd774c695093d215302796cb3770a71ef4574e7a9b298504c3c0c104cf4b48c8eda67b2a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

I'm working on a follow-up to https://github.com/jestjs/jest/pull/15750 to switch Jest to using Babel 8 internally, and one of the blockers is that `babel-plugin-istanbul` cannot be run with Babel 8.

The only change in `babel-plugin-istanbul@7.0.1` is that it stops throwing when used with Babel 8.

## Test plan

n/a