### PR TITLE
docs: remove deprecated 'Setup with Create React App' guide (#15882)

### DIFF
--- a/website/versioned_docs/version-30.0/TutorialReact.md
+++ b/website/versioned_docs/version-30.0/TutorialReact.md
@@ -7,12 +7,6 @@ At Facebook, we use Jest to test [React](https://reactjs.org/) applications.
 
 ## Setup
 
-:::caution
-The **Create React App (CRA)** project is no longer actively maintained. For starting a new React project, we recommend using modern tools such as **[Vite](https://vitejs.dev/)** or **[Next.js](https://nextjs.org/)**, which often include their own recommended Jest setup. Please refer to their documentation for the most current configuration instructions.
-:::
-
-### Manual Setup
-
 If you have an existing application you'll need to install a few packages to make everything work well together. We are using the `babel-jest` package and the `react` babel preset to transform our code inside of the test environment. Also see [using babel](GettingStarted.md#using-babel).
 
 Run


### PR DESCRIPTION
Summary

This PR addresses the outdated guidance regarding the setup of Jest with React projects.

The Create React App (CRA) is no longer actively maintained and is considered deprecated. This change removes the dedicated "Setup with Create React App" section from website/docs/tutorial-react.md and replaces it with a cautionary note directing users to modern alternatives like Vite or Next.js.

It also renames the "Setup without Create React App" section to "Manual Setup" to promote it as the default configuration guide.

Test plan

Since this change is purely documentation (Markdown) and does not involve changing any source code, no new tests were added.

I confirmed that:

    The relevant section was removed from website/docs/tutorial-react.md.

    The resulting Markdown file renders correctly, showing the new caution block regarding CRA's deprecation.

    The dependencies were installed successfully using npm exec yarn install.