### PR TITLE
fix(crowdin): force versioned mdx parser even for .md

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -8,6 +8,10 @@ base_path: '.'
 base_url: 'https://api.crowdin.com'
 preserve_hierarchy: true
 
+# Force a specific MDX parser version for all newly added files .md/.mdx files
+# See https://github.com/jestjs/jest/issues/15947#issuecomment-3853479828
+mdx_file_type: &mdx_file_type mdx_v1_2
+
 # See Yaml anchors: https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/
 languages_mapping: &languages_mapping
   locale:
@@ -25,25 +29,21 @@ languages_mapping: &languages_mapping
 # see https://support.crowdin.com/configuration-file/
 #
 files:
-  [
-    {
-      'source': '/website/i18n/en/**/*',
-      'translation': '/website/i18n/%locale%/**/%original_file_name%',
-      'languages_mapping': *languages_mapping,
-    },
-    {
-      'source': '/docs/**/*',
-      'translation': '/website/i18n/%locale%/docusaurus-plugin-content-docs/current/**/%original_file_name%',
-      'languages_mapping': *languages_mapping,
-    },
-    {
-      'source': '/website/versioned_docs/**/*',
-      'translation': '/website/i18n/%locale%/docusaurus-plugin-content-docs/**/%original_file_name%',
-      'languages_mapping': *languages_mapping,
-    },
-    {
-      'source': '/website/blog/**/*',
-      'translation': '/website/i18n/%locale%/docusaurus-plugin-content-blog/**/%original_file_name%',
-      'languages_mapping': *languages_mapping,
-    },
-  ]
+  - source: /website/i18n/en/**/*
+    translation: /website/i18n/%two_letters_code%/**/%original_file_name%
+    languages_mapping: *languages_mapping
+
+  - source: /docs/**/*
+    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
+    languages_mapping: *languages_mapping
+    type: *mdx_file_type # Force specific MDX parser version
+
+  - source: /website/versioned_docs/**/*
+    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/**/%original_file_name%
+    languages_mapping: *languages_mapping
+    type: *mdx_file_type # Force specific MDX parser version
+
+  - source: /website/blog/**/*
+    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-blog/**/%original_file_name%
+    languages_mapping: *languages_mapping
+    type: *mdx_file_type # Force specific MDX parser version


### PR DESCRIPTION

## Summary

Fix localized website deployment on Netlify: https://app.netlify.com/projects/jestjs/deploys

Fix https://github.com/jestjs/jest/issues/15947

See detailed explanation of the problem here: https://github.com/jestjs/jest/issues/15947#issuecomment-3853479828

## How the fix works

We are forcing all docs/versioned_docs files to be parsed with the `mdx_v1_2` parser.

In my experience, this specific MDX parser version works well with Docusaurus website, and supports our non-standard headingId syntax `{* #headingId *}`

To apply the fix safely, I did a backup of all former source files on the Jest Crowdin site:

<img width="654" height="338" alt="CleanShot 2026-02-05 at 15 46 12@2x" src="https://github.com/user-attachments/assets/1c4c90e1-8335-4cdc-bbe5-294a6f3b6b2a" />

And then I uploaded the new source files from localhost as MDX v1.2 files:

<img width="682" height="346" alt="CleanShot 2026-02-05 at 15 46 48@2x" src="https://github.com/user-attachments/assets/8e243ed3-8581-4a28-b51b-463f39d8f61b" />


## Potential future issues

We use the following config:

```yaml
  - source: /docs/**/*
    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
    languages_mapping: *languages_mapping
    type: mdx_v1_2 # Force specific MDX parser version
```

If you ever need to upload non-md files from the `./docs` folder, now they are going to be parsed as MDX. This will not work well if you put an image in `./docs`, for example.

If you ever need to put something that is not Markdown/MDX in the docs folder, you would need to do like us and have multiple source entries for the `./docs` folder:

```yaml
    # Force md files as MDX 1.2
  - source: /website/docs/**/*.md
    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
    languages_mapping: *languages_mapping
    type: *mdx_file_type
    
    # Infer file type / parser from extension for all other files
  - source: /website/docs/**/*
    translation: /website/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%
    languages_mapping: *languages_mapping
    ignore: [/**/*.md]
```

I couldn't apply this setting right now, otherwise Crowdin CLI would error on upload, since there is zero non-md file, and it requires at least one 🤷‍♂️ 

```bash
❌ No sources found for '/website/versioned_docs/**/*' pattern. Check the source paths in your configuration file
```

## Test plan

```bash
git@github.com:jestjs/jest.git
cd jest
yarn install
yarn workspace jest-website netlify:prepare
yarn workspace jest-website netlify:crowdin
yarn workspace jest-website build
```