### PR TITLE
Remove unreachable code in BaseJSDOMEnvironment

### DIFF
--- a/packages/jest-environment-jsdom-abstract/src/index.ts
+++ b/packages/jest-environment-jsdom-abstract/src/index.ts
@@ -94,10 +94,6 @@ export default abstract class BaseJSDOMEnvironment implements JestEnvironment<nu
     );
     const global = (this.global = this.dom.window as unknown as Win);
 
-    if (global == null) {
-      throw new Error('JSDOM did not return a Window object');
-    }
-
     // TODO: remove at some point - for "universal" code (code should use `globalThis`)
     global.global = global;
 


### PR DESCRIPTION
After initializing JSDOM, it will always have a non-null window property. There is no need to check it.

## Summary

Towards reducing unreachable code and simplifying the implementation.

## Test plan

Project's test suite and type checking.
