### PR TITLE
docs: remove `create-react-app` reference for greenfield React app testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore & Maintenance
 
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
+- `[docs]` Remove `create-react-app` reference for greenfield React app testing ([#15883](https://github.com/jestjs/jest/pull/15883))
 - `[deps]` Update to sinon/fake-timers v15
 
 ## 30.2.0

--- a/website/versioned_docs/version-29.7/TutorialReact.md
+++ b/website/versioned_docs/version-29.7/TutorialReact.md
@@ -7,17 +7,7 @@ At Facebook, we use Jest to test [React](https://reactjs.org/) applications.
 
 ## Setup
 
-### Setup with Create React App
-
-If you are new to React, we recommend using [Create React App](https://create-react-app.dev/). It is ready to use and [ships with Jest](https://create-react-app.dev/docs/running-tests/#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
-
-Run
-
-```bash npm2yarn
-npm install --save-dev react-test-renderer
-```
-
-### Setup without Create React App
+### Setup for React app
 
 If you have an existing application you'll need to install a few packages to make everything work well together. We are using the `babel-jest` package and the `react` babel preset to transform our code inside of the test environment. Also see [using babel](GettingStarted.md#using-babel).
 

--- a/website/versioned_docs/version-30.0/TutorialReact.md
+++ b/website/versioned_docs/version-30.0/TutorialReact.md
@@ -7,17 +7,7 @@ At Facebook, we use Jest to test [React](https://reactjs.org/) applications.
 
 ## Setup
 
-### Setup with Create React App
-
-If you are new to React, we recommend using [Create React App](https://create-react-app.dev/). It is ready to use and [ships with Jest](https://create-react-app.dev/docs/running-tests/#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
-
-Run
-
-```bash npm2yarn
-npm install --save-dev react-test-renderer
-```
-
-### Setup without Create React App
+### Setup for React app
 
 If you have an existing application you'll need to install a few packages to make everything work well together. We are using the `babel-jest` package and the `react` babel preset to transform our code inside of the test environment. Also see [using babel](GettingStarted.md#using-babel).
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Closes #15882

Although `create-react-app` is no longer suggested in `docs/*.md` files, older versions like v30 and v29.7 still refers to it, inadvertently suggest new folks to use a deprecated library. We should remove these references once and for all.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- [x] Green CI
- [x] Visual confirmation

## Test evidences

Before
<img width="1288" height="839" alt="image" src="https://github.com/user-attachments/assets/456b6d3e-2ded-46fd-8ee8-cc8564876af4" />


After
<img width="1217" height="814" alt="image" src="https://github.com/user-attachments/assets/f625d7f2-0d27-4a8c-be8f-d60a2f1e24b5" />
