### PR TITLE
Remove unused dependencies from jest-environment-jsdom

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -21,8 +21,6 @@
   "dependencies": {
     "@jest/environment": "workspace:*",
     "@jest/environment-jsdom-abstract": "workspace:*",
-    "@types/jsdom": "^21.1.7",
-    "@types/node": "*",
     "jsdom": "^26.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14031,8 +14031,6 @@ __metadata:
     "@jest/environment": "workspace:*"
     "@jest/environment-jsdom-abstract": "workspace:*"
     "@jest/test-utils": "workspace:*"
-    "@types/jsdom": "npm:^21.1.7"
-    "@types/node": "npm:*"
     jsdom: "npm:^26.1.0"
   peerDependencies:
     canvas: ^3.0.0


### PR DESCRIPTION
## Summary

The following dependencies are unused directly by the jest-environment-jsdom package:

- `@types/jsdom`
- `@types/node`

These are instead imported and used by the
jest-environment-jsdom-abstract package only, so let that package manage them. These are just transient dependencies.

Unused since 01a923b22e92a5c250e8e32478b5dba392eda534.

## Test plan

Project test suite, type checker, and CI.
